### PR TITLE
fix: handle JSON requests for categories and groups

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -11,78 +11,74 @@
         <nav class="sidebar" id="menu"></nav>
         <main class="content">
             <h1>Manage Categories</h1>
-            <section>
-                <h2>Add Category</h2>
-                <form action="../php_backend/public/categories.php" method="post">
-                    <input type="hidden" name="action" value="create">
-                    <input type="text" name="name" placeholder="Category name">
-                    <button type="submit">Add</button>
-                </form>
-            </section>
-            <section>
-                <h2>Update Category</h2>
-                <form action="../php_backend/public/categories.php" method="post">
-                    <input type="hidden" name="action" value="update">
-                    <input type="number" name="id" placeholder="Category ID">
-                    <input type="text" name="name" placeholder="New name">
-                    <button type="submit">Update</button>
-                </form>
-            </section>
-            <section>
-                <h2>Assign Tag to Category</h2>
-                <form action="../php_backend/public/categories.php" method="post">
-                    <input type="hidden" name="action" value="add_tag">
-                    <input type="number" name="category_id" placeholder="Category ID">
-                    <input type="number" name="tag_id" placeholder="Tag ID">
-                    <button type="submit">Assign</button>
-                </form>
-            </section>
-            <section>
-                <h2>Existing Categories</h2>
-                <ul id="category-list"></ul>
-            </section>
+            <form id="category-form">
+                <label>Category Name<br><input type="text" id="category-name"></label><br>
+                <button type="submit">Create Category</button>
+            </form>
+            <h2>Existing Categories</h2>
+            <ul id="category-list"></ul>
         </main>
     </div>
-
     <script src="js/menu.js"></script>
-    <script src="js/overlay.js"></script>
     <script>
