### PR TITLE
Add basic transaction group management

### DIFF
--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Manage Groups</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar" id="menu"></nav>
+        <main class="content">
+            <h1>Manage Groups</h1>
+            <section>
+                <h2>Add Group</h2>
+                <form action="../php_backend/public/groups.php" method="post">
+                    <input type="hidden" name="action" value="create">
+                    <input type="text" name="name" placeholder="Group name">
+                    <button type="submit">Add</button>
+                </form>
+            </section>
+            <section>
+                <h2>Update Group</h2>
+                <form action="../php_backend/public/groups.php" method="post">
+                    <input type="hidden" name="action" value="update">
+                    <input type="number" name="id" placeholder="Group ID">
+                    <input type="text" name="name" placeholder="New name">
+                    <button type="submit">Update</button>
+                </form>
+            </section>
+        </main>
+    </div>
+
+    <script src="js/menu.js"></script>
+    <script src="js/overlay.js"></script>
+    <script>
+    document.querySelectorAll("form").forEach(f => {
+        f.addEventListener("submit", async e => {
+            e.preventDefault();
+            const data = new FormData(f);
+            const resp = await fetch(f.action, {method: f.method.toUpperCase(), body: data});
+            const text = await resp.text();
+            try {
+                const j = JSON.parse(text);
+                if (j.error) showMessage("Error: " + j.error);
+                else if (j.id) showMessage("Created ID " + j.id);
+                else showMessage("Success");
+            } catch {
+                showMessage(text);
+            }
+        });
+    });
+    </script>
+
+</body>
+</html>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -7,5 +7,6 @@
     <li><a href="search.html">Search Transactions</a></li>
     <li><a href="tags.html">Manage Tags</a></li>
     <li><a href="categories.html">Manage Categories</a></li>
+    <li><a href="groups.html">Manage Groups</a></li>
     <li><a href="logs.html">View Logs</a></li>
 </ul>

--- a/php_backend/models/TransactionGroup.php
+++ b/php_backend/models/TransactionGroup.php
@@ -8,5 +8,11 @@ class TransactionGroup {
         $stmt->execute(['name' => $name]);
         return (int)$db->lastInsertId();
     }
+
+    public static function update(int $id, string $name): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE transaction_groups SET name = :name WHERE id = :id');
+        $stmt->execute(['id' => $id, 'name' => $name]);
+    }
 }
 ?>

--- a/php_backend/public/groups.php
+++ b/php_backend/public/groups.php
@@ -1,0 +1,41 @@
+<?php
+require_once __DIR__ . '/../models/TransactionGroup.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+$action = $_POST['action'] ?? null;
+
+try {
+    switch ($action) {
+        case 'create':
+            $name = trim($_POST['name'] ?? '');
+            if ($name === '') {
+                http_response_code(400);
+                echo json_encode(['error' => 'Name required']);
+                return;
+            }
+            $id = TransactionGroup::create($name);
+            Log::write("Created group $name");
+            echo json_encode(['id' => $id]);
+            break;
+        case 'update':
+            $id = (int)($_POST['id'] ?? 0);
+            $name = trim($_POST['name'] ?? '');
+            if ($id <= 0 || $name === '') {
+                http_response_code(400);
+                echo json_encode(['error' => 'ID and name required']);
+                return;
+            }
+            TransactionGroup::update($id, $name);
+            Log::write("Updated group $id");
+            echo json_encode(['status' => 'ok']);
+            break;
+        default:
+            throw new Exception('Invalid action');
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Group error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>


### PR DESCRIPTION
## Summary
- allow transaction groups to be updated
- expose create/update group API
- add frontend page to manage transaction groups

## Testing
- `php -l php_backend/models/TransactionGroup.php`
- `php -l php_backend/public/groups.php`


------
https://chatgpt.com/codex/tasks/task_e_688dd3fca974832ebbcaef7407474ade