### PR TITLE
Display tag names instead of IDs

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -47,7 +47,10 @@ async function loadCategories() {
         const tagBtn = document.createElement('button');
         tagBtn.textContent = 'Assign Tag';
         tagBtn.addEventListener('click', async () => {
-            const tagId = prompt('Tag ID');
+            const resTags = await fetch('../php_backend/public/tags.php');
+            const allTags = await resTags.json();
+            const tagOptions = allTags.map(t => `${t.id}: ${t.name}`).join('\n');
+            const tagId = prompt('Select Tag:\n' + tagOptions);
             if (tagId === null) return;
             await fetch('../php_backend/public/categories.php', {
                 method: 'POST',

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -13,8 +13,8 @@
         <main class="content">
             <h1>Transaction Reports</h1>
             <form id="report-form">
-                <label>Category ID: <input type="number" id="category"></label>
-                <label>Tag ID: <input type="number" id="tag"></label>
+                <label>Category: <select id="category"></select></label>
+                <label>Tag: <select id="tag"></select></label>
                 <label>Group ID: <input type="number" id="group"></label>
                 <button type="submit">Run Report</button>
             </form>
@@ -30,6 +30,33 @@
     function formatCurrency(value) {
         return '£' + parseFloat(value).toFixed(2);
     }
+
+    async function loadOptions() {
+        const [catRes, tagRes] = await Promise.all([
+            fetch('../php_backend/public/categories.php'),
+            fetch('../php_backend/public/tags.php')
+        ]);
+        const categories = await catRes.json();
+        const tags = await tagRes.json();
+        const catSelect = document.getElementById('category');
+        const tagSelect = document.getElementById('tag');
+        catSelect.innerHTML = '<option value="">All</option>';
+        categories.forEach(c => {
+            const opt = document.createElement('option');
+            opt.value = c.id;
+            opt.textContent = c.name;
+            catSelect.appendChild(opt);
+        });
+        tagSelect.innerHTML = '<option value="">All</option>';
+        tags.forEach(t => {
+            const opt = document.createElement('option');
+            opt.value = t.id;
+            opt.textContent = t.name;
+            tagSelect.appendChild(opt);
+        });
+    }
+
+    loadOptions();
 
     document.getElementById('report-form').addEventListener('submit', function(e) {
         e.preventDefault();


### PR DESCRIPTION
## Summary
- List tag names when assigning tags to categories
- Populate report filters with category and tag names rather than numeric IDs

## Testing
- `node -e "const fs=require('fs');const html=fs.readFileSync('frontend/categories.html','utf8');const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)];const script=scripts[scripts.length-1][1];new Function(script);console.log('ok')"`
- `node -e "const fs=require('fs');const html=fs.readFileSync('frontend/report.html','utf8');const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)];const script=scripts[scripts.length-1][1];new Function(script);console.log('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_688e2edb9f50832ebf8c62faea07edf3