### PR TITLE
Enable tagging transactions in monthly statement

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -28,6 +28,7 @@
 <script>
 const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
+let tagValues = {};
 
 fetch('../php_backend/public/transaction_months.php')
     .then(resp => resp.json())
@@ -72,22 +73,68 @@ form.addEventListener('submit', function(e) {
     e.preventDefault();
     const month = monthSelect.value;
     const year = yearSelect.value;
-    fetch('../php_backend/public/transactions.php?month=' + month + '&year=' + year)
-        .then(resp => resp.json())
-        .then(data => {
-            new Tabulator('#transactions-grid', {
-                data: data,
-                layout: 'fitColumns',
-                columns: [
-                    { title: 'Date', field: 'date' },
-                    { title: 'Description', field: 'description' },
-                    { title: 'Category', field: 'category_name' },
-                    { title: 'Tag', field: 'tag_name' },
-                    { title: 'Group', field: 'group_name' },
-                    { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
-                ]
-            });
+    Promise.all([
+        fetch('../php_backend/public/transactions.php?month=' + month + '&year=' + year).then(r => r.json()),
+        fetch('../php_backend/public/tags.php').then(r => r.json())
+    ]).then(([data, tags]) => {
+        tagValues = {};
+        tags.forEach(t => { tagValues[t.id] = t.name; });
+        tagValues['__new'] = 'Add New Tag...';
+
+        new Tabulator('#transactions-grid', {
+            data: data,
+            layout: 'fitColumns',
+            columns: [
+                { title: 'Date', field: 'date' },
+                { title: 'Description', field: 'description' },
+                { title: 'Category', field: 'category_name' },
+                {
+                    title: 'Tag',
+                    field: 'tag_id',
+                    editor: 'select',
+                    editorParams: { values: tagValues },
+                    formatter: function(cell) { return tagValues[cell.getValue()] || ''; }
+                },
+                { title: 'Group', field: 'group_name' },
+                { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+            ],
+            cellEdited: function(cell) {
+                if (cell.getField() === 'tag_id') {
+                    const val = cell.getValue();
+                    const data = cell.getRow().getData();
+                    const payload = { transaction_id: data.id, account_id: data.account_id, description: data.description };
+                    if (val === '__new') {
+                        const name = prompt('Enter new tag name:');
+                        if (!name) {
+                            cell.setValue(data.tag_id, true);
+                            return;
+                        }
+                        payload.tag_name = name;
+                    } else {
+                        payload.tag_id = val;
+                    }
+                    fetch('../php_backend/public/update_transaction_tag.php', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(payload)
+                    })
+                    .then(resp => resp.json())
+                    .then(res => {
+                        if (res && res.status === 'ok') {
+                            form.dispatchEvent(new Event('submit'));
+                        } else {
+                            alert('Failed to save tag');
+                            cell.setValue(data.tag_id, true);
+                        }
+                    })
+                    .catch(() => {
+                        alert('Failed to save tag');
+                        cell.setValue(data.tag_id, true);
+                    });
+                }
+            }
         });
+    });
 });
 </script>
     <script src="js/overlay.js"></script>

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -49,6 +49,15 @@ class Tag {
     }
 
     /**
+     * Set a tag's keyword if it is currently blank.
+     */
+    public static function setKeywordIfMissing(int $tagId, string $keyword): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE `tags` SET `keyword` = :kw WHERE `id` = :id AND (`keyword` IS NULL OR `keyword` = "")');
+        $stmt->execute(['kw' => $keyword, 'id' => $tagId]);
+    }
+
+    /**
      * Apply tag keywords to untagged transactions for a given account.
      * Returns the number of transactions updated.
      */

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -81,6 +81,7 @@ class Transaction {
     public static function getByMonth(int $month, int $year): array {
         $db = Database::getConnection();
         $sql = 'SELECT t.`id`, t.`account_id`, t.`date`, t.`amount`, t.`description`, t.`memo`, '
+             . 't.`category_id`, t.`tag_id`, '
              . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
@@ -92,6 +93,15 @@ class Transaction {
         $stmt->execute(['month' => $month, 'year' => $year]);
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Update the tag of a specific transaction.
+     */
+    public static function setTag(int $transactionId, int $tagId): bool {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE `transactions` SET `tag_id` = :tag WHERE `id` = :id');
+        return $stmt->execute(['tag' => $tagId, 'id' => $transactionId]);
     }
 
     public static function getAvailableMonths(): array {

--- a/php_backend/public/update_transaction_tag.php
+++ b/php_backend/public/update_transaction_tag.php
@@ -1,0 +1,52 @@
+<?php
+// API endpoint to update a transaction's tag and apply auto-tagging.
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/CategoryTag.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$transactionId = $data['transaction_id'] ?? null;
+$accountId = $data['account_id'] ?? null;
+$tagId = $data['tag_id'] ?? null;
+$tagName = $data['tag_name'] ?? null;
+$description = $data['description'] ?? null;
+
+if (!$transactionId || !$accountId || (!$tagId && !$tagName) || !$description) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid parameters']);
+    exit;
+}
+
+try {
+    if (!$tagId && $tagName) {
+        $tagId = Tag::create($tagName, $description);
+        Log::write("Created tag $tagName");
+    } else {
+        Tag::setKeywordIfMissing((int)$tagId, $description);
+    }
+
+    Transaction::setTag((int)$transactionId, (int)$tagId);
+
+    $applied = Tag::applyToAccountTransactions((int)$accountId);
+    $categorised = CategoryTag::applyToAccountTransactions((int)$accountId);
+
+    echo json_encode([
+        'status' => 'ok',
+        'tag_id' => (int)$tagId,
+        'auto_tagged' => $applied,
+        'auto_categorised' => $categorised,
+    ]);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Update transaction tag error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>


### PR DESCRIPTION
## Summary
- allow editing transaction tags from the monthly statement table
- add API endpoint to set a transaction tag, create new tags and re-run auto tagging and categorisation
- expose tag and category IDs in monthly statement data and support updating tags

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/public/update_transaction_tag.php`
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6890dc12672c832eb23bbd5137e8fe7d