### PR TITLE
Populate statement filters from existing data

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -12,23 +12,10 @@
         <main class="content">
             <h1>Monthly Statement</h1>
             <form id="statement-form">
-                <label for="month">Month:</label>
-                <select id="month" name="month">
-                    <option value="1">January</option>
-                    <option value="2">February</option>
-                    <option value="3">March</option>
-                    <option value="4">April</option>
-                    <option value="5">May</option>
-                    <option value="6">June</option>
-                    <option value="7">July</option>
-                    <option value="8">August</option>
-                    <option value="9">September</option>
-                    <option value="10">October</option>
-                    <option value="11">November</option>
-                    <option value="12">December</option>
-                </select>
                 <label for="year">Year:</label>
-                <input type="number" id="year" name="year" min="2000" value="2024">
+                <select id="year" name="year"></select>
+                <label for="month">Month:</label>
+                <select id="month" name="month"></select>
                 <button type="submit">View</button>
             </form>
             <div id="transactions-grid"></div>
@@ -39,11 +26,52 @@
     <script src="https://code.highcharts.com/modules/data.js"></script>
     <script src="https://code.highcharts.com/modules/datagrid.js"></script>
 <script>
+const monthSelect = document.getElementById('month');
+const yearSelect = document.getElementById('year');
+
+fetch('../php_backend/public/transaction_months.php')
+    .then(resp => resp.json())
+    .then(data => {
+        const monthsByYear = {};
+        data.forEach(row => {
+            const y = row.year;
+            const m = row.month;
+            if (!monthsByYear[y]) {
+                monthsByYear[y] = [];
+            }
+            monthsByYear[y].push(m);
+        });
+
+        const years = Object.keys(monthsByYear).sort((a, b) => b - a);
+        years.forEach(y => {
+            const opt = document.createElement('option');
+            opt.value = y;
+            opt.textContent = y;
+            yearSelect.appendChild(opt);
+            monthsByYear[y].sort((a, b) => b - a);
+        });
+
+        function populateMonths() {
+            const year = yearSelect.value;
+            monthSelect.innerHTML = '';
+            (monthsByYear[year] || []).forEach(m => {
+                const opt = document.createElement('option');
+                opt.value = m;
+                const d = new Date(year, m - 1);
+                opt.textContent = d.toLocaleString('default', { month: 'long' });
+                monthSelect.appendChild(opt);
+            });
+        }
+
+        yearSelect.addEventListener('change', populateMonths);
+        populateMonths();
+    });
+
 const form = document.getElementById('statement-form');
 form.addEventListener('submit', function(e) {
     e.preventDefault();
-    const month = document.getElementById('month').value;
-    const year = document.getElementById('year').value;
+    const month = monthSelect.value;
+    const year = yearSelect.value;
     fetch('../php_backend/public/transactions.php?month=' + month + '&year=' + year)
         .then(resp => resp.json())
         .then(data => {

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -63,6 +63,12 @@ class Transaction {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public static function getAvailableMonths(): array {
+        $db = Database::getConnection();
+        $stmt = $db->query('SELECT DISTINCT YEAR(`date`) AS year, MONTH(`date`) AS month FROM `transactions` ORDER BY YEAR(`date`) DESC, MONTH(`date`) DESC');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
     /**
      * Search transactions by a specific field.
      * Supports partial matches for text fields and exact matches for numeric fields.

--- a/php_backend/public/transaction_months.php
+++ b/php_backend/public/transaction_months.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+try {
+    $months = Transaction::getAvailableMonths();
+    echo json_encode($months);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- Limit available months and years on the monthly statement page to those with data.
- Provide API and model support to fetch available month/year combinations.

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/transaction_months.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688dd309b51c832e86c6552eb222d231