### PR TITLE
Add monthly statement view

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ This repository now provides a simple PHP implementation for managing accounts a
 
 ## Frontend
 
-A simple static frontend can be opened directly from `frontend/index.html`. It provides a navigation menu to upload OFX files or view monthly statements.
+A simple static frontend can be opened directly from `frontend/index.html`. It provides a navigation menu to upload OFX files or view monthly statements. The monthly statement page (`frontend/monthly_statement.html`) allows selecting a month and year to list transactions for that period.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,7 @@
             <h2>Menu</h2>
             <ul>
                 <li><a href="#" id="upload-ofx">Upload OFX File</a></li>
-                <li><a href="#" id="view-statement">View Monthly Statement</a></li>
+                <li><a href="monthly_statement.html" id="view-statement">View Monthly Statement</a></li>
             </ul>
         </nav>
         <main class="content">

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Monthly Statement</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar">
+            <h2>Menu</h2>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="monthly_statement.html">View Monthly Statement</a></li>
+            </ul>
+        </nav>
+        <main class="content">
+            <h1>Monthly Statement</h1>
+            <form id="statement-form">
+                <label for="month">Month:</label>
+                <select id="month" name="month">
+                    <option value="1">January</option>
+                    <option value="2">February</option>
+                    <option value="3">March</option>
+                    <option value="4">April</option>
+                    <option value="5">May</option>
+                    <option value="6">June</option>
+                    <option value="7">July</option>
+                    <option value="8">August</option>
+                    <option value="9">September</option>
+                    <option value="10">October</option>
+                    <option value="11">November</option>
+                    <option value="12">December</option>
+                </select>
+                <label for="year">Year:</label>
+                <input type="number" id="year" name="year" min="2000" value="2024">
+                <button type="submit">View</button>
+            </form>
+            <table id="transactions-table">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Description</th>
+                        <th>Amount</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </main>
+    </div>
+<script>
+const form = document.getElementById('statement-form');
+form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const month = document.getElementById('month').value;
+    const year = document.getElementById('year').value;
+    fetch('../php_backend/public/transactions.php?month=' + month + '&year=' + year)
+        .then(resp => resp.json())
+        .then(data => {
+            const tbody = document.querySelector('#transactions-table tbody');
+            tbody.innerHTML = '';
+            data.forEach(tx => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${tx.date}</td><td>${tx.description}</td><td>${tx.amount}</td>`;
+                tbody.appendChild(tr);
+            });
+        });
+});
+</script>
+</body>
+</html>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -17,5 +17,12 @@ class Transaction {
         ]);
         return (int)$db->lastInsertId();
     }
+
+    public static function getByMonth(int $month, int $year): array {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT * FROM transactions WHERE MONTH(date) = :month AND YEAR(date) = :year ORDER BY date');
+        $stmt->execute(['month' => $month, 'year' => $year]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }
 ?>

--- a/php_backend/public/transactions.php
+++ b/php_backend/public/transactions.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+$month = isset($_GET['month']) ? (int)$_GET['month'] : date('n');
+$year = isset($_GET['year']) ? (int)$_GET['year'] : date('Y');
+
+try {
+    $transactions = Transaction::getByMonth($month, $year);
+    echo json_encode($transactions);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+


### PR DESCRIPTION
## Summary
- add method to fetch transactions for a month
- expose transactions endpoint
- create monthly statement frontend page
- link from main page
- document in README

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/transactions.php`
- `find php_backend -name '*.php' -print -exec php -l {} \;`


------
https://chatgpt.com/codex/tasks/task_e_688cadcac0bc832ebdb7eacea4fd2e71