### PR TITLE
Fix Highcharts grids not showing

### DIFF
--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Application Logs</title>
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://code.highcharts.com/css/datagrid.css">
 </head>
 <body>
     <div class="container">
@@ -30,7 +31,7 @@
                     message: data.map(log => log.message)
                 }
             });
-            Highcharts.DataGrid('#logs-grid', {
+            Highcharts.DataGrid('logs-grid', {
                 dataTable,
                 columns: {
                     time: { title: 'Time' },

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Monthly Statement</title>
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://code.highcharts.com/css/datagrid.css">
 </head>
 <body>
     <div class="container">
@@ -86,7 +87,7 @@ form.addEventListener('submit', function(e) {
                     amount: data.map(tx => formatCurrency(tx.amount))
                 }
             });
-            Highcharts.DataGrid('#transactions-grid', {
+            Highcharts.DataGrid('transactions-grid', {
                 dataTable,
                 columns: {
                     date: { title: 'Date' },

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Transaction Reports</title>
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://code.highcharts.com/css/datagrid.css">
 </head>
 <body>
     <div class="container">
@@ -42,9 +43,9 @@
         fetch('../php_backend/public/report.php?' + params.toString())
             .then(resp => resp.json())
             .then(data => {
-                const gridContainer = '#results-grid';
+                const gridEl = document.getElementById('results-grid');
                 const chartContainer = document.getElementById('chart');
-                document.querySelector(gridContainer).innerHTML = '';
+                gridEl.innerHTML = '';
                 chartContainer.innerHTML = '';
                 if (Array.isArray(data) && data.length) {
                     const dataTable = new Highcharts.DataTable({
@@ -54,7 +55,7 @@
                             description: data.map(tx => tx.description)
                         }
                     });
-                    Highcharts.DataGrid(gridContainer, {
+                    Highcharts.DataGrid(gridEl, {
                         dataTable,
                         columns: {
                             date: { title: 'Date' },
@@ -76,7 +77,7 @@
                         series: [{ name: 'Amount', data: amounts }]
                     });
                 } else {
-                    document.querySelector(gridContainer).innerHTML = 'No transactions found.';
+                    gridEl.innerHTML = 'No transactions found.';
                 }
             });
     });

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Search Transactions</title>
     <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://code.highcharts.com/css/datagrid.css">
 </head>
 <body>
     <div class="container">
@@ -48,8 +49,7 @@
         fetch('../php_backend/public/search_transactions.php?' + params.toString())
             .then(resp => resp.json())
             .then(data => {
-                const gridContainer = '#results-grid';
-                const gridEl = document.querySelector(gridContainer);
+                const gridEl = document.getElementById('results-grid');
                 gridEl.innerHTML = '';
                 if (data.results && data.results.length) {
                     const dataTable = new Highcharts.DataTable({
@@ -59,7 +59,7 @@
                             amount: data.results.map(tx => formatCurrency(tx.amount))
                         }
                     });
-                    Highcharts.DataGrid(gridContainer, {
+                    Highcharts.DataGrid(gridEl, {
                         dataTable,
                         columns: {
                             date: { title: 'Date' },


### PR DESCRIPTION
## Summary
- Link Highcharts DataGrid stylesheet and use element IDs for grids so logs, monthly statements, search, and reports render tables correctly.

## Testing
- `php -S localhost:8000` and `curl http://localhost:8000/frontend/logs.html | head -n 20`
- `curl http://localhost:8000/frontend/monthly_statement.html | head -n 20`
- `curl http://localhost:8000/frontend/search.html | head -n 20`
- `curl http://localhost:8000/frontend/report.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_688dfcbb0624832e9123812c290f467d