### PR TITLE
Implement global overlay for feedback

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -44,5 +44,24 @@
             </section>
         </main>
     </div>
+    <script src="js/overlay.js"></script>
+    <script>
+    document.querySelectorAll("form").forEach(f => {
+        f.addEventListener("submit", async e => {
+            e.preventDefault();
+            const data = new FormData(f);
+            const resp = await fetch(f.action, {method: f.method, body: data});
+            const text = await resp.text();
+            try {
+                const j = JSON.parse(text);
+                if (j.error) showMessage("Error: " + j.error);
+                else if (j.id) showMessage("Created ID " + j.id);
+                else showMessage("Success");
+            } catch {
+                showMessage(text);
+            }
+        });
+    });
+    </script>
 </body>
 </html>

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -48,3 +48,26 @@ th, td {
 th {
     background-color: #eee;
 }
+
+.overlay{
+    position:fixed;
+    top:0;
+    left:0;
+    width:100%;
+    height:100%;
+    background:rgba(0,0,0,0.5);
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    visibility:hidden;
+}
+.overlay.show{
+    visibility:visible;
+}
+.overlay-content{
+    background:#fff;
+    padding:20px;
+    border-radius:4px;
+    max-width:80%;
+    box-shadow:0 2px 6px rgba(0,0,0,0.3);
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,5 +26,6 @@
             <p>Select an option from the menu to get started.</p>
         </main>
     </div>
+    <script src="js/overlay.js"></script>
 </body>
 </html>

--- a/frontend/js/overlay.js
+++ b/frontend/js/overlay.js
@@ -1,0 +1,21 @@
+(function(){
+    function createOverlay(){
+        const overlay = document.createElement('div');
+        overlay.id = 'overlay';
+        overlay.className = 'overlay';
+        overlay.innerHTML = '<div class="overlay-content"></div>';
+        overlay.addEventListener('click', () => overlay.classList.remove('show'));
+        document.body.appendChild(overlay);
+        return overlay;
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        window.__overlay = createOverlay();
+    });
+
+    window.showMessage = function(msg){
+        const overlay = window.__overlay || document.getElementById('overlay') || createOverlay();
+        overlay.querySelector('.overlay-content').textContent = msg;
+        overlay.classList.add('show');
+    };
+})();

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -68,5 +68,6 @@ form.addEventListener('submit', function(e) {
         });
 });
 </script>
+    <script src="js/overlay.js"></script>
 </body>
 </html>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -57,5 +57,6 @@
             });
     });
     </script>
+    <script src="js/overlay.js"></script>
 </body>
 </html>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -50,9 +50,11 @@ document.getElementById('tag-form').addEventListener('submit', async (e)=>{
     document.getElementById('tag-name').value='';
     document.getElementById('tag-keyword').value='';
     loadTags();
+    showMessage("Tag created");
 });
 
 loadTags();
 </script>
+    <script src="js/overlay.js"></script>
 </body>
 </html>

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -22,5 +22,16 @@
             </form>
         </main>
     </div>
+    <script src="js/overlay.js"></script>
+    <script>
+const uploadForm = document.querySelector("form");
+uploadForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const data = new FormData(uploadForm);
+    const resp = await fetch(uploadForm.action, {method: "POST", body: data});
+    const text = await resp.text();
+    showMessage(text);
+});
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable `overlay.js` script
- update styles for overlay
- intercept form submissions in categories and upload pages
- add feedback messages when creating tags
- include overlay support on all pages

## Testing
- `find . -name '*test*' -maxdepth 2`

------
https://chatgpt.com/codex/tasks/task_e_688cdec88914832e84c37201d6ad5de8