### PR TITLE
Implement OFX upload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This repository now provides a simple PHP implementation for managing accounts a
    php php_backend/public/index.php
    ```
 
+To import transactions from an OFX file, use the upload script:
+```bash
+curl -F ofx_file=@yourfile.ofx http://localhost/path/to/php_backend/public/upload_ofx.php
+```
+
 ## Frontend
 
 A simple static frontend can be opened directly from `frontend/index.html`. It provides a navigation menu to upload OFX files or view monthly statements.

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Finance Manager</title>
+    <title>Upload OFX</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -11,13 +11,15 @@
         <nav class="sidebar">
             <h2>Menu</h2>
             <ul>
-                <li><a href="upload.html" id="upload-ofx">Upload OFX File</a></li>
-                <li><a href="#" id="view-statement">View Monthly Statement</a></li>
+                <li><a href="index.html">Home</a></li>
             </ul>
         </nav>
         <main class="content">
-            <h1>Welcome to Finance Manager</h1>
-            <p>Select an option from the menu to get started.</p>
+            <h1>Upload OFX File</h1>
+            <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data">
+                <input type="file" name="ofx_file" accept=".ofx" required>
+                <button type="submit">Upload</button>
+            </form>
         </main>
     </div>
 </body>

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -1,0 +1,63 @@
+<?php
+require_once __DIR__ . '/../models/Account.php';
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../Database.php';
+
+if (!isset($_FILES['ofx_file']) || $_FILES['ofx_file']['error'] !== UPLOAD_ERR_OK) {
+    http_response_code(400);
+    echo "No file uploaded.";
+    exit;
+}
+
+$ofxData = file_get_contents($_FILES['ofx_file']['tmp_name']);
+if ($ofxData === false) {
+    http_response_code(400);
+    echo "Unable to read uploaded file.";
+    exit;
+}
+
+// try to get account name from <ACCTID> tag, fallback to 'Default'
+$accountName = 'Default';
+if (preg_match('/<ACCTID>([^\r\n<]+)/i', $ofxData, $m)) {
+    $accountName = trim($m[1]);
+}
+
+$db = Database::getConnection();
+$stmt = $db->prepare('SELECT id FROM accounts WHERE name = :name LIMIT 1');
+$stmt->execute(['name' => $accountName]);
+$account = $stmt->fetch(PDO::FETCH_ASSOC);
+if ($account) {
+    $accountId = (int)$account['id'];
+} else {
+    $accountId = Account::create($accountName);
+}
+
+preg_match_all('/<STMTTRN>(.*?)<\/STMTTRN>/is', $ofxData, $matches);
+$inserted = 0;
+foreach ($matches[1] as $block) {
+    if (preg_match('/<DTPOSTED>([^\r\n<]+)/i', $block, $m)) {
+        $dateStr = substr(trim($m[1]), 0, 8); // YYYYMMDD
+        $date = date('Y-m-d', strtotime($dateStr));
+    } else {
+        continue; // skip invalid entry
+    }
+    if (!preg_match('/<TRNAMT>([^\r\n<]+)/i', $block, $am)) {
+        continue;
+    }
+    $amount = (float)trim($am[1]);
+    $desc = '';
+    if (preg_match('/<NAME>([^\r\n<]+)/i', $block, $dm)) {
+        $desc = trim($dm[1]);
+    } elseif (preg_match('/<MEMO>([^\r\n<]+)/i', $block, $dm)) {
+        $desc = trim($dm[1]);
+    }
+    $ofxId = null;
+    if (preg_match('/<FITID>([^\r\n<]+)/i', $block, $om)) {
+        $ofxId = trim($om[1]);
+    }
+    Transaction::create($accountId, $date, $amount, $desc, null, null, null, $ofxId);
+    $inserted++;
+}
+
+echo "Inserted $inserted transactions for account $accountName.";
+?>


### PR DESCRIPTION
## Summary
- add a new PHP endpoint `upload_ofx.php` to parse OFX files and insert transactions
- provide a front-end page `upload.html` with a form to upload OFX files
- update navigation link in `index.html`
- document upload usage in README

## Testing
- `php -l php_backend/public/upload_ofx.php`
- `php -l php_backend/public/index.php`
- `php -l php_backend/Database.php`
- `php -l php_backend/create_tables.php`

------
https://chatgpt.com/codex/tasks/task_e_688cad895108832e87f587418e2783a0