-    async function loadCategories() {
-        const resp = await fetch('../php_backend/public/categories.php');
-        const cats = await resp.json();
-        const list = document.getElementById('category-list');
-        list.innerHTML = '';
-        cats.forEach(c => {
-            const li = document.createElement('li');
-            const tags = c.tags.map(t => t.name).join(', ');
-            li.textContent = `${c.name}${tags ? ': ' + tags : ''}`;
-            list.appendChild(li);
+async function loadCategories(){
+    const res = await fetch('../php_backend/public/categories.php');
+    const cats = await res.json();
+    const list = document.getElementById('category-list');
+    list.innerHTML = '';
+    cats.forEach(c => {
+        const li = document.createElement('li');
+        const span = document.createElement('span');
+        const tags = c.tags.map(t => t.name).join(', ');
+        span.textContent = `${c.name}${tags ? ': ' + tags : ''}`;
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.addEventListener('click', async () => {
+            const name = prompt('Category Name', c.name);
+            if (name === null) return;
+            await fetch('../php_backend/public/categories.php', {
+                method: 'PUT',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({id: c.id, name})
+            });
+            loadCategories();
+            showMessage('Category updated');
         });
-    }
-
-    document.querySelectorAll("form").forEach(f => {
-        f.addEventListener("submit", async e => {
-            e.preventDefault();
-            const data = new FormData(f);
-            const resp = await fetch(f.action, {method: f.method.toUpperCase(), body: data});
-            const text = await resp.text();
-            try {
-                const j = JSON.parse(text);
-                if (j.error) {
-                    showMessage("Error: " + j.error);
-                } else {
-                    if (j.id) showMessage("Created ID " + j.id);
-                    else showMessage("Success");
-                    loadCategories();
-                }
-            } catch {
-                showMessage(text);
-            }
+        const tagBtn = document.createElement('button');
+        tagBtn.textContent = 'Assign Tag';
+        tagBtn.addEventListener('click', async () => {
+            const tagId = prompt('Tag ID');
+            if (tagId === null) return;
+            await fetch('../php_backend/public/categories.php', {
+                method:'POST',
+                headers:{'Content-Type':'application/json'},
+                body: JSON.stringify({action:'add_tag', category_id: c.id, tag_id: tagId})
+            });
+            loadCategories();
+            showMessage('Tag assigned');
         });
+        li.appendChild(span);
+        li.appendChild(editBtn);
+        li.appendChild(tagBtn);
+        list.appendChild(li);
     });
+}
 
+document.getElementById('category-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const name = document.getElementById('category-name').value;
+    await fetch('../php_backend/public/categories.php', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({name})
+    });
+    document.getElementById('category-name').value='';
     loadCategories();
-    </script>
+    showMessage('Category created');
+});
 
+loadCategories();
+    </script>
+    <script src="js/overlay.js"></script>
 </body>
 </html>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -11,46 +11,59 @@
         <nav class="sidebar" id="menu"></nav>
         <main class="content">
             <h1>Manage Groups</h1>
-            <section>
-                <h2>Add Group</h2>
-                <form action="../php_backend/public/groups.php" method="post">
-                    <input type="hidden" name="action" value="create">
-                    <input type="text" name="name" placeholder="Group name">
-                    <button type="submit">Add</button>
-                </form>
-            </section>
-            <section>
-                <h2>Update Group</h2>
-                <form action="../php_backend/public/groups.php" method="post">
-                    <input type="hidden" name="action" value="update">
-                    <input type="number" name="id" placeholder="Group ID">
-                    <input type="text" name="name" placeholder="New name">
-                    <button type="submit">Update</button>
-                </form>
-            </section>
+            <form id="group-form">
+                <label>Group Name<br><input type="text" id="group-name"></label><br>
+                <button type="submit">Create Group</button>
+            </form>
+            <h2>Existing Groups</h2>
+            <ul id="group-list"></ul>
         </main>
     </div>
-
     <script src="js/menu.js"></script>
-    <script src="js/overlay.js"></script>
     <script>
-    document.querySelectorAll("form").forEach(f => {
-        f.addEventListener("submit", async e => {
-            e.preventDefault();
-            const data = new FormData(f);
-            const resp = await fetch(f.action, {method: f.method.toUpperCase(), body: data});
-            const text = await resp.text();
-            try {
-                const j = JSON.parse(text);
-                if (j.error) showMessage("Error: " + j.error);
-                else if (j.id) showMessage("Created ID " + j.id);
-                else showMessage("Success");
-            } catch {
-                showMessage(text);
-            }
+async function loadGroups(){
+    const res = await fetch('../php_backend/public/groups.php');
+    const groups = await res.json();
+    const list = document.getElementById('group-list');
+    list.innerHTML = '';
+    groups.forEach(g => {
+        const li = document.createElement('li');
+        const span = document.createElement('span');
+        span.textContent = g.name;
+        const btn = document.createElement('button');
+        btn.textContent = 'Edit';
+        btn.addEventListener('click', async () => {
+            const name = prompt('Group Name', g.name);
+            if (name === null) return;
+            await fetch('../php_backend/public/groups.php', {
+                method: 'PUT',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({id: g.id, name})
+            });
+            loadGroups();
+            showMessage('Group updated');
         });
+        li.appendChild(span);
+        li.appendChild(btn);
+        list.appendChild(li);
     });
-    </script>
+}
 
+document.getElementById('group-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const name = document.getElementById('group-name').value;
+    await fetch('../php_backend/public/groups.php', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body: JSON.stringify({name})
+    });
+    document.getElementById('group-name').value='';
+    loadGroups();
+    showMessage('Group created');
+});
+
+loadGroups();
+    </script>
+    <script src="js/overlay.js"></script>
 </body>
 </html>

--- a/php_backend/models/TransactionGroup.php
+++ b/php_backend/models/TransactionGroup.php
@@ -14,5 +14,11 @@ class TransactionGroup {
         $stmt = $db->prepare('UPDATE transaction_groups SET name = :name WHERE id = :id');
         $stmt->execute(['id' => $id, 'name' => $name]);
     }
+
+    public static function all(): array {
+        $db = Database::getConnection();
+        $stmt = $db->query('SELECT id, name FROM transaction_groups ORDER BY id');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }
 ?>

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -17,53 +17,60 @@ if ($method === 'GET') {
     return;
 }
 
-$action = $_POST['action'] ?? null;
+$data = json_decode(file_get_contents('php://input'), true) ?? [];
+$action = $data['action'] ?? null;
 
 try {
-    switch ($action) {
-        case 'create':
-            $name = trim($_POST['name'] ?? '');
-            if ($name === '') {
+    if ($method === 'POST') {
+        switch ($action) {
+            case null:
+            case 'create':
+                $name = trim($data['name'] ?? '');
+                if ($name === '') {
+                    http_response_code(400);
+                    echo json_encode(['error' => 'Name required']);
+                    return;
+                }
+                $id = Category::create($name);
+                Log::write("Created category $name");
+                echo json_encode(['id' => $id]);
+                break;
+            case 'add_tag':
+                $categoryId = (int)($data['category_id'] ?? 0);
+                $tagId = (int)($data['tag_id'] ?? 0);
+                CategoryTag::add($categoryId, $tagId);
+                Log::write("Added tag $tagId to category $categoryId");
+                echo json_encode(['status' => 'ok']);
+                break;
+            case 'remove_tag':
+                $categoryId = (int)($data['category_id'] ?? 0);
+                $tagId = (int)($data['tag_id'] ?? 0);
+                CategoryTag::remove($categoryId, $tagId);
+                Log::write("Removed tag $tagId from category $categoryId");
+                echo json_encode(['status' => 'ok']);
+                break;
+            default:
                 http_response_code(400);
-                echo json_encode(['error' => 'Name required']);
-                return;
-            }
-            $id = Category::create($name);
-            Log::write("Created category $name");
-            echo json_encode(['id' => $id]);
-            break;
-        case 'update':
-            $id = (int)($_POST['id'] ?? 0);
-            $name = trim($_POST['name'] ?? '');
-            if ($id <= 0 || $name === '') {
-                http_response_code(400);
-                echo json_encode(['error' => 'ID and name required']);
-                return;
-            }
-            Category::update($id, $name);
-            Log::write("Updated category $id");
-            echo json_encode(['status' => 'ok']);
-            break;
-        case 'add_tag':
-            $categoryId = (int)($_POST['category_id'] ?? 0);
-            $tagId = (int)($_POST['tag_id'] ?? 0);
-            CategoryTag::add($categoryId, $tagId);
-            Log::write("Added tag $tagId to category $categoryId");
-            echo json_encode(['status' => 'ok']);
-            break;
-        case 'remove_tag':
-            $categoryId = (int)($_POST['category_id'] ?? 0);
-            $tagId = (int)($_POST['tag_id'] ?? 0);
-            CategoryTag::remove($categoryId, $tagId);
-            Log::write("Removed tag $tagId from category $categoryId");
-            echo json_encode(['status' => 'ok']);
-            break;
-        default:
-            throw new Exception('Invalid action');
+                echo json_encode(['error' => 'Invalid action']);
+        }
+    } elseif ($method === 'PUT') {
+        $id = (int)($data['id'] ?? 0);
+        $name = trim($data['name'] ?? '');
+        if ($id <= 0 || $name === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID and name required']);
+            return;
+        }
+        Category::update($id, $name);
+        Log::write("Updated category $id");
+        echo json_encode(['status' => 'ok']);
+    } else {
+        http_response_code(405);
     }
 } catch (Exception $e) {
     http_response_code(500);
     Log::write('Category error: ' . $e->getMessage(), 'ERROR');
     echo json_encode(['error' => 'Server error']);
 }
+
 ?>

--- a/php_backend/public/groups.php
+++ b/php_backend/public/groups.php
@@ -3,39 +3,51 @@ require_once __DIR__ . '/../models/TransactionGroup.php';
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
-$action = $_POST['action'] ?? null;
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    try {
+        echo json_encode(TransactionGroup::all());
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Group error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode([]);
+    }
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true) ?? [];
 
 try {
-    switch ($action) {
-        case 'create':
-            $name = trim($_POST['name'] ?? '');
-            if ($name === '') {
-                http_response_code(400);
-                echo json_encode(['error' => 'Name required']);
-                return;
-            }
-            $id = TransactionGroup::create($name);
-            Log::write("Created group $name");
-            echo json_encode(['id' => $id]);
-            break;
-        case 'update':
-            $id = (int)($_POST['id'] ?? 0);
-            $name = trim($_POST['name'] ?? '');
-            if ($id <= 0 || $name === '') {
-                http_response_code(400);
-                echo json_encode(['error' => 'ID and name required']);
-                return;
-            }
-            TransactionGroup::update($id, $name);
-            Log::write("Updated group $id");
-            echo json_encode(['status' => 'ok']);
-            break;
-        default:
-            throw new Exception('Invalid action');
+    if ($method === 'POST') {
+        $name = trim($data['name'] ?? '');
+        if ($name === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'Name required']);
+            return;
+        }
+        $id = TransactionGroup::create($name);
+        Log::write("Created group $name");
+        echo json_encode(['id' => $id]);
+    } elseif ($method === 'PUT') {
+        $id = (int)($data['id'] ?? 0);
+        $name = trim($data['name'] ?? '');
+        if ($id <= 0 || $name === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID and name required']);
+            return;
+        }
+        TransactionGroup::update($id, $name);
+        Log::write("Updated group $id");
+        echo json_encode(['status' => 'ok']);
+    } else {
+        http_response_code(405);
     }
 } catch (Exception $e) {
     http_response_code(500);
     Log::write('Group error: ' . $e->getMessage(), 'ERROR');
     echo json_encode(['error' => 'Server error']);
 }
+
 ?>


### PR DESCRIPTION
## Summary
- handle JSON input and HTTP methods in category and group endpoints
- submit category and group forms via JSON like tags

## Testing
- `php -l php_backend/models/TransactionGroup.php`
- `php -l php_backend/public/groups.php`
- `php -l php_backend/public/categories.php`


------
https://chatgpt.com/codex/tasks/task_e_688dd62571d0832eb7cb5d09c714b175