### PR TITLE
Include tag, category, and group names in transaction listings

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -81,6 +81,9 @@ form.addEventListener('submit', function(e) {
                 columns: [
                     { title: 'Date', field: 'date' },
                     { title: 'Description', field: 'description' },
+                    { title: 'Category', field: 'category_name' },
+                    { title: 'Tag', field: 'tag_name' },
+                    { title: 'Group', field: 'group_name' },
                     { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
                 ]
             });

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -77,8 +77,11 @@
                         layout: 'fitColumns',
                         columns: [
                             { title: 'Date', field: 'date' },
-                            { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
-                            { title: 'Description', field: 'description' }
+                            { title: 'Description', field: 'description' },
+                            { title: 'Category', field: 'category_name' },
+                            { title: 'Tag', field: 'tag_name' },
+                            { title: 'Group', field: 'group_name' },
+                            { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
                         ]
                     });
                     const categories = data.map(tx => tx.date);

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -59,6 +59,9 @@
                             { title: 'Date', field: 'date' },
                             { title: 'Description', field: 'description' },
                             { title: 'Memo', field: 'memo' },
+                            { title: 'Category', field: 'category_name' },
+                            { title: 'Tag', field: 'tag_name' },
+                            { title: 'Group', field: 'group_name' },
                             { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
                         ]
                     });


### PR DESCRIPTION
## Summary
- Return category, tag, and group names with transaction queries
- Display descriptive names in search, monthly statement, and report tables

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/search_transactions.php`
- `php -l php_backend/public/transactions.php`
- `php -l php_backend/public/report.php`


------
https://chatgpt.com/codex/tasks/task_e_6890d043d7b4832e976830b917c1cbaf