### PR TITLE
fix: uppercase method for category requests

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -47,7 +47,7 @@
         f.addEventListener("submit", async e => {
             e.preventDefault();
             const data = new FormData(f);
-            const resp = await fetch(f.action, {method: f.method, body: data});
+            const resp = await fetch(f.action, {method: f.method.toUpperCase(), body: data});
             const text = await resp.text();
             try {
                 const j = JSON.parse(text);


### PR DESCRIPTION
## Summary
- ensure category form submissions use an uppercase HTTP method so PHP backend routes correctly

## Testing
- `php -l php_backend/public/categories.php`


------
https://chatgpt.com/codex/tasks/task_e_688dcdadf570832eabd4807a334f8c6e