### PR TITLE
Add logs viewer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This repository now provides a simple PHP implementation for managing accounts a
    ```
 
 Any errors during upload or other operations are stored in a `logs` table.
+You can view these entries by opening `frontend/logs.html` which calls the
+`php_backend/public/logs.php` endpoint.
 
 To import transactions from an OFX file, use the upload script:
 ```bash

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Application Logs</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar" id="menu"></nav>
+        <main class="content">
+            <h1>Application Logs</h1>
+            <table id="logs-table">
+                <thead>
+                    <tr>
+                        <th>Time</th>
+                        <th>Level</th>
+                        <th>Message</th>
+                    </tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </main>
+    </div>
+
+    <script src="js/menu.js"></script>
+    <script>
+    fetch('../php_backend/public/logs.php')
+        .then(resp => resp.json())
+        .then(data => {
+            const tbody = document.querySelector('#logs-table tbody');
+            tbody.innerHTML = '';
+            data.forEach(log => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `<td>${log.created_at}</td><td>${log.level}</td><td>${log.message}</td>`;
+                tbody.appendChild(tr);
+            });
+        });
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -6,4 +6,5 @@
     <li><a href="report.html">Transaction Reports</a></li>
     <li><a href="tags.html">Manage Tags</a></li>
     <li><a href="categories.html">Manage Categories</a></li>
+    <li><a href="logs.html">View Logs</a></li>
 </ul>

--- a/php_backend/models/Log.php
+++ b/php_backend/models/Log.php
@@ -7,5 +7,19 @@ class Log {
         $stmt = $db->prepare('INSERT INTO logs (level, message) VALUES (:level, :message)');
         $stmt->execute(['level' => $level, 'message' => $message]);
     }
+
+    public static function all(int $limit = 100): array {
+        $db = Database::getConnection();
+        $sql = 'SELECT level, message, created_at FROM logs ORDER BY created_at DESC';
+        if ($limit !== null) {
+            $sql .= ' LIMIT :limit';
+        }
+        $stmt = $db->prepare($sql);
+        if ($limit !== null) {
+            $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        }
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }
 ?>

--- a/php_backend/public/logs.php
+++ b/php_backend/public/logs.php
@@ -1,0 +1,13 @@
+<?php
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 100;
+try {
+    echo json_encode(Log::all($limit));
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+


### PR DESCRIPTION
## Summary
- implement Log::all to fetch stored log records
- add backend endpoint to return logs in JSON
- create frontend logs page listing the log entries
- link to logs page from the sidebar menu
- document how to access logs in README

## Testing
- `php -l php_backend/public/logs.php`
- `php -l php_backend/models/Log.php`


------
https://chatgpt.com/codex/tasks/task_e_688cef347d88832e97d5f7268224a025