### PR TITLE
Add transaction search page and API

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -4,6 +4,7 @@
     <li><a href="upload.html">Upload OFX File</a></li>
     <li><a href="monthly_statement.html">View Monthly Statement</a></li>
     <li><a href="report.html">Transaction Reports</a></li>
+    <li><a href="search.html">Search Transactions</a></li>
     <li><a href="tags.html">Manage Tags</a></li>
     <li><a href="categories.html">Manage Categories</a></li>
     <li><a href="logs.html">View Logs</a></li>

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Search Transactions</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar" id="menu"></nav>
+        <main class="content">
+            <h1>Search Transactions</h1>
+            <form id="search-form">
+                <label>Field:
+                    <select id="field">
+                        <option value="description">Description</option>
+                        <option value="date">Date</option>
+                        <option value="amount">Amount</option>
+                        <option value="account_id">Account ID</option>
+                        <option value="category_id">Category ID</option>
+                        <option value="tag_id">Tag ID</option>
+                        <option value="group_id">Group ID</option>
+                        <option value="ofx_id">OFX ID</option>
+                    </select>
+                </label>
+                <input type="text" id="term" placeholder="Search value">
+                <button type="submit">Search</button>
+            </form>
+            <table id="results">
+                <thead>
+                    <tr><th>Date</th><th>Description</th><th>Amount</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+            <p id="total"></p>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script>
+    document.getElementById('search-form').addEventListener('submit', function(e){
+        e.preventDefault();
+        const field = document.getElementById('field').value;
+        const term = document.getElementById('term').value;
+        const params = new URLSearchParams({field: field, value: term});
+        fetch('../php_backend/public/search_transactions.php?' + params.toString())
+            .then(resp => resp.json())
+            .then(data => {
+                const tbody = document.querySelector('#results tbody');
+                tbody.innerHTML = '';
+                if (data.results && data.results.length) {
+                    data.results.forEach(tx => {
+                        const tr = document.createElement('tr');
+                        tr.innerHTML = `<td>${tx.date}</td><td>${tx.description}</td><td>${tx.amount}</td>`;
+                        tbody.appendChild(tr);
+                    });
+                } else {
+                    tbody.innerHTML = '<tr><td colspan="3">No transactions found.</td></tr>';
+                }
+                document.getElementById('total').textContent = 'Total: ' + data.total;
+            });
+    });
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -62,5 +62,30 @@ class Transaction {
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
+
+    /**
+     * Search transactions by a specific field.
+     * Supports partial matches for text fields and exact matches for numeric fields.
+     */
+    public static function search(string $field, string $value): array {
+        $allowed = ['id','account_id','date','amount','description','category_id','tag_id','group_id','ofx_id'];
+        if (!in_array($field, $allowed, true)) {
+            throw new Exception('Invalid search field');
+        }
+
+        $db = Database::getConnection();
+
+        // numeric fields use exact match
+        $numeric = ['id','account_id','category_id','tag_id','group_id','amount'];
+        if (in_array($field, $numeric, true)) {
+            $stmt = $db->prepare("SELECT * FROM `transactions` WHERE `$field` = :val");
+            $stmt->execute(['val' => $value]);
+        } else {
+            $stmt = $db->prepare("SELECT * FROM `transactions` WHERE `$field` LIKE :val");
+            $stmt->execute(['val' => '%' . $value . '%']);
+        }
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }
 ?>

--- a/php_backend/public/search_transactions.php
+++ b/php_backend/public/search_transactions.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+$field = $_GET['field'] ?? '';
+$value = $_GET['value'] ?? '';
+
+if ($field === '' || $value === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Field and value are required']);
+    exit;
+}
+
+try {
+    $results = Transaction::search($field, $value);
+    $total = 0.0;
+    foreach ($results as $row) {
+        $total += (float)$row['amount'];
+    }
+    echo json_encode(['results' => $results, 'total' => $total]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- support searching transactions by any field
- add search endpoint to backend
- add search page to frontend and link it from menu

## Testing
- `php -l php_backend/public/search_transactions.php`
- `php -l php_backend/models/Transaction.php`

------
https://chatgpt.com/codex/tasks/task_e_688cf55fe3e8832ebadb21ccf6460fcc