### PR TITLE
Add transaction reporting page and PHP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,10 @@ This repository now provides a simple PHP implementation for managing accounts a
 ## Frontend
 
 A simple static frontend can be opened directly from `frontend/index.html`. It provides a navigation menu to upload OFX files or view monthly statements.
+
+## Reports
+
+The frontend also includes a simple reporting page available at `frontend/report.html`.
+It allows running a report to list all transactions filtered by category, tag or group.
+The page sends requests to `php_backend/public/report.php` which returns matching
+transactions as JSON.

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -32,3 +32,19 @@ body {
     flex-grow: 1;
     padding: 20px;
 }
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+}
+
+th, td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: left;
+}
+
+th {
+    background-color: #eee;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,6 +13,7 @@
             <ul>
                 <li><a href="#" id="upload-ofx">Upload OFX File</a></li>
                 <li><a href="#" id="view-statement">View Monthly Statement</a></li>
+                <li><a href="report.html">Transaction Reports</a></li>
             </ul>
         </nav>
         <main class="content">

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Transaction Reports</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar">
+            <h2>Menu</h2>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+            </ul>
+        </nav>
+        <main class="content">
+            <h1>Transaction Reports</h1>
+            <form id="report-form">
+                <label>Category ID: <input type="number" id="category"></label>
+                <label>Tag ID: <input type="number" id="tag"></label>
+                <label>Group ID: <input type="number" id="group"></label>
+                <button type="submit">Run Report</button>
+            </form>
+            <table id="results">
+                <thead>
+                    <tr><th>Date</th><th>Amount</th><th>Description</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </main>
+    </div>
+    <script>
+    document.getElementById('report-form').addEventListener('submit', function(e) {
+        e.preventDefault();
+        const category = document.getElementById('category').value;
+        const tag = document.getElementById('tag').value;
+        const group = document.getElementById('group').value;
+        const params = new URLSearchParams();
+        if (category) params.append('category', category);
+        if (tag) params.append('tag', tag);
+        if (group) params.append('group', group);
+        fetch('../php_backend/public/report.php?' + params.toString())
+            .then(resp => resp.json())
+            .then(data => {
+                const tbody = document.querySelector('#results tbody');
+                tbody.innerHTML = '';
+                if (Array.isArray(data) && data.length) {
+                    data.forEach(tx => {
+                        const tr = document.createElement('tr');
+                        tr.innerHTML = `<td>${tx.date}</td><td>${tx.amount}</td><td>${tx.description}</td>`;
+                        tbody.appendChild(tr);
+                    });
+                } else {
+                    tbody.innerHTML = '<tr><td colspan="3">No transactions found.</td></tr>';
+                }
+            });
+    });
+    </script>
+</body>
+</html>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -17,5 +17,26 @@ class Transaction {
         ]);
         return (int)$db->lastInsertId();
     }
+
+    public static function getByCategory(int $categoryId): array {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT date, amount, description FROM transactions WHERE category_id = :category');
+        $stmt->execute(['category' => $categoryId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public static function getByTag(int $tagId): array {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT date, amount, description FROM transactions WHERE tag_id = :tag');
+        $stmt->execute(['tag' => $tagId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public static function getByGroup(int $groupId): array {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT date, amount, description FROM transactions WHERE group_id = :grp');
+        $stmt->execute(['grp' => $groupId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }
 ?>

--- a/php_backend/public/report.php
+++ b/php_backend/public/report.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+$category = isset($_GET['category']) ? (int)$_GET['category'] : null;
+$tag = isset($_GET['tag']) ? (int)$_GET['tag'] : null;
+$group = isset($_GET['group']) ? (int)$_GET['group'] : null;
+
+if ($category) {
+    echo json_encode(Transaction::getByCategory($category));
+} elseif ($tag) {
+    echo json_encode(Transaction::getByTag($tag));
+} elseif ($group) {
+    echo json_encode(Transaction::getByGroup($group));
+} else {
+    echo json_encode([]);
+}
+?>


### PR DESCRIPTION
## Summary
- add methods to query transactions by category, tag or group
- expose `php_backend/public/report.php` to return filtered transactions
- create a simple reporting page in `frontend/report.html`
- link new page from the main index
- add table styling
- document reporting page in README

## Testing
- `php -l php_backend/public/report.php`
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_688caf1f1728832e805b3127b684368c