### PR TITLE
Categorise transactions based on tags after OFX upload

### DIFF
--- a/php_backend/models/CategoryTag.php
+++ b/php_backend/models/CategoryTag.php
@@ -13,5 +13,23 @@ class CategoryTag {
         $stmt = $db->prepare('DELETE FROM category_tags WHERE category_id = :category_id AND tag_id = :tag_id');
         $stmt->execute(['category_id' => $categoryId, 'tag_id' => $tagId]);
     }
+
+    /**
+     * Apply category IDs to transactions for a specific account based on their tag.
+     * Only transactions that are tagged and currently uncategorised will be updated.
+     * Returns the number of transactions that were categorised.
+     */
+    public static function applyToAccountTransactions(int $accountId): int {
+        $db = Database::getConnection();
+        $sql = 'UPDATE transactions t '
+             . 'JOIN category_tags ct ON t.tag_id = ct.tag_id '
+             . 'SET t.category_id = ct.category_id '
+             . 'WHERE t.account_id = :acc '
+             . 'AND t.tag_id IS NOT NULL '
+             . 'AND t.category_id IS NULL';
+        $stmt = $db->prepare($sql);
+        $stmt->execute(['acc' => $accountId]);
+        return $stmt->rowCount();
+    }
 }
 ?>

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/../models/Account.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../Database.php';
 
 try {
@@ -63,9 +64,10 @@ foreach ($matches[1] as $block) {
 }
 
 $tagged = Tag::applyToAccountTransactions($accountId);
+$categorised = CategoryTag::applyToAccountTransactions($accountId);
 
-    echo "Inserted $inserted transactions for account $accountName. Tagged $tagged transactions.";
-    Log::write("Inserted $inserted transactions for account $accountName; tagged $tagged transactions");
+    echo "Inserted $inserted transactions for account $accountName. Tagged $tagged transactions. Categorised $categorised transactions.";
+    Log::write("Inserted $inserted transactions for account $accountName; tagged $tagged transactions; categorised $categorised transactions");
 } catch (Exception $e) {
     http_response_code(500);
     $msg = 'Error: ' . $e->getMessage();


### PR DESCRIPTION
## Summary
- Categorise tagged transactions by linking category-tag mappings during OFX upload
- Log how many transactions were categorised alongside tagging information

## Testing
- `php -l php_backend/models/CategoryTag.php`
- `php -l php_backend/public/upload_ofx.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_688e01c2876c832e8fe00ad1aaf5c69d