### PR TITLE
Fix SQL column errors and add DB logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repository now provides a simple PHP implementation for managing accounts a
    php php_backend/public/index.php
    ```
 
+Any errors during upload or other operations are stored in a `logs` table.
+
 To import transactions from an OFX file, use the upload script:
 ```bash
 curl -F ofx_file=@yourfile.ofx http://localhost/path/to/php_backend/public/upload_ofx.php

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -48,6 +48,13 @@ CREATE TABLE IF NOT EXISTS transactions (
     FOREIGN KEY (tag_id) REFERENCES tags(id),
     FOREIGN KEY (group_id) REFERENCES transaction_groups(id)
 );
+
+CREATE TABLE IF NOT EXISTS logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    level VARCHAR(10) NOT NULL,
+    message TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 SQL;
 
 $db->exec($sql);

--- a/php_backend/models/Log.php
+++ b/php_backend/models/Log.php
@@ -1,0 +1,11 @@
+<?php
+require_once __DIR__ . '/../Database.php';
+
+class Log {
+    public static function write(string $message, string $level = 'INFO'): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT INTO logs (level, message) VALUES (:level, :message)');
+        $stmt->execute(['level' => $level, 'message' => $message]);
+    }
+}
+?>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -11,7 +11,7 @@ class Transaction {
 
         // avoid duplicate inserts when an OFX id already exists
         if ($ofx_id !== null) {
-            $check = $db->prepare('SELECT id FROM transactions WHERE ofx_id = :oid LIMIT 1');
+            $check = $db->prepare('SELECT id FROM `transactions` WHERE `ofx_id` = :oid LIMIT 1');
             $check->execute(['oid' => $ofx_id]);
             $existing = $check->fetch(PDO::FETCH_ASSOC);
             if ($existing) {
@@ -19,7 +19,7 @@ class Transaction {
             }
         }
 
-        $stmt = $db->prepare('INSERT INTO transactions (account_id, date, amount, description, category_id, tag_id, group_id, ofx_id) VALUES (:account, :date, :amount, :description, :category, :tag, :group, :ofx_id)');
+        $stmt = $db->prepare('INSERT INTO transactions (`account_id`, `date`, `amount`, `description`, `category_id`, `tag_id`, `group_id`, `ofx_id`) VALUES (:account, :date, :amount, :description, :category, :tag, :group, :ofx_id)');
         $stmt->execute([
             'account' => $account,
             'date' => $date,
@@ -36,28 +36,28 @@ class Transaction {
 
     public static function getByCategory(int $categoryId): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare('SELECT date, amount, description FROM transactions WHERE category_id = :category');
+        $stmt = $db->prepare('SELECT `date`, `amount`, `description` FROM `transactions` WHERE `category_id` = :category');
         $stmt->execute(['category' => $categoryId]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     public static function getByTag(int $tagId): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare('SELECT date, amount, description FROM transactions WHERE tag_id = :tag');
+        $stmt = $db->prepare('SELECT `date`, `amount`, `description` FROM `transactions` WHERE `tag_id` = :tag');
         $stmt->execute(['tag' => $tagId]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     public static function getByGroup(int $groupId): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare('SELECT date, amount, description FROM transactions WHERE group_id = :grp');
+        $stmt = $db->prepare('SELECT `date`, `amount`, `description` FROM `transactions` WHERE `group_id` = :grp');
         $stmt->execute(['grp' => $groupId]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
     public static function getByMonth(int $month, int $year): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare('SELECT * FROM transactions WHERE MONTH(date) = :month AND YEAR(date) = :year ORDER BY date');
+        $stmt = $db->prepare('SELECT * FROM `transactions` WHERE MONTH(`date`) = :month AND YEAR(`date`) = :year ORDER BY `date`');
         $stmt->execute(['month' => $month, 'year' => $year]);
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/../models/Account.php';
 require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../Database.php';
 
 try {
@@ -61,8 +62,11 @@ foreach ($matches[1] as $block) {
 }
 
     echo "Inserted $inserted transactions for account $accountName.";
+    Log::write("Inserted $inserted transactions for account $accountName");
 } catch (Exception $e) {
     http_response_code(500);
-    echo 'Error: ' . $e->getMessage();
+    $msg = 'Error: ' . $e->getMessage();
+    Log::write($msg, 'ERROR');
+    echo $msg;
 }
 ?>


### PR DESCRIPTION
## Summary
- add a database table for logs
- add a Log model for writing log entries
- fix transaction queries by quoting column names
- log successes and errors during OFX upload
- document logging table in README

## Testing
- `php -l php_backend/models/Log.php`
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/upload_ofx.php`
- `php -l php_backend/create_tables.php`

------
https://chatgpt.com/codex/tasks/task_e_688ceb73339c832e9d215395d274cbc1