### PR TITLE
Add tag deletion capability

### DIFF
--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -46,8 +46,21 @@ async function loadTags(){
             loadTags();
             showMessage('Tag updated');
         });
+        const del = document.createElement('button');
+        del.textContent = 'Delete';
+        del.addEventListener('click', async () => {
+            if (!confirm('Delete this tag?')) return;
+            await fetch('../php_backend/public/tags.php', {
+                method: 'DELETE',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({id: t.id})
+            });
+            loadTags();
+            showMessage('Tag deleted');
+        });
         li.appendChild(span);
         li.appendChild(btn);
+        li.appendChild(del);
         list.appendChild(li);
     });
 }

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -21,6 +21,21 @@ class Tag {
         return $stmt->execute(['name' => $name, 'keyword' => $keyword, 'id' => $id]);
     }
 
+    public static function delete(int $id): bool {
+        $db = Database::getConnection();
+        // remove any relationships to categories
+        $stmt = $db->prepare('DELETE FROM `category_tags` WHERE `tag_id` = :id');
+        $stmt->execute(['id' => $id]);
+
+        // clear references from transactions
+        $stmt = $db->prepare('UPDATE `transactions` SET `tag_id` = NULL WHERE `tag_id` = :id');
+        $stmt->execute(['id' => $id]);
+
+        // delete the tag itself
+        $stmt = $db->prepare('DELETE FROM `tags` WHERE `id` = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+
     public static function findMatch(string $text): ?int {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT `id`, `keyword` FROM `tags` WHERE `keyword` IS NOT NULL AND `keyword` != ""');

--- a/php_backend/public/tags.php
+++ b/php_backend/public/tags.php
@@ -49,6 +49,23 @@ if ($method === 'POST') {
         Log::write('Tag error: ' . $e->getMessage(), 'ERROR');
         echo json_encode(['error' => 'Server error']);
     }
+} elseif ($method === 'DELETE') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $id = $data['id'] ?? null;
+    if (!$id) {
+        http_response_code(400);
+        echo json_encode(['error' => 'ID required']);
+        exit;
+    }
+    try {
+        Tag::delete((int)$id);
+        Log::write("Deleted tag $id");
+        echo json_encode(['status' => 'ok']);
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Tag error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode(['error' => 'Server error']);
+    }
 } else {
     http_response_code(405);
 }


### PR DESCRIPTION
## Summary
- allow removing tags via backend DELETE endpoint and new `Tag::delete` model
- add delete button in frontend tag management for convenient removal

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/public/tags.php`


------
https://chatgpt.com/codex/tasks/task_e_688ddf115894832ea2a94479bb369b9d