### PR TITLE
Expose running version on homepage

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,10 +12,12 @@
         <main class="content">
             <h1>Welcome to Finance Manager</h1>
             <p>Select an option from the menu to get started.</p>
+            <p id="version">Version: loading...</p>
         </main>
     </div>
 
     <script src="js/menu.js"></script>
+    <script src="js/version.js"></script>
 
     <script src="js/overlay.js"></script>
 </body>

--- a/frontend/js/version.js
+++ b/frontend/js/version.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const target = document.getElementById('version');
+  if (!target) return;
+  fetch('../php_backend/public/version.php')
+    .then((response) => response.json())
+    .then((data) => {
+      if (data.version) {
+        target.textContent = `Version: ${data.version}`;
+      }
+    })
+    .catch(() => {
+      target.textContent = 'Version: unknown';
+    });
+});

--- a/php_backend/public/version.php
+++ b/php_backend/public/version.php
@@ -1,0 +1,6 @@
+<?php
+header('Content-Type: application/json');
+$rootDir = dirname(__DIR__, 2);
+$commitHash = trim(shell_exec('git -C ' . escapeshellarg($rootDir) . ' rev-parse --short HEAD'));
+echo json_encode(['version' => $commitHash]);
+


### PR DESCRIPTION
## Summary
- show current git commit on the landing page
- add JS helper to retrieve version info
- add PHP endpoint returning repository commit hash

## Testing
- `node --check frontend/js/version.js`
- `php -l php_backend/public/version.php`
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ddeabc508832e86b12f3554de524a