### PR TITLE
Add current year dashboard with monthly spending chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Then open `http://localhost:8000/frontend/index.html` in your browser.
 
 A simple static frontend can be opened directly from `frontend/index.html`. It provides a navigation menu to upload OFX files or view monthly statements.
 
+The dashboard page (`frontend/dashboard.html`) shows current-year monthly spending totals with a simple chart.
+
 The monthly statement page (`frontend/monthly_statement.html`) allows selecting a month and year to list transactions for that period.
 
 ## Reports

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Current Dashboard</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar" id="menu"></nav>
+        <main class="content">
+            <h1>Current Dashboard</h1>
+            <div id="spend-summary"></div>
+            <div id="spend-chart" style="height:400px"></div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script>
+    fetch('../php_backend/public/dashboard.php')
+        .then(resp => resp.json())
+        .then(data => {
+            const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+            const chartData = months.map((m, idx) => {
+                const entry = data.find(d => d.month === idx + 1);
+                return entry ? parseFloat(entry.spent) : 0;
+            });
+
+            const summary = document.getElementById('spend-summary');
+            const list = document.createElement('ul');
+            chartData.forEach((val, idx) => {
+                const li = document.createElement('li');
+                li.textContent = months[idx] + ': $' + val.toFixed(2);
+                list.appendChild(li);
+            });
+            summary.appendChild(list);
+
+            Highcharts.chart('spend-chart', {
+                title: { text: 'Monthly Spend ' + new Date().getFullYear() },
+                xAxis: { categories: months },
+                yAxis: { title: { text: 'Amount' } },
+                series: [{ name: 'Spend', data: chartData }]
+            });
+        });
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -2,6 +2,7 @@
 <ul>
     <li><a href="index.html">Home</a></li>
     <li><a href="upload.html">Upload OFX File</a></li>
+    <li><a href="dashboard.html">Current Dashboard</a></li>
     <li><a href="monthly_statement.html">View Monthly Statement</a></li>
     <li><a href="report.html">Transaction Reports</a></li>
     <li><a href="search.html">Search Transactions</a></li>

--- a/php_backend/public/dashboard.php
+++ b/php_backend/public/dashboard.php
@@ -1,0 +1,14 @@
+<?php
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+$year = isset($_GET['year']) ? (int)$_GET['year'] : date('Y');
+
+try {
+    $data = Transaction::getMonthlySpending($year);
+    echo json_encode($data);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- introduce Transaction::getMonthlySpending and new dashboard API endpoint for yearly monthly totals
- add dashboard page with Highcharts visualization and summary list
- include Current Dashboard link and README note

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_688dd35eb2e4832eaa79502f1c588de1