### PR TITLE
Add PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # Accounts
 
-## Development Setup
+This repository now provides a simple PHP implementation for managing accounts and transactions.
 
-1. Create a Python virtual environment and install dependencies:
+## PHP Development Setup
+
+1. Ensure PHP and MySQL are installed.
+2. Configure database credentials using the environment variables `DB_HOST`, `DB_NAME`, `DB_USER` and `DB_PASS`.
+3. Create the database tables:
    ```bash
-   python3 -m venv venv
-   source venv/bin/activate
-   pip install -r backend/requirements.txt
+   php php_backend/create_tables.php
    ```
-2. Configure MySQL settings in `backend/finance_manager/settings.py`.
-3. Run migrations and start the development server:
+4. Run the example script which inserts a sample account:
    ```bash
-   cd backend
-   ./manage.py migrate
-   ./manage.py runserver
+   php php_backend/public/index.php
    ```

--- a/php_backend/Database.php
+++ b/php_backend/Database.php
@@ -1,0 +1,18 @@
+<?php
+class Database {
+    private static $instance = null;
+
+    public static function getConnection(): PDO {
+        if (self::$instance === null) {
+            $host = getenv('DB_HOST') ?: 'localhost';
+            $name = getenv('DB_NAME') ?: 'finance';
+            $user = getenv('DB_USER') ?: 'root';
+            $pass = getenv('DB_PASS') ?: '';
+            $dsn = "mysql:host=$host;dbname=$name;charset=utf8mb4";
+            self::$instance = new PDO($dsn, $user, $pass);
+            self::$instance->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        }
+        return self::$instance;
+    }
+}
+?>

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/Database.php';
+
+$db = Database::getConnection();
+
+$sql = <<<SQL
+CREATE TABLE IF NOT EXISTS accounts (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS categories (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS transaction_groups (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS transactions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    account_id INT NOT NULL,
+    date DATE NOT NULL,
+    amount DECIMAL(10,2) NOT NULL,
+    description VARCHAR(255) NOT NULL,
+    category_id INT DEFAULT NULL,
+    tag_id INT DEFAULT NULL,
+    group_id INT DEFAULT NULL,
+    ofx_id VARCHAR(255) UNIQUE,
+    FOREIGN KEY (account_id) REFERENCES accounts(id),
+    FOREIGN KEY (category_id) REFERENCES categories(id),
+    FOREIGN KEY (tag_id) REFERENCES tags(id),
+    FOREIGN KEY (group_id) REFERENCES transaction_groups(id)
+);
+SQL;
+
+$db->exec($sql);
+
+echo "Database tables created.\n";
+?>

--- a/php_backend/models/Account.php
+++ b/php_backend/models/Account.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../Database.php';
+
+class Account {
+    public static function create(string $name): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT INTO accounts (name) VALUES (:name)');
+        $stmt->execute(['name' => $name]);
+        return (int)$db->lastInsertId();
+    }
+}
+?>

--- a/php_backend/models/Category.php
+++ b/php_backend/models/Category.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../Database.php';
+
+class Category {
+    public static function create(string $name): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT INTO categories (name) VALUES (:name)');
+        $stmt->execute(['name' => $name]);
+        return (int)$db->lastInsertId();
+    }
+}
+?>

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../Database.php';
+
+class Tag {
+    public static function create(string $name): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT INTO tags (name) VALUES (:name)');
+        $stmt->execute(['name' => $name]);
+        return (int)$db->lastInsertId();
+    }
+}
+?>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -1,0 +1,21 @@
+<?php
+require_once __DIR__ . '/../Database.php';
+
+class Transaction {
+    public static function create(int $account, string $date, float $amount, string $description, ?int $category = null, ?int $tag = null, ?int $group = null, ?string $ofx_id = null): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT INTO transactions (account_id, date, amount, description, category_id, tag_id, group_id, ofx_id) VALUES (:account, :date, :amount, :description, :category, :tag, :group, :ofx_id)');
+        $stmt->execute([
+            'account' => $account,
+            'date' => $date,
+            'amount' => $amount,
+            'description' => $description,
+            'category' => $category,
+            'tag' => $tag,
+            'group' => $group,
+            'ofx_id' => $ofx_id
+        ]);
+        return (int)$db->lastInsertId();
+    }
+}
+?>

--- a/php_backend/models/TransactionGroup.php
+++ b/php_backend/models/TransactionGroup.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../Database.php';
+
+class TransactionGroup {
+    public static function create(string $name): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT INTO transaction_groups (name) VALUES (:name)');
+        $stmt->execute(['name' => $name]);
+        return (int)$db->lastInsertId();
+    }
+}
+?>

--- a/php_backend/public/index.php
+++ b/php_backend/public/index.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__ . '/../models/Account.php';
+
+$accountId = Account::create('Checking');
+
+echo "Created account with ID: $accountId\n";
+?>


### PR DESCRIPTION
## Summary
- replace README with PHP instructions
- add a barebones PHP backend with models and a table creation script

## Testing
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'finance')*

------
https://chatgpt.com/codex/tasks/task_e_688ca6bb0cf4832e95e8bada9b013e17