### PR TITLE
Add category admin interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ This repository now provides a simple PHP implementation for managing accounts a
 ## Frontend
 
 A simple static frontend can be opened directly from `frontend/index.html`. It provides a navigation menu to upload OFX files or view monthly statements.
+
+### Category Administration
+
+The navigation now includes a *Manage Categories* link which opens `frontend/categories.html`.
+From this page you can create new categories, rename them and associate tags with a category.
+The forms submit to `php_backend/public/categories.php` which performs the requested action.

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Manage Categories</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar">
+            <h2>Menu</h2>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+            </ul>
+        </nav>
+        <main class="content">
+            <h1>Manage Categories</h1>
+            <section>
+                <h2>Add Category</h2>
+                <form action="../php_backend/public/categories.php" method="post">
+                    <input type="hidden" name="action" value="create">
+                    <input type="text" name="name" placeholder="Category name">
+                    <button type="submit">Add</button>
+                </form>
+            </section>
+            <section>
+                <h2>Update Category</h2>
+                <form action="../php_backend/public/categories.php" method="post">
+                    <input type="hidden" name="action" value="update">
+                    <input type="number" name="id" placeholder="Category ID">
+                    <input type="text" name="name" placeholder="New name">
+                    <button type="submit">Update</button>
+                </form>
+            </section>
+            <section>
+                <h2>Assign Tag to Category</h2>
+                <form action="../php_backend/public/categories.php" method="post">
+                    <input type="hidden" name="action" value="add_tag">
+                    <input type="number" name="category_id" placeholder="Category ID">
+                    <input type="number" name="tag_id" placeholder="Tag ID">
+                    <button type="submit">Assign</button>
+                </form>
+            </section>
+        </main>
+    </div>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,6 +13,7 @@
             <ul>
                 <li><a href="#" id="upload-ofx">Upload OFX File</a></li>
                 <li><a href="#" id="view-statement">View Monthly Statement</a></li>
+                <li><a href="categories.html" id="manage-categories">Manage Categories</a></li>
             </ul>
         </nav>
         <main class="content">

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -19,6 +19,14 @@ CREATE TABLE IF NOT EXISTS tags (
     name VARCHAR(100) NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS category_tags (
+    category_id INT NOT NULL,
+    tag_id INT NOT NULL,
+    PRIMARY KEY (category_id, tag_id),
+    FOREIGN KEY (category_id) REFERENCES categories(id),
+    FOREIGN KEY (tag_id) REFERENCES tags(id)
+);
+
 CREATE TABLE IF NOT EXISTS transaction_groups (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL

--- a/php_backend/models/Category.php
+++ b/php_backend/models/Category.php
@@ -8,5 +8,11 @@ class Category {
         $stmt->execute(['name' => $name]);
         return (int)$db->lastInsertId();
     }
+
+    public static function update(int $id, string $name): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE categories SET name = :name WHERE id = :id');
+        $stmt->execute(['id' => $id, 'name' => $name]);
+    }
 }
 ?>

--- a/php_backend/models/CategoryTag.php
+++ b/php_backend/models/CategoryTag.php
@@ -1,0 +1,17 @@
+<?php
+require_once __DIR__ . '/../Database.php';
+
+class CategoryTag {
+    public static function add(int $categoryId, int $tagId): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT IGNORE INTO category_tags (category_id, tag_id) VALUES (:category_id, :tag_id)');
+        $stmt->execute(['category_id' => $categoryId, 'tag_id' => $tagId]);
+    }
+
+    public static function remove(int $categoryId, int $tagId): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('DELETE FROM category_tags WHERE category_id = :category_id AND tag_id = :tag_id');
+        $stmt->execute(['category_id' => $categoryId, 'tag_id' => $tagId]);
+    }
+}
+?>

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -1,0 +1,40 @@
+<?php
+require_once __DIR__ . '/../models/Category.php';
+require_once __DIR__ . '/../models/CategoryTag.php';
+
+header('Content-Type: application/json');
+$action = $_POST['action'] ?? null;
+
+try {
+    switch ($action) {
+        case 'create':
+            $name = trim($_POST['name'] ?? '');
+            $id = Category::create($name);
+            echo json_encode(['id' => $id]);
+            break;
+        case 'update':
+            $id = (int)($_POST['id'] ?? 0);
+            $name = trim($_POST['name'] ?? '');
+            Category::update($id, $name);
+            echo json_encode(['status' => 'ok']);
+            break;
+        case 'add_tag':
+            $categoryId = (int)($_POST['category_id'] ?? 0);
+            $tagId = (int)($_POST['tag_id'] ?? 0);
+            CategoryTag::add($categoryId, $tagId);
+            echo json_encode(['status' => 'ok']);
+            break;
+        case 'remove_tag':
+            $categoryId = (int)($_POST['category_id'] ?? 0);
+            $tagId = (int)($_POST['tag_id'] ?? 0);
+            CategoryTag::remove($categoryId, $tagId);
+            echo json_encode(['status' => 'ok']);
+            break;
+        default:
+            throw new Exception('Invalid action');
+    }
+} catch (Exception $e) {
+    http_response_code(400);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- add table to link categories with tags
- support updating categories in the model
- expose `categories.php` API to create/update categories and assign tags
- create CategoryTag model for tag associations
- add a simple frontend page for managing categories
- update menu and documentation

## Testing
- `php -l php_backend/create_tables.php`
- `php -l php_backend/models/Category.php`
- `php -l php_backend/models/CategoryTag.php`
- `php -l php_backend/public/categories.php`
- `php -l php_backend/public/index.php`

------
https://chatgpt.com/codex/tasks/task_e_688caecd3a00832ebc8a18ccbcd75f2c