### PR TITLE
fix: record application errors in logs

### DIFF
--- a/php_backend/models/Log.php
+++ b/php_backend/models/Log.php
@@ -13,14 +13,23 @@ class Log {
         $db = Database::getConnection();
         $sql = 'SELECT level, message, created_at FROM logs ORDER BY created_at DESC';
         if ($limit !== null) {
-            $sql .= ' LIMIT :limit';
+            $sql .= ' LIMIT ' . (int)$limit;
         }
-        $stmt = $db->prepare($sql);
-        if ($limit !== null) {
-            $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
-        }
-        $stmt->execute();
+        $stmt = $db->query($sql);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
+
+    public static function registerHandlers(): void {
+        set_error_handler(function ($severity, $message, $file, $line): bool {
+            self::write("$message in $file on line $line", 'ERROR');
+            return false;
+        });
+
+        set_exception_handler(function (Throwable $e): void {
+            self::write($e->getMessage(), 'ERROR');
+        });
+    }
 }
+
+Log::registerHandlers();
 ?>

--- a/php_backend/public/dashboard.php
+++ b/php_backend/public/dashboard.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/index.php
+++ b/php_backend/public/index.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Account.php';
 
 $accountId = Account::create('Checking');

--- a/php_backend/public/report.php
+++ b/php_backend/public/report.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/search_transactions.php
+++ b/php_backend/public/search_transactions.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/transaction_months.php
+++ b/php_backend/public/transaction_months.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/transactions.php
+++ b/php_backend/public/transactions.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 
 header('Content-Type: application/json');


### PR DESCRIPTION
## Summary
- register PHP error and exception handlers so runtime issues are saved to `logs`
- ensure all public endpoints include the logging layer
- simplify log retrieval query to avoid parameter binding issues

## Testing
- `php -l php_backend/models/Log.php`
- `php -l php_backend/public/dashboard.php`
- `php -l php_backend/public/index.php`
- `php -l php_backend/public/report.php`
- `php -l php_backend/public/search_transactions.php`
- `php -l php_backend/public/transaction_months.php`
- `php -l php_backend/public/transactions.php`


------
https://chatgpt.com/codex/tasks/task_e_688ddcbd5f5c832eaf47ffb98305df3f