### PR TITLE
fix: handle JSON requests for categories and groups

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -63,8 +63,20 @@
     document.querySelectorAll("form").forEach(f => {
         f.addEventListener("submit", async e => {
             e.preventDefault();
-            const data = new FormData(f);
-            const resp = await fetch(f.action, {method: f.method.toUpperCase(), body: data});
+            const formData = new FormData(f);
+            const data = Object.fromEntries(formData.entries());
+            let method = f.method.toUpperCase();
+            if (data.action === 'update') {
+                method = 'PUT';
+                delete data.action;
+            } else if (data.action === 'create') {
+                delete data.action;
+            }
+            const resp = await fetch(f.action, {
+                method,
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(data)
+            });
             const text = await resp.text();
             try {
                 const j = JSON.parse(text);

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -37,8 +37,18 @@
     document.querySelectorAll("form").forEach(f => {
         f.addEventListener("submit", async e => {
             e.preventDefault();
-            const data = new FormData(f);
-            const resp = await fetch(f.action, {method: f.method.toUpperCase(), body: data});
+            const formData = new FormData(f);
+            const data = Object.fromEntries(formData.entries());
+            let method = f.method.toUpperCase();
+            if (data.action === 'update') {
+                method = 'PUT';
+            }
+            delete data.action;
+            const resp = await fetch(f.action, {
+                method,
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify(data)
+            });
             const text = await resp.text();
             try {
                 const j = JSON.parse(text);

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -17,53 +17,60 @@ if ($method === 'GET') {
     return;
 }
 
-$action = $_POST['action'] ?? null;
+$data = json_decode(file_get_contents('php://input'), true) ?? [];
+$action = $data['action'] ?? null;
 
 try {
-    switch ($action) {
-        case 'create':
-            $name = trim($_POST['name'] ?? '');
-            if ($name === '') {
+    if ($method === 'POST') {
+        switch ($action) {
+            case null:
+            case 'create':
+                $name = trim($data['name'] ?? '');
+                if ($name === '') {
+                    http_response_code(400);
+                    echo json_encode(['error' => 'Name required']);
+                    return;
+                }
+                $id = Category::create($name);
+                Log::write("Created category $name");
+                echo json_encode(['id' => $id]);
+                break;
+            case 'add_tag':
+                $categoryId = (int)($data['category_id'] ?? 0);
+                $tagId = (int)($data['tag_id'] ?? 0);
+                CategoryTag::add($categoryId, $tagId);
+                Log::write("Added tag $tagId to category $categoryId");
+                echo json_encode(['status' => 'ok']);
+                break;
+            case 'remove_tag':
+                $categoryId = (int)($data['category_id'] ?? 0);
+                $tagId = (int)($data['tag_id'] ?? 0);
+                CategoryTag::remove($categoryId, $tagId);
+                Log::write("Removed tag $tagId from category $categoryId");
+                echo json_encode(['status' => 'ok']);
+                break;
+            default:
                 http_response_code(400);
-                echo json_encode(['error' => 'Name required']);
-                return;
-            }
-            $id = Category::create($name);
-            Log::write("Created category $name");
-            echo json_encode(['id' => $id]);
-            break;
-        case 'update':
-            $id = (int)($_POST['id'] ?? 0);
-            $name = trim($_POST['name'] ?? '');
-            if ($id <= 0 || $name === '') {
-                http_response_code(400);
-                echo json_encode(['error' => 'ID and name required']);
-                return;
-            }
-            Category::update($id, $name);
-            Log::write("Updated category $id");
-            echo json_encode(['status' => 'ok']);
-            break;
-        case 'add_tag':
-            $categoryId = (int)($_POST['category_id'] ?? 0);
-            $tagId = (int)($_POST['tag_id'] ?? 0);
-            CategoryTag::add($categoryId, $tagId);
-            Log::write("Added tag $tagId to category $categoryId");
-            echo json_encode(['status' => 'ok']);
-            break;
-        case 'remove_tag':
-            $categoryId = (int)($_POST['category_id'] ?? 0);
-            $tagId = (int)($_POST['tag_id'] ?? 0);
-            CategoryTag::remove($categoryId, $tagId);
-            Log::write("Removed tag $tagId from category $categoryId");
-            echo json_encode(['status' => 'ok']);
-            break;
-        default:
-            throw new Exception('Invalid action');
+                echo json_encode(['error' => 'Invalid action']);
+        }
+    } elseif ($method === 'PUT') {
+        $id = (int)($data['id'] ?? 0);
+        $name = trim($data['name'] ?? '');
+        if ($id <= 0 || $name === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID and name required']);
+            return;
+        }
+        Category::update($id, $name);
+        Log::write("Updated category $id");
+        echo json_encode(['status' => 'ok']);
+    } else {
+        http_response_code(405);
     }
 } catch (Exception $e) {
     http_response_code(500);
     Log::write('Category error: ' . $e->getMessage(), 'ERROR');
     echo json_encode(['error' => 'Server error']);
 }
+
 ?>

--- a/php_backend/public/groups.php
+++ b/php_backend/public/groups.php
@@ -3,39 +3,39 @@ require_once __DIR__ . '/../models/TransactionGroup.php';
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
-$action = $_POST['action'] ?? null;
+
+$method = $_SERVER['REQUEST_METHOD'];
+$data = json_decode(file_get_contents('php://input'), true) ?? [];
 
 try {
-    switch ($action) {
-        case 'create':
-            $name = trim($_POST['name'] ?? '');
-            if ($name === '') {
-                http_response_code(400);
-                echo json_encode(['error' => 'Name required']);
-                return;
-            }
-            $id = TransactionGroup::create($name);
-            Log::write("Created group $name");
-            echo json_encode(['id' => $id]);
-            break;
-        case 'update':
-            $id = (int)($_POST['id'] ?? 0);
-            $name = trim($_POST['name'] ?? '');
-            if ($id <= 0 || $name === '') {
-                http_response_code(400);
-                echo json_encode(['error' => 'ID and name required']);
-                return;
-            }
-            TransactionGroup::update($id, $name);
-            Log::write("Updated group $id");
-            echo json_encode(['status' => 'ok']);
-            break;
-        default:
-            throw new Exception('Invalid action');
+    if ($method === 'POST') {
+        $name = trim($data['name'] ?? '');
+        if ($name === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'Name required']);
+            return;
+        }
+        $id = TransactionGroup::create($name);
+        Log::write("Created group $name");
+        echo json_encode(['id' => $id]);
+    } elseif ($method === 'PUT') {
+        $id = (int)($data['id'] ?? 0);
+        $name = trim($data['name'] ?? '');
+        if ($id <= 0 || $name === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID and name required']);
+            return;
+        }
+        TransactionGroup::update($id, $name);
+        Log::write("Updated group $id");
+        echo json_encode(['status' => 'ok']);
+    } else {
+        http_response_code(405);
     }
 } catch (Exception $e) {
     http_response_code(500);
     Log::write('Group error: ' . $e->getMessage(), 'ERROR');
     echo json_encode(['error' => 'Server error']);
 }
+
 ?>


### PR DESCRIPTION
## Summary
- handle JSON input and HTTP methods in category and group endpoints
- submit category and group forms via JSON like tags

## Testing
- `php -l php_backend/public/groups.php`
- `php -l php_backend/public/categories.php`


------
https://chatgpt.com/codex/tasks/task_e_688dd62571d0832eb7cb5d09c714b175