### PR TITLE
Fix Transaction class for OFX upload

### DIFF
--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -41,6 +41,8 @@ class Transaction {
         $db = Database::getConnection();
         $stmt = $db->prepare('SELECT date, amount, description FROM transactions WHERE group_id = :grp');
         $stmt->execute(['grp' => $groupId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 
     public static function getByMonth(int $month, int $year): array {
         $db = Database::getConnection();


### PR DESCRIPTION
## Summary
- fix syntax error in `Transaction` model that blocked OFX uploads

## Testing
- `php -l php_backend/models/Transaction.php`
- `find php_backend -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_688cde57c194832ea7dab3b6fa0b010f