### PR TITLE
Drop tables before recreation

### DIFF
--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -3,7 +3,21 @@ require_once __DIR__ . '/Database.php';
 
 $db = Database::getConnection();
 
-$sql = <<<SQL
+// Drop existing tables to ensure a clean state
+$db->exec("SET FOREIGN_KEY_CHECKS=0");
+$dropSql = <<<SQL
+DROP TABLE IF EXISTS logs;
+DROP TABLE IF EXISTS transactions;
+DROP TABLE IF EXISTS transaction_groups;
+DROP TABLE IF EXISTS category_tags;
+DROP TABLE IF EXISTS tags;
+DROP TABLE IF EXISTS categories;
+DROP TABLE IF EXISTS accounts;
+SQL;
+$db->exec($dropSql);
+$db->exec("SET FOREIGN_KEY_CHECKS=1");
+
+$createSql = <<<SQL
 CREATE TABLE IF NOT EXISTS accounts (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL
@@ -57,7 +71,7 @@ CREATE TABLE IF NOT EXISTS logs (
 );
 SQL;
 
-$db->exec($sql);
+$db->exec($createSql);
 
 // Ensure keyword column exists if the tags table pre-dates it
 $result = $db->query("SHOW COLUMNS FROM `tags` LIKE 'keyword'");


### PR DESCRIPTION
## Summary
- Drop existing tables before recreation to ensure clean state

## Testing
- `php -l php_backend/create_tables.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688dde77d6dc832e96224c1b4a5d99af