### PR TITLE
Enable editing tags

### DIFF
--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -29,7 +29,25 @@ async function loadTags(){
     list.innerHTML = '';
     tags.forEach(t => {
         const li = document.createElement('li');
-        li.textContent = `${t.name} (${t.keyword||''})`;
+        const span = document.createElement('span');
+        span.textContent = `${t.name} (${t.keyword||''})`;
+        const btn = document.createElement('button');
+        btn.textContent = 'Edit';
+        btn.addEventListener('click', async () => {
+            const name = prompt('Tag Name', t.name);
+            if (name === null) return;
+            const keyword = prompt('Keyword (for auto tagging)', t.keyword || '');
+            if (keyword === null) return;
+            await fetch('../php_backend/public/tags.php', {
+                method: 'PUT',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({id: t.id, name, keyword})
+            });
+            loadTags();
+            showMessage('Tag updated');
+        });
+        li.appendChild(span);
+        li.appendChild(btn);
         list.appendChild(li);
     });
 }

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -15,6 +15,12 @@ class Tag {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public static function update(int $id, string $name, ?string $keyword = null): bool {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE `tags` SET `name` = :name, `keyword` = :keyword WHERE `id` = :id');
+        return $stmt->execute(['name' => $name, 'keyword' => $keyword, 'id' => $id]);
+    }
+
     public static function findMatch(string $text): ?int {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT `id`, `keyword` FROM `tags` WHERE `keyword` IS NOT NULL AND `keyword` != ""');

--- a/php_backend/public/tags.php
+++ b/php_backend/public/tags.php
@@ -30,6 +30,25 @@ if ($method === 'POST') {
         Log::write('Tag error: ' . $e->getMessage(), 'ERROR');
         echo json_encode([]);
     }
+} elseif ($method === 'PUT') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $id = $data['id'] ?? null;
+    $name = $data['name'] ?? null;
+    $keyword = $data['keyword'] ?? null;
+    if (!$id || !$name) {
+        http_response_code(400);
+        echo json_encode(['error' => 'ID and name required']);
+        exit;
+    }
+    try {
+        Tag::update((int)$id, $name, $keyword);
+        Log::write("Updated tag $id");
+        echo json_encode(['status' => 'ok']);
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Tag error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode(['error' => 'Server error']);
+    }
 } else {
     http_response_code(405);
 }


### PR DESCRIPTION
## Summary
- Allow updating existing tags via PUT endpoint in backend
- Add Tag model update method
- Provide frontend UI to edit tag name and keyword

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/public/tags.php`


------
https://chatgpt.com/codex/tasks/task_e_688dd3892eb4832e87eebc19c95bf566