### PR TITLE
feat: render tables with highcharts datagrid

### DIFF
--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -11,30 +11,32 @@
         <nav class="sidebar" id="menu"></nav>
         <main class="content">
             <h1>Application Logs</h1>
-            <table id="logs-table">
-                <thead>
-                    <tr>
-                        <th>Time</th>
-                        <th>Level</th>
-                        <th>Message</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
+            <div id="logs-grid"></div>
         </main>
     </div>
 
     <script src="js/menu.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/data.js"></script>
+    <script src="https://code.highcharts.com/modules/datagrid.js"></script>
     <script>
     fetch('../php_backend/public/logs.php')
         .then(resp => resp.json())
         .then(data => {
-            const tbody = document.querySelector('#logs-table tbody');
-            tbody.innerHTML = '';
-            data.forEach(log => {
-                const tr = document.createElement('tr');
-                tr.innerHTML = `<td>${log.created_at}</td><td>${log.level}</td><td>${log.message}</td>`;
-                tbody.appendChild(tr);
+            const dataTable = new Highcharts.DataTable({
+                columns: {
+                    time: data.map(log => log.created_at),
+                    level: data.map(log => log.level),
+                    message: data.map(log => log.message)
+                }
+            });
+            Highcharts.DataGrid('#logs-grid', {
+                dataTable,
+                columns: {
+                    time: { title: 'Time' },
+                    level: { title: 'Level' },
+                    message: { title: 'Message' }
+                }
             });
         });
     </script>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -31,19 +31,13 @@
                 <input type="number" id="year" name="year" min="2000" value="2024">
                 <button type="submit">View</button>
             </form>
-            <table id="transactions-table">
-                <thead>
-                    <tr>
-                        <th>Date</th>
-                        <th>Description</th>
-                        <th>Amount</th>
-                    </tr>
-                </thead>
-                <tbody></tbody>
-            </table>
+            <div id="transactions-grid"></div>
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/data.js"></script>
+    <script src="https://code.highcharts.com/modules/datagrid.js"></script>
 <script>
 const form = document.getElementById('statement-form');
 form.addEventListener('submit', function(e) {
@@ -53,12 +47,20 @@ form.addEventListener('submit', function(e) {
     fetch('../php_backend/public/transactions.php?month=' + month + '&year=' + year)
         .then(resp => resp.json())
         .then(data => {
-            const tbody = document.querySelector('#transactions-table tbody');
-            tbody.innerHTML = '';
-            data.forEach(tx => {
-                const tr = document.createElement('tr');
-                tr.innerHTML = `<td>${tx.date}</td><td>${tx.description}</td><td>${tx.amount}</td>`;
-                tbody.appendChild(tr);
+            const dataTable = new Highcharts.DataTable({
+                columns: {
+                    date: data.map(tx => tx.date),
+                    description: data.map(tx => tx.description),
+                    amount: data.map(tx => tx.amount)
+                }
+            });
+            Highcharts.DataGrid('#transactions-grid', {
+                dataTable,
+                columns: {
+                    date: { title: 'Date' },
+                    description: { title: 'Description' },
+                    amount: { title: 'Amount' }
+                }
             });
         });
 });

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -17,17 +17,14 @@
                 <label>Group ID: <input type="number" id="group"></label>
                 <button type="submit">Run Report</button>
             </form>
-            <table id="results">
-                <thead>
-                    <tr><th>Date</th><th>Amount</th><th>Description</th></tr>
-                </thead>
-                <tbody></tbody>
-            </table>
+            <div id="results-grid"></div>
             <div id="chart" style="height:400px;margin-top:20px;"></div>
         </main>
     </div>
     <script src="js/menu.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/data.js"></script>
+    <script src="https://code.highcharts.com/modules/datagrid.js"></script>
     <script>
     document.getElementById('report-form').addEventListener('submit', function(e) {
         e.preventDefault();
@@ -41,15 +38,25 @@
         fetch('../php_backend/public/report.php?' + params.toString())
             .then(resp => resp.json())
             .then(data => {
-                const tbody = document.querySelector('#results tbody');
+                const gridContainer = '#results-grid';
                 const chartContainer = document.getElementById('chart');
-                tbody.innerHTML = '';
+                document.querySelector(gridContainer).innerHTML = '';
                 chartContainer.innerHTML = '';
                 if (Array.isArray(data) && data.length) {
-                    data.forEach(tx => {
-                        const tr = document.createElement('tr');
-                        tr.innerHTML = `<td>${tx.date}</td><td>${tx.amount}</td><td>${tx.description}</td>`;
-                        tbody.appendChild(tr);
+                    const dataTable = new Highcharts.DataTable({
+                        columns: {
+                            date: data.map(tx => tx.date),
+                            amount: data.map(tx => tx.amount),
+                            description: data.map(tx => tx.description)
+                        }
+                    });
+                    Highcharts.DataGrid(gridContainer, {
+                        dataTable,
+                        columns: {
+                            date: { title: 'Date' },
+                            amount: { title: 'Amount' },
+                            description: { title: 'Description' }
+                        }
                     });
                     const categories = data.map(tx => tx.date);
                     const amounts = data.map(tx => parseFloat(tx.amount));
@@ -61,7 +68,7 @@
                         series: [{ name: 'Amount', data: amounts }]
                     });
                 } else {
-                    tbody.innerHTML = '<tr><td colspan="3">No transactions found.</td></tr>';
+                    document.querySelector(gridContainer).innerHTML = 'No transactions found.';
                 }
             });
     });

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -27,16 +27,14 @@
                 <input type="text" id="term" placeholder="Search value">
                 <button type="submit">Search</button>
             </form>
-            <table id="results">
-                <thead>
-                    <tr><th>Date</th><th>Description</th><th>Amount</th></tr>
-                </thead>
-                <tbody></tbody>
-            </table>
+            <div id="results-grid"></div>
             <p id="total"></p>
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/data.js"></script>
+    <script src="https://code.highcharts.com/modules/datagrid.js"></script>
     <script>
     document.getElementById('search-form').addEventListener('submit', function(e){
         e.preventDefault();
@@ -46,16 +44,27 @@
         fetch('../php_backend/public/search_transactions.php?' + params.toString())
             .then(resp => resp.json())
             .then(data => {
-                const tbody = document.querySelector('#results tbody');
-                tbody.innerHTML = '';
+                const gridContainer = '#results-grid';
+                const gridEl = document.querySelector(gridContainer);
+                gridEl.innerHTML = '';
                 if (data.results && data.results.length) {
-                    data.results.forEach(tx => {
-                        const tr = document.createElement('tr');
-                        tr.innerHTML = `<td>${tx.date}</td><td>${tx.description}</td><td>${tx.amount}</td>`;
-                        tbody.appendChild(tr);
+                    const dataTable = new Highcharts.DataTable({
+                        columns: {
+                            date: data.results.map(tx => tx.date),
+                            description: data.results.map(tx => tx.description),
+                            amount: data.results.map(tx => tx.amount)
+                        }
+                    });
+                    Highcharts.DataGrid(gridContainer, {
+                        dataTable,
+                        columns: {
+                            date: { title: 'Date' },
+                            description: { title: 'Description' },
+                            amount: { title: 'Amount' }
+                        }
                     });
                 } else {
-                    tbody.innerHTML = '<tr><td colspan="3">No transactions found.</td></tr>';
+                    gridEl.innerHTML = 'No transactions found.';
                 }
                 document.getElementById('total').textContent = 'Total: ' + data.total;
             });


### PR DESCRIPTION
## Summary
- replace legacy tables with Highcharts DataGrid across logs, reports, searches, and monthly statements
- integrate Highcharts DataTable/DataGrid modules for consistent table rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dd0d61c4c832eb243bb1cb41fca6e