### PR TITLE
Add global navigation menu

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -8,12 +8,7 @@
 </head>
 <body>
     <div class="container">
-        <nav class="sidebar">
-            <h2>Menu</h2>
-            <ul>
-                <li><a href="index.html">Home</a></li>
-            </ul>
-        </nav>
+        <nav class="sidebar" id="menu"></nav>
         <main class="content">
             <h1>Manage Categories</h1>
             <section>
@@ -44,5 +39,6 @@
             </section>
         </main>
     </div>
+    <script src="js/menu.js"></script>
 </body>
 </html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,23 +8,12 @@
 </head>
 <body>
     <div class="container">
-        <nav class="sidebar">
-            <h2>Menu</h2>
-            <ul>
-
-                <li><a href="monthly_statement.html" id="view-statement">View Monthly Statement</a></li>
-                <li><a href="upload.html" id="upload-ofx">Upload OFX File</a></li>
-                <li><a href="#" id="view-statement">View Monthly Statement</a></li>
-                <li><a href="report.html">Transaction Reports</a></li>
-                <li><a href="tags.html" id="manage-tags">Manage Tags</a></li>
-                <li><a href="categories.html" id="manage-categories">Manage Categories</a></li>
-
-            </ul>
-        </nav>
+        <nav class="sidebar" id="menu"></nav>
         <main class="content">
             <h1>Welcome to Finance Manager</h1>
             <p>Select an option from the menu to get started.</p>
         </main>
     </div>
+    <script src="js/menu.js"></script>
 </body>
 </html>

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const menu = document.getElementById('menu');
+  if (menu) {
+    fetch('menu.html')
+      .then(resp => resp.text())
+      .then(html => {
+        menu.innerHTML = html;
+      })
+      .catch(err => console.error('Menu load failed', err));
+  }
+});

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -1,0 +1,9 @@
+<h2>Menu</h2>
+<ul>
+    <li><a href="index.html">Home</a></li>
+    <li><a href="upload.html">Upload OFX File</a></li>
+    <li><a href="monthly_statement.html">View Monthly Statement</a></li>
+    <li><a href="report.html">Transaction Reports</a></li>
+    <li><a href="tags.html">Manage Tags</a></li>
+    <li><a href="categories.html">Manage Categories</a></li>
+</ul>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -8,13 +8,7 @@
 </head>
 <body>
     <div class="container">
-        <nav class="sidebar">
-            <h2>Menu</h2>
-            <ul>
-                <li><a href="index.html">Home</a></li>
-                <li><a href="monthly_statement.html">View Monthly Statement</a></li>
-            </ul>
-        </nav>
+        <nav class="sidebar" id="menu"></nav>
         <main class="content">
             <h1>Monthly Statement</h1>
             <form id="statement-form">
@@ -49,6 +43,7 @@
             </table>
         </main>
     </div>
+    <script src="js/menu.js"></script>
 <script>
 const form = document.getElementById('statement-form');
 form.addEventListener('submit', function(e) {

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -8,12 +8,7 @@
 </head>
 <body>
     <div class="container">
-        <nav class="sidebar">
-            <h2>Menu</h2>
-            <ul>
-                <li><a href="index.html">Home</a></li>
-            </ul>
-        </nav>
+        <nav class="sidebar" id="menu"></nav>
         <main class="content">
             <h1>Transaction Reports</h1>
             <form id="report-form">
@@ -30,6 +25,7 @@
             </table>
         </main>
     </div>
+    <script src="js/menu.js"></script>
     <script>
     document.getElementById('report-form').addEventListener('submit', function(e) {
         e.preventDefault();

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -8,12 +8,7 @@
 </head>
 <body>
     <div class="container">
-        <nav class="sidebar">
-            <h2>Menu</h2>
-            <ul>
-                <li><a href="index.html">Home</a></li>
-            </ul>
-        </nav>
+        <nav class="sidebar" id="menu"></nav>
         <main class="content">
             <h1>Manage Tags</h1>
             <form id="tag-form">
@@ -25,6 +20,7 @@
             <ul id="tag-list"></ul>
         </main>
     </div>
+    <script src="js/menu.js"></script>
 <script>
 async function loadTags(){
     const res = await fetch('../php_backend/public/tags.php');

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -8,12 +8,7 @@
 </head>
 <body>
     <div class="container">
-        <nav class="sidebar">
-            <h2>Menu</h2>
-            <ul>
-                <li><a href="index.html">Home</a></li>
-            </ul>
-        </nav>
+        <nav class="sidebar" id="menu"></nav>
         <main class="content">
             <h1>Upload OFX File</h1>
             <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data">
@@ -22,5 +17,6 @@
             </form>
         </main>
     </div>
+    <script src="js/menu.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep the sidebar menu consistent across the site
- load menu content from a shared HTML snippet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688cdef4e7f4832e9d276ce09fefce3e