### PR TITLE
Display categories with their tags

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -37,12 +37,29 @@
                     <button type="submit">Assign</button>
                 </form>
             </section>
+            <section>
+                <h2>Existing Categories</h2>
+                <ul id="category-list"></ul>
+            </section>
         </main>
     </div>
 
     <script src="js/menu.js"></script>
     <script src="js/overlay.js"></script>
     <script>
+    async function loadCategories() {
+        const resp = await fetch('../php_backend/public/categories.php');
+        const cats = await resp.json();
+        const list = document.getElementById('category-list');
+        list.innerHTML = '';
+        cats.forEach(c => {
+            const li = document.createElement('li');
+            const tags = c.tags.map(t => t.name).join(', ');
+            li.textContent = `${c.name}${tags ? ': ' + tags : ''}`;
+            list.appendChild(li);
+        });
+    }
+
     document.querySelectorAll("form").forEach(f => {
         f.addEventListener("submit", async e => {
             e.preventDefault();
@@ -51,14 +68,20 @@
             const text = await resp.text();
             try {
                 const j = JSON.parse(text);
-                if (j.error) showMessage("Error: " + j.error);
-                else if (j.id) showMessage("Created ID " + j.id);
-                else showMessage("Success");
+                if (j.error) {
+                    showMessage("Error: " + j.error);
+                } else {
+                    if (j.id) showMessage("Created ID " + j.id);
+                    else showMessage("Success");
+                    loadCategories();
+                }
             } catch {
                 showMessage(text);
             }
         });
     });
+
+    loadCategories();
     </script>
 
 </body>

--- a/php_backend/models/Category.php
+++ b/php_backend/models/Category.php
@@ -14,5 +14,36 @@ class Category {
         $stmt = $db->prepare('UPDATE categories SET name = :name WHERE id = :id');
         $stmt->execute(['id' => $id, 'name' => $name]);
     }
+
+    public static function allWithTags(): array {
+        $db = Database::getConnection();
+        $sql = 'SELECT c.id AS category_id, c.name AS category_name, '
+             . 't.id AS tag_id, t.name AS tag_name '
+             . 'FROM categories c '
+             . 'LEFT JOIN category_tags ct ON c.id = ct.category_id '
+             . 'LEFT JOIN tags t ON t.id = ct.tag_id '
+             . 'ORDER BY c.id';
+        $stmt = $db->query($sql);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $categories = [];
+        foreach ($rows as $row) {
+            $id = (int)$row['category_id'];
+            if (!isset($categories[$id])) {
+                $categories[$id] = [
+                    'id' => $id,
+                    'name' => $row['category_name'],
+                    'tags' => []
+                ];
+            }
+            if ($row['tag_id'] !== null) {
+                $categories[$id]['tags'][] = [
+                    'id' => (int)$row['tag_id'],
+                    'name' => $row['tag_name']
+                ];
+            }
+        }
+        return array_values($categories);
+    }
 }
 ?>

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -4,6 +4,19 @@ require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    try {
+        echo json_encode(Category::allWithTags());
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Category error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode([]);
+    }
+    return;
+}
+
 $action = $_POST['action'] ?? null;
 
 try {


### PR DESCRIPTION
## Summary
- add `Category::allWithTags` to fetch categories and their associated tags
- allow `categories.php` GET requests to list categories with tags
- show existing categories and linked tags on categories management page

## Testing
- `php -l php_backend/models/Category.php`
- `php -l php_backend/public/categories.php`


------
https://chatgpt.com/codex/tasks/task_e_688dd3b7b214832e9430057e662bee97