### PR TITLE
Capture memo field from OFX imports

### DIFF
--- a/frontend/search.html
+++ b/frontend/search.html
@@ -17,6 +17,7 @@
                 <label>Field:
                     <select id="field">
                         <option value="description">Description</option>
+                        <option value="memo">Memo</option>
                         <option value="date">Date</option>
                         <option value="amount">Amount</option>
                         <option value="account_id">Account ID</option>
@@ -57,6 +58,7 @@
                         columns: [
                             { title: 'Date', field: 'date' },
                             { title: 'Description', field: 'description' },
+                            { title: 'Memo', field: 'memo' },
                             { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
                         ]
                     });

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -54,6 +54,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     date DATE NOT NULL,
     amount DECIMAL(10,2) NOT NULL,
     description VARCHAR(255) NOT NULL,
+    memo VARCHAR(255) DEFAULT NULL,
     category_id INT DEFAULT NULL,
     tag_id INT DEFAULT NULL,
     group_id INT DEFAULT NULL,

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -4,7 +4,7 @@ require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/Tag.php';
 
 class Transaction {
-    public static function create(int $account, string $date, float $amount, string $description, ?int $category = null, ?int $tag = null, ?int $group = null, ?string $ofx_id = null): int {
+    public static function create(int $account, string $date, float $amount, string $description, ?string $memo = null, ?int $category = null, ?int $tag = null, ?int $group = null, ?string $ofx_id = null): int {
         if ($tag === null) {
             $tag = Tag::findMatch($description);
         }
@@ -20,12 +20,13 @@ class Transaction {
             }
         }
 
-        $stmt = $db->prepare('INSERT INTO transactions (`account_id`, `date`, `amount`, `description`, `category_id`, `tag_id`, `group_id`, `ofx_id`) VALUES (:account, :date, :amount, :description, :category, :tag, :group, :ofx_id)');
+        $stmt = $db->prepare('INSERT INTO transactions (`account_id`, `date`, `amount`, `description`, `memo`, `category_id`, `tag_id`, `group_id`, `ofx_id`) VALUES (:account, :date, :amount, :description, :memo, :category, :tag, :group, :ofx_id)');
         $stmt->execute([
             'account' => $account,
             'date' => $date,
             'amount' => $amount,
             'description' => $description,
+            'memo' => $memo,
             'category' => $category,
             'tag' => $tag,
             'group' => $group,
@@ -107,7 +108,7 @@ class Transaction {
      * Supports partial matches for text fields and exact matches for numeric fields.
      */
     public static function search(string $field, string $value): array {
-        $allowed = ['id','account_id','date','amount','description','category_id','tag_id','group_id','ofx_id'];
+        $allowed = ['id','account_id','date','amount','description','memo','category_id','tag_id','group_id','ofx_id'];
         if (!in_array($field, $allowed, true)) {
             throw new Exception('Invalid search field');
         }

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -51,16 +51,21 @@ foreach ($matches[1] as $block) {
     }
     $amount = (float)trim($am[1]);
     $desc = '';
+    $memo = '';
     if (preg_match('/<NAME>([^\r\n<]+)/i', $block, $dm)) {
         $desc = trim($dm[1]);
-    } elseif (preg_match('/<MEMO>([^\r\n<]+)/i', $block, $dm)) {
-        $desc = trim($dm[1]);
+    }
+    if (preg_match('/<MEMO>([^\r\n<]+)/i', $block, $mm)) {
+        $memo = trim($mm[1]);
+        if ($desc === '') {
+            $desc = $memo;
+        }
     }
     $ofxId = null;
     if (preg_match('/<FITID>([^\r\n<]+)/i', $block, $om)) {
         $ofxId = trim($om[1]);
     }
-    Transaction::create($accountId, $date, $amount, $desc, null, null, null, $ofxId);
+    Transaction::create($accountId, $date, $amount, $desc, $memo, null, null, null, $ofxId);
     $inserted++;
 }
 


### PR DESCRIPTION
## Summary
- store memo text from OFX transactions in a new `memo` column
- allow searching memo field via API and UI
- display memo in search results

## Testing
- `php -l php_backend/create_tables.php`
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/upload_ofx.php`
- `php -l php_backend/public/search_transactions.php`


------
https://chatgpt.com/codex/tasks/task_e_6890ccee0264832ebbe6bf14966a2a57