### PR TITLE
Add monthly dashboard with summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ A simple static frontend can be opened directly from `frontend/index.html`. It p
 
 The yearly dashboard page (`frontend/yearly_dashboard.html`) lets you select a year and view total spending by tag, category, and group with tables and bar charts.
 
+The monthly dashboard page (`frontend/monthly_dashboard.html`) shows totals by tag, category, and group for a selected month along with overall income, outgoings, and delta.
+
 The monthly statement page (`frontend/monthly_statement.html`) allows selecting a month and year to list transactions for that period.
 
 ## Reports

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -76,3 +76,11 @@ th {
 .currency {
     text-align: right;
 }
+
+.positive {
+    color: green;
+}
+
+.negative {
+    color: red;
+}

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -4,6 +4,7 @@
     <li><a href="index.html">Home</a></li>
     <li><a href="upload.html">Upload OFX File</a></li>
     <li><a href="yearly_dashboard.html">Yearly Dashboard</a></li>
+    <li><a href="monthly_dashboard.html">Monthly Dashboard</a></li>
     <li><a href="monthly_statement.html">View Monthly Statement</a></li>
     <li><a href="report.html">Transaction Reports</a></li>
     <li><a href="search.html">Search Transactions</a></li>

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<!-- Dashboard showing monthly spending summaries -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Monthly Dashboard</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar" id="menu"></nav>
+        <main class="content">
+            <h1>Monthly Dashboard</h1>
+            <label for="year-select">Year:
+                <select id="year-select"></select>
+            </label>
+            <label for="month-select">Month:
+                <select id="month-select"></select>
+            </label>
+
+            <div id="totals">
+                <p>Income: <span id="income-total">£0.00</span></p>
+                <p>Outgoings: <span id="outgoings-total">£0.00</span></p>
+                <p>Delta: <span id="delta-total">£0.00</span></p>
+            </div>
+
+            <h2>Tag Totals</h2>
+            <div id="tags-table"></div>
+            <div id="tags-chart" style="height:400px"></div>
+
+            <h2>Category Totals</h2>
+            <div id="categories-table"></div>
+            <div id="categories-chart" style="height:400px"></div>
+
+            <h2>Group Totals</h2>
+            <div id="groups-table"></div>
+            <div id="groups-chart" style="height:400px"></div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script>
+    function buildTable(id, data){
+        const el = document.getElementById(id);
+        el.innerHTML = '';
+        new Tabulator(el, {
+            data: data,
+            layout: 'fitColumns',
+            columns: [
+                { title: 'Name', field: 'name' },
+                { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+            ]
+        });
+    }
+
+    function buildChart(id, title, data){
+        Highcharts.chart(id, {
+            chart: { type: 'column' },
+            title: { text: title },
+            xAxis: { categories: data.map(d => d.name) },
+            yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)) }]
+        });
+    }
+
+    function loadMonth(year, month){
+        fetch('../php_backend/public/monthly_dashboard.php?year=' + year + '&month=' + month)
+            .then(resp => resp.json())
+            .then(data => {
+                const totals = data.totals;
+                document.getElementById('income-total').textContent = '£' + parseFloat(totals.income).toFixed(2);
+                document.getElementById('outgoings-total').textContent = '£' + parseFloat(totals.outgoings).toFixed(2);
+                const deltaEl = document.getElementById('delta-total');
+                deltaEl.textContent = '£' + parseFloat(totals.delta).toFixed(2);
+                deltaEl.className = totals.delta >= 0 ? 'positive' : 'negative';
+
+                buildTable('tags-table', data.tags);
+                buildChart('tags-chart', 'Tag Totals', data.tags);
+                buildTable('categories-table', data.categories);
+                buildChart('categories-chart', 'Category Totals', data.categories);
+                buildTable('groups-table', data.groups);
+                buildChart('groups-chart', 'Group Totals', data.groups);
+            });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        fetch('../php_backend/public/transaction_months.php')
+            .then(resp => resp.json())
+            .then(months => {
+                const monthsByYear = {};
+                months.forEach(m => {
+                    if (!monthsByYear[m.year]) { monthsByYear[m.year] = []; }
+                    monthsByYear[m.year].push(m.month);
+                });
+
+                const yearSelect = document.getElementById('year-select');
+                Object.keys(monthsByYear).sort((a,b) => b - a).forEach(y => {
+                    const opt = document.createElement('option');
+                    opt.value = y;
+                    opt.textContent = y;
+                    yearSelect.appendChild(opt);
+                    monthsByYear[y].sort((a,b) => b - a);
+                });
+
+                const monthSelect = document.getElementById('month-select');
+                function populateMonths(){
+                    const y = yearSelect.value;
+                    monthSelect.innerHTML = '';
+                    (monthsByYear[y] || []).forEach(m => {
+                        const opt = document.createElement('option');
+                        opt.value = m;
+                        const d = new Date(y, m - 1);
+                        opt.textContent = d.toLocaleString('default', { month: 'long' });
+                        monthSelect.appendChild(opt);
+                    });
+                }
+
+                yearSelect.addEventListener('change', () => {
+                    populateMonths();
+                    loadMonth(yearSelect.value, monthSelect.value);
+                });
+                populateMonths();
+                loadMonth(yearSelect.value, monthSelect.value);
+                monthSelect.addEventListener('change', () => loadMonth(yearSelect.value, monthSelect.value));
+            });
+    });
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>
+

--- a/php_backend/public/monthly_dashboard.php
+++ b/php_backend/public/monthly_dashboard.php
@@ -1,0 +1,28 @@
+<?php
+// API endpoint returning monthly totals for tags, categories, groups and income/outgoings.
+require_once __DIR__ . '/../models/Log.php';
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+$year = isset($_GET['year']) ? (int)$_GET['year'] : date('Y');
+$month = isset($_GET['month']) ? (int)$_GET['month'] : date('n');
+
+try {
+    $totals = Transaction::getMonthlyTotals($month, $year);
+    $tags = Transaction::getTagTotalsByMonth($month, $year);
+    $categories = Transaction::getCategoryTotalsByMonth($month, $year);
+    $groups = Transaction::getGroupTotalsByMonth($month, $year);
+    echo json_encode([
+        'totals' => $totals,
+        'tags' => $tags,
+        'categories' => $categories,
+        'groups' => $groups
+    ]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+
+?>
+


### PR DESCRIPTION
## Summary
- Add monthly dashboard frontend with selectable month and income/outgoing/delta summary
- Expose monthly_dashboard API and extend Transaction model for monthly totals
- Include positive/negative styling and navigation/README updates

## Testing
- `php -l php_backend/public/monthly_dashboard.php`
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6890d94397b8832e842683a00abc0e3e