### PR TITLE
Replace Highcharts data grids with Tabulator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## Code Style
 - No formal coding standard is enforced; keep code clear and consistent with existing files.
-- Use Highcharts for graphs and tables.
+- Use Highcharts for graphs and Tabulator for tables.
 - Display monetary values with the pound symbol (£).
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository now provides a simple PHP implementation for managing accounts a
 
 ## Specifications
 
-- Highcharts should be used for rendering both graphs and tables.
+- Highcharts is used for graphs, while Tabulator renders interactive tables.
 - Display all monetary values using the pound symbol (£) instead of the dollar sign ($).
 
 ## PHP Development Setup

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Application Logs</title>
     <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="https://code.highcharts.com/css/datagrid.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
 </head>
 <body>
     <div class="container">
@@ -18,29 +18,19 @@
     </div>
 
     <script src="js/menu.js"></script>
-    <script src="https://code.highcharts.com/highcharts.js"></script>
-    <script src="https://code.highcharts.com/modules/data.js"></script>
-    <script src="https://code.highcharts.com/modules/data-grid.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script>
     fetch('../php_backend/public/logs.php')
         .then(resp => resp.json())
         .then(data => {
-            const dataTable = new DataGrid.DataTable({
-                columns: {
-                    time: data.map(log => log.created_at),
-                    level: data.map(log => log.level),
-                    message: data.map(log => log.message)
-                }
-            });
-
-            new DataGrid.DataGrid(document.getElementById('logs-grid'), {
-
-                dataTable,
-                columns: {
-                    time: { title: 'Time' },
-                    level: { title: 'Level' },
-                    message: { title: 'Message' }
-                }
+            new Tabulator('#logs-grid', {
+                data: data,
+                layout: 'fitColumns',
+                columns: [
+                    { title: 'Time', field: 'created_at' },
+                    { title: 'Level', field: 'level' },
+                    { title: 'Message', field: 'message' }
+                ]
             });
         });
     </script>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Monthly Statement</title>
     <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="https://code.highcharts.com/css/datagrid.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
 </head>
 <body>
     <div class="container">
@@ -24,16 +24,10 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
-    <script src="https://code.highcharts.com/highcharts.js"></script>
-    <script src="https://code.highcharts.com/modules/data.js"></script>
-    <script src="https://code.highcharts.com/modules/data-grid.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
 <script>
 const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
-
-function formatCurrency(value) {
-    return '£' + parseFloat(value).toFixed(2);
-}
 
 fetch('../php_backend/public/transaction_months.php')
     .then(resp => resp.json())
@@ -81,26 +75,14 @@ form.addEventListener('submit', function(e) {
     fetch('../php_backend/public/transactions.php?month=' + month + '&year=' + year)
         .then(resp => resp.json())
         .then(data => {
-            const dataTable = new DataGrid.DataTable({
-                columns: {
-                    date: data.map(tx => tx.date),
-                    description: data.map(tx => tx.description),
-                    amount: data.map(tx => formatCurrency(tx.amount))
-                }
-            });
-
-            new DataGrid.DataGrid(document.getElementById('transactions-grid'), {
-
-                dataTable,
-                columns: {
-                    date: { title: 'Date' },
-                    description: { title: 'Description' },
-                    amount: { title: 'Amount' }
-                }
-            });
-            document.querySelectorAll('#transactions-grid table tr').forEach(row => {
-                const cell = row.children[2];
-                if (cell) cell.classList.add('currency');
+            new Tabulator('#transactions-grid', {
+                data: data,
+                layout: 'fitColumns',
+                columns: [
+                    { title: 'Date', field: 'date' },
+                    { title: 'Description', field: 'description' },
+                    { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+                ]
             });
         });
 });

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Transaction Reports</title>
     <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="https://code.highcharts.com/css/datagrid.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
 </head>
 <body>
     <div class="container">
@@ -25,12 +25,8 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
-    <script src="https://code.highcharts.com/modules/data.js"></script>
-    <script src="https://code.highcharts.com/modules/data-grid.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script>
-    function formatCurrency(value) {
-        return '£' + parseFloat(value).toFixed(2);
-    }
 
     async function loadOptions() {
         const [catRes, tagRes] = await Promise.all([
@@ -76,26 +72,14 @@
                 gridEl.innerHTML = '';
                 chartContainer.innerHTML = '';
                 if (Array.isArray(data) && data.length) {
-                    const dataTable = new DataGrid.DataTable({
-                        columns: {
-                            date: data.map(tx => tx.date),
-                            amount: data.map(tx => formatCurrency(tx.amount)),
-                            description: data.map(tx => tx.description)
-                        }
-                    });
-
-                    new DataGrid.DataGrid(gridEl, {
-
-                        dataTable,
-                        columns: {
-                            date: { title: 'Date' },
-                            amount: { title: 'Amount' },
-                            description: { title: 'Description' }
-                        }
-                    });
-                    document.querySelectorAll('#results-grid table tr').forEach(row => {
-                        const cell = row.children[1];
-                        if (cell) cell.classList.add('currency');
+                    new Tabulator(gridEl, {
+                        data: data,
+                        layout: 'fitColumns',
+                        columns: [
+                            { title: 'Date', field: 'date' },
+                            { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
+                            { title: 'Description', field: 'description' }
+                        ]
                     });
                     const categories = data.map(tx => tx.date);
                     const amounts = data.map(tx => parseFloat(tx.amount));

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Search Transactions</title>
     <link rel="stylesheet" href="css/style.css">
-    <link rel="stylesheet" href="https://code.highcharts.com/css/datagrid.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
 </head>
 <body>
     <div class="container">
@@ -34,9 +34,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
-    <script src="https://code.highcharts.com/highcharts.js"></script>
-    <script src="https://code.highcharts.com/modules/data.js"></script>
-    <script src="https://code.highcharts.com/modules/data-grid.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script>
     function formatCurrency(value) {
         return '£' + parseFloat(value).toFixed(2);
@@ -53,26 +51,14 @@
                 const gridEl = document.getElementById('results-grid');
                 gridEl.innerHTML = '';
                 if (data.results && data.results.length) {
-                    const dataTable = new DataGrid.DataTable({
-                        columns: {
-                            date: data.results.map(tx => tx.date),
-                            description: data.results.map(tx => tx.description),
-                            amount: data.results.map(tx => formatCurrency(tx.amount))
-                        }
-                    });
-
-                    new DataGrid.DataGrid(gridEl, {
-
-                        dataTable,
-                        columns: {
-                            date: { title: 'Date' },
-                            description: { title: 'Description' },
-                            amount: { title: 'Amount' }
-                        }
-                    });
-                    document.querySelectorAll('#results-grid table tr').forEach(row => {
-                        const cell = row.children[2];
-                        if (cell) cell.classList.add('currency');
+                    new Tabulator(gridEl, {
+                        data: data.results,
+                        layout: 'fitColumns',
+                        columns: [
+                            { title: 'Date', field: 'date' },
+                            { title: 'Description', field: 'description' },
+                            { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+                        ]
                     });
                 } else {
                     gridEl.innerHTML = 'No transactions found.';


### PR DESCRIPTION
## Summary
- replace Highcharts DataGrid components with Tabulator tables on monthly statement, search, log, and report pages
- document new table library usage in AGENTS and README instructions

## Testing
- `php -S localhost:8000 >/tmp/server.log & PID=$!` *(lsof: command not found)* `kill $PID`


------
https://chatgpt.com/codex/tasks/task_e_6890cb55c370832e90c0a64fb93249ae