### PR TITLE
Align and format financial numbers

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -71,3 +71,7 @@ th {
     max-width:80%;
     box-shadow:0 2px 6px rgba(0,0,0,0.3);
 }
+
+.currency {
+    text-align: right;
+}

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -29,6 +29,7 @@
 
             const summary = document.getElementById('spend-summary');
             const list = document.createElement('ul');
+            list.classList.add('currency');
             chartData.forEach((val, idx) => {
                 const li = document.createElement('li');
                 li.textContent = months[idx] + ': £' + val.toFixed(2);

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -29,6 +29,10 @@
 const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
 
+function formatCurrency(value) {
+    return '£' + parseFloat(value).toFixed(2);
+}
+
 fetch('../php_backend/public/transaction_months.php')
     .then(resp => resp.json())
     .then(data => {
@@ -79,7 +83,7 @@ form.addEventListener('submit', function(e) {
                 columns: {
                     date: data.map(tx => tx.date),
                     description: data.map(tx => tx.description),
-                    amount: data.map(tx => tx.amount)
+                    amount: data.map(tx => formatCurrency(tx.amount))
                 }
             });
             Highcharts.DataGrid('#transactions-grid', {
@@ -89,6 +93,10 @@ form.addEventListener('submit', function(e) {
                     description: { title: 'Description' },
                     amount: { title: 'Amount' }
                 }
+            });
+            document.querySelectorAll('#transactions-grid table tr').forEach(row => {
+                const cell = row.children[2];
+                if (cell) cell.classList.add('currency');
             });
         });
 });

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -24,8 +24,12 @@
     <script src="js/menu.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/modules/data.js"></script>
-    <script src="https://code.highcharts.com/modules/datagrid.js"></script>
+<script src="https://code.highcharts.com/modules/datagrid.js"></script>
     <script>
+    function formatCurrency(value) {
+        return '£' + parseFloat(value).toFixed(2);
+    }
+
     document.getElementById('report-form').addEventListener('submit', function(e) {
         e.preventDefault();
         const category = document.getElementById('category').value;
@@ -46,7 +50,7 @@
                     const dataTable = new Highcharts.DataTable({
                         columns: {
                             date: data.map(tx => tx.date),
-                            amount: data.map(tx => tx.amount),
+                            amount: data.map(tx => formatCurrency(tx.amount)),
                             description: data.map(tx => tx.description)
                         }
                     });
@@ -57,6 +61,10 @@
                             amount: { title: 'Amount' },
                             description: { title: 'Description' }
                         }
+                    });
+                    document.querySelectorAll('#results-grid table tr').forEach(row => {
+                        const cell = row.children[1];
+                        if (cell) cell.classList.add('currency');
                     });
                     const categories = data.map(tx => tx.date);
                     const amounts = data.map(tx => parseFloat(tx.amount));

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -34,8 +34,12 @@
     <script src="js/menu.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/modules/data.js"></script>
-    <script src="https://code.highcharts.com/modules/datagrid.js"></script>
+<script src="https://code.highcharts.com/modules/datagrid.js"></script>
     <script>
+    function formatCurrency(value) {
+        return '£' + parseFloat(value).toFixed(2);
+    }
+
     document.getElementById('search-form').addEventListener('submit', function(e){
         e.preventDefault();
         const field = document.getElementById('field').value;
@@ -52,7 +56,7 @@
                         columns: {
                             date: data.results.map(tx => tx.date),
                             description: data.results.map(tx => tx.description),
-                            amount: data.results.map(tx => tx.amount)
+                            amount: data.results.map(tx => formatCurrency(tx.amount))
                         }
                     });
                     Highcharts.DataGrid(gridContainer, {
@@ -63,10 +67,16 @@
                             amount: { title: 'Amount' }
                         }
                     });
+                    document.querySelectorAll('#results-grid table tr').forEach(row => {
+                        const cell = row.children[2];
+                        if (cell) cell.classList.add('currency');
+                    });
                 } else {
                     gridEl.innerHTML = 'No transactions found.';
                 }
-                document.getElementById('total').textContent = 'Total: ' + data.total;
+                const totalEl = document.getElementById('total');
+                totalEl.textContent = 'Total: ' + formatCurrency(data.total);
+                totalEl.classList.add('currency');
             });
     });
     </script>


### PR DESCRIPTION
## Summary
- Format monetary values to two decimals using a reusable `formatCurrency` helper.
- Align currency columns and totals to the right across dashboard and reporting pages.
- Introduce `.currency` CSS class to standardize right alignment of financial figures.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ddc85ad74832e89ba49c29e64cbeb