### PR TITLE
Tag OFX transactions by keywords after upload

### DIFF
--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/../models/Account.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
+require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../Database.php';
 
 try {
@@ -61,8 +62,10 @@ foreach ($matches[1] as $block) {
     $inserted++;
 }
 
-    echo "Inserted $inserted transactions for account $accountName.";
-    Log::write("Inserted $inserted transactions for account $accountName");
+$tagged = Tag::applyToAccountTransactions($accountId);
+
+    echo "Inserted $inserted transactions for account $accountName. Tagged $tagged transactions.";
+    Log::write("Inserted $inserted transactions for account $accountName; tagged $tagged transactions");
 } catch (Exception $e) {
     http_response_code(500);
     $msg = 'Error: ' . $e->getMessage();


### PR DESCRIPTION
## Summary
- add helper to apply tag keywords to untagged account transactions
- extend OFX upload script to apply tags post-import and log tagged count

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/public/upload_ofx.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688dfdb5378c832eb7491d7bcde216d4