### PR TITLE
Fix tags keyword column error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository now provides a simple PHP implementation for managing accounts a
    ```bash
    php php_backend/create_tables.php
    ```
+   Re-running this script after upgrading will also add any new columns.
 4. Run the example script which inserts a sample account:
    ```bash
    php php_backend/public/index.php

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -59,5 +59,11 @@ SQL;
 
 $db->exec($sql);
 
+// Ensure keyword column exists if the tags table pre-dates it
+$result = $db->query("SHOW COLUMNS FROM `tags` LIKE 'keyword'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `tags` ADD COLUMN `keyword` VARCHAR(100) DEFAULT NULL");
+}
+
 echo "Database tables created.\n";
 ?>


### PR DESCRIPTION
## Summary
- ensure keyword column gets created for existing databases
- clarify in README that create_tables.php can be re-run

## Testing
- `php -l php_backend/create_tables.php`

------
https://chatgpt.com/codex/tasks/task_e_688cf1860854832e9eef3a018f3cf462