### PR TITLE
Initialize Django skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # Accounts
+
+## Development Setup
+
+1. Create a Python virtual environment and install dependencies:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r backend/requirements.txt
+   ```
+2. Configure MySQL settings in `backend/finance_manager/settings.py`.
+3. Run migrations and start the development server:
+   ```bash
+   cd backend
+   ./manage.py migrate
+   ./manage.py runserver
+   ```

--- a/backend/finance_manager/asgi.py
+++ b/backend/finance_manager/asgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'finance_manager.settings')
+application = get_asgi_application()

--- a/backend/finance_manager/finance/__init__.py
+++ b/backend/finance_manager/finance/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'finance.apps.FinanceConfig'

--- a/backend/finance_manager/finance/apps.py
+++ b/backend/finance_manager/finance/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class FinanceConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'finance'

--- a/backend/finance_manager/finance/models.py
+++ b/backend/finance_manager/finance/models.py
@@ -1,0 +1,23 @@
+from django.db import models
+
+class Account(models.Model):
+    name = models.CharField(max_length=100)
+
+class Category(models.Model):
+    name = models.CharField(max_length=100)
+
+class Tag(models.Model):
+    name = models.CharField(max_length=100)
+
+class TransactionGroup(models.Model):
+    name = models.CharField(max_length=100)
+
+class Transaction(models.Model):
+    account = models.ForeignKey(Account, on_delete=models.CASCADE)
+    date = models.DateField()
+    amount = models.DecimalField(max_digits=10, decimal_places=2)
+    description = models.CharField(max_length=255)
+    category = models.ForeignKey(Category, on_delete=models.SET_NULL, null=True)
+    tag = models.ForeignKey(Tag, on_delete=models.SET_NULL, null=True)
+    group = models.ForeignKey(TransactionGroup, on_delete=models.SET_NULL, null=True)
+    ofx_id = models.CharField(max_length=255, unique=True)

--- a/backend/finance_manager/finance/tests.py
+++ b/backend/finance_manager/finance/tests.py
@@ -1,0 +1,7 @@
+from django.test import TestCase
+from .models import Account
+
+class AccountModelTest(TestCase):
+    def test_create_account(self):
+        account = Account.objects.create(name='Checking')
+        self.assertEqual(account.name, 'Checking')

--- a/backend/finance_manager/settings.py
+++ b/backend/finance_manager/settings.py
@@ -1,0 +1,53 @@
+SECRET_KEY = 'replace-this-with-a-secure-key'
+DEBUG = True
+ALLOWED_HOSTS = ['*']
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'finance',
+]
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
+ROOT_URLCONF = 'finance_manager.urls'
+TEMPLATES = [{
+    'BACKEND': 'django.template.backends.django.DjangoTemplates',
+    'DIRS': [],
+    'APP_DIRS': True,
+    'OPTIONS': {
+        'context_processors': [
+            'django.template.context_processors.debug',
+            'django.template.context_processors.request',
+            'django.contrib.auth.context_processors.auth',
+            'django.contrib.messages.context_processors.messages',
+        ],
+    },
+}]
+WSGI_APPLICATION = 'finance_manager.wsgi.application'
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': 'finance_db',
+        'USER': 'finance_user',
+        'PASSWORD': 'replace-password',
+        'HOST': 'localhost',
+        'PORT': '3306',
+    }
+}
+AUTH_PASSWORD_VALIDATORS = []
+LANGUAGE_CODE = 'en-us'
+TIME_ZONE = 'UTC'
+USE_I18N = True
+USE_TZ = True
+STATIC_URL = 'static/'
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

--- a/backend/finance_manager/urls.py
+++ b/backend/finance_manager/urls.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+from django.urls import path
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+]

--- a/backend/finance_manager/wsgi.py
+++ b/backend/finance_manager/wsgi.py
@@ -1,0 +1,5 @@
+import os
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'finance_manager.settings')
+application = get_wsgi_application()

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import os
+import sys
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'finance_manager.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+
+if __name__ == '__main__':
+    main()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+django
+ofxparse
+mysqlclient


### PR DESCRIPTION
## Summary
- add initial Django project layout
- define finance models
- add sample test and requirements
- document development setup

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_688b7a585870832e9818e23eeb5e7ea9