### PR TITLE
Add period breakdown columns to dashboards

### DIFF
--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -43,16 +43,28 @@
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
-    function buildTable(id, data){
+    function buildTable(id, data, days){
         const el = document.getElementById(id);
         el.innerHTML = '';
+
+        const dayCols = Array.from({length: days}, (_, i) => ({
+            title: String(i + 1),
+            field: String(i + 1),
+            formatter: 'money',
+            formatterParams: { symbol: '£', precision: 2 },
+            hozAlign: 'right'
+        }));
+
+        const columns = [
+            { title: 'Name', field: 'name' },
+            ...dayCols,
+            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+        ];
+
         new Tabulator(el, {
             data: data,
             layout: 'fitColumns',
-            columns: [
-                { title: 'Name', field: 'name' },
-                { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
-            ]
+            columns: columns
         });
     }
 
@@ -78,11 +90,13 @@
                 deltaEl.textContent = '£' + parseFloat(totals.delta).toFixed(2);
                 deltaEl.className = totals.delta >= 0 ? 'positive' : 'negative';
 
-                buildTable('tags-table', data.tags);
+                const days = new Date(year, month, 0).getDate();
+
+                buildTable('tags-table', data.tags, days);
                 buildChart('tags-chart', 'Tag Totals', data.tags);
-                buildTable('categories-table', data.categories);
+                buildTable('categories-table', data.categories, days);
                 buildChart('categories-chart', 'Category Totals', data.categories);
-                buildTable('groups-table', data.groups);
+                buildTable('groups-table', data.groups, days);
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });
     }

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -37,13 +37,25 @@
     function buildTable(id, data){
         const el = document.getElementById(id);
         el.innerHTML = '';
+
+        const monthCols = Array.from({length: 12}, (_, i) => ({
+            title: new Date(0, i).toLocaleString('default', { month: 'short' }),
+            field: String(i + 1),
+            formatter: 'money',
+            formatterParams: { symbol: '£', precision: 2 },
+            hozAlign: 'right'
+        }));
+
+        const columns = [
+            { title: 'Name', field: 'name' },
+            ...monthCols,
+            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+        ];
+
         new Tabulator(el, {
             data: data,
             layout: 'fitColumns',
-            columns: [
-                { title: 'Name', field: 'name' },
-                { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
-            ]
+            columns: columns
         });
     }
 

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -215,15 +215,22 @@ class Transaction {
      */
     public static function getTagTotalsByMonth(int $month, int $year): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare(
-            'SELECT tg.`name` AS `name`,
-                    SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
+
+        $dayCases = [];
+        for ($d = 1; $d <= 31; $d++) {
+            $dayCases[] = "SUM(CASE WHEN DAY(t.`date`) = $d AND t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `$d`";
+        }
+
+        $sql = 'SELECT tg.`name` AS `name`, '
+             . implode(', ', $dayCases)
+             . ', SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
              FROM `transactions` t
              JOIN `tags` tg ON t.`tag_id` = tg.`id`
              WHERE MONTH(t.`date`) = :month AND YEAR(t.`date`) = :year
              GROUP BY tg.`id`, tg.`name`
-             ORDER BY `total` DESC'
-        );
+             ORDER BY `total` DESC';
+
+        $stmt = $db->prepare($sql);
         $stmt->execute(['month' => $month, 'year' => $year]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -234,15 +241,22 @@ class Transaction {
      */
     public static function getCategoryTotalsByMonth(int $month, int $year): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare(
-            'SELECT c.`name` AS `name`,
-                    SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
+
+        $dayCases = [];
+        for ($d = 1; $d <= 31; $d++) {
+            $dayCases[] = "SUM(CASE WHEN DAY(t.`date`) = $d AND t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `$d`";
+        }
+
+        $sql = 'SELECT c.`name` AS `name`, '
+             . implode(', ', $dayCases)
+             . ', SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
              FROM `transactions` t
              JOIN `categories` c ON t.`category_id` = c.`id`
              WHERE MONTH(t.`date`) = :month AND YEAR(t.`date`) = :year
              GROUP BY c.`id`, c.`name`
-             ORDER BY `total` DESC'
-        );
+             ORDER BY `total` DESC';
+
+        $stmt = $db->prepare($sql);
         $stmt->execute(['month' => $month, 'year' => $year]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -253,15 +267,22 @@ class Transaction {
      */
     public static function getGroupTotalsByMonth(int $month, int $year): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare(
-            'SELECT g.`name` AS `name`,
-                    SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
+
+        $dayCases = [];
+        for ($d = 1; $d <= 31; $d++) {
+            $dayCases[] = "SUM(CASE WHEN DAY(t.`date`) = $d AND t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `$d`";
+        }
+
+        $sql = 'SELECT g.`name` AS `name`, '
+             . implode(', ', $dayCases)
+             . ', SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
              FROM `transactions` t
              JOIN `transaction_groups` g ON t.`group_id` = g.`id`
              WHERE MONTH(t.`date`) = :month AND YEAR(t.`date`) = :year
              GROUP BY g.`id`, g.`name`
-             ORDER BY `total` DESC'
-        );
+             ORDER BY `total` DESC';
+
+        $stmt = $db->prepare($sql);
         $stmt->execute(['month' => $month, 'year' => $year]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -273,15 +294,22 @@ class Transaction {
      */
     public static function getTagTotalsByYear(int $year): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare(
-            'SELECT tg.`name` AS `name`,
-                    SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
+
+        $monthCases = [];
+        for ($m = 1; $m <= 12; $m++) {
+            $monthCases[] = "SUM(CASE WHEN MONTH(t.`date`) = $m AND t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `$m`";
+        }
+
+        $sql = 'SELECT tg.`name` AS `name`, '
+             . implode(', ', $monthCases)
+             . ', SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
              FROM `transactions` t
              JOIN `tags` tg ON t.`tag_id` = tg.`id`
              WHERE YEAR(t.`date`) = :year
              GROUP BY tg.`id`, tg.`name`
-             ORDER BY `total` DESC'
-        );
+             ORDER BY `total` DESC';
+
+        $stmt = $db->prepare($sql);
         $stmt->execute(['year' => $year]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -292,15 +320,22 @@ class Transaction {
      */
     public static function getCategoryTotalsByYear(int $year): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare(
-            'SELECT c.`name` AS `name`,
-                    SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
+
+        $monthCases = [];
+        for ($m = 1; $m <= 12; $m++) {
+            $monthCases[] = "SUM(CASE WHEN MONTH(t.`date`) = $m AND t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `$m`";
+        }
+
+        $sql = 'SELECT c.`name` AS `name`, '
+             . implode(', ', $monthCases)
+             . ', SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
              FROM `transactions` t
              JOIN `categories` c ON t.`category_id` = c.`id`
              WHERE YEAR(t.`date`) = :year
              GROUP BY c.`id`, c.`name`
-             ORDER BY `total` DESC'
-        );
+             ORDER BY `total` DESC';
+
+        $stmt = $db->prepare($sql);
         $stmt->execute(['year' => $year]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
@@ -311,15 +346,22 @@ class Transaction {
      */
     public static function getGroupTotalsByYear(int $year): array {
         $db = Database::getConnection();
-        $stmt = $db->prepare(
-            'SELECT g.`name` AS `name`,
-                    SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
+
+        $monthCases = [];
+        for ($m = 1; $m <= 12; $m++) {
+            $monthCases[] = "SUM(CASE WHEN MONTH(t.`date`) = $m AND t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `$m`";
+        }
+
+        $sql = 'SELECT g.`name` AS `name`, '
+             . implode(', ', $monthCases)
+             . ', SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
              FROM `transactions` t
              JOIN `transaction_groups` g ON t.`group_id` = g.`id`
              WHERE YEAR(t.`date`) = :year
              GROUP BY g.`id`, g.`name`
-             ORDER BY `total` DESC'
-        );
+             ORDER BY `total` DESC';
+
+        $stmt = $db->prepare($sql);
         $stmt->execute(['year' => $year]);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }


### PR DESCRIPTION
## Summary
- extend backend totals to include per-month and per-day breakdowns
- show monthly columns on yearly dashboard tables
- show daily columns on monthly dashboard tables

## Testing
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6890e176102c832e93921792c5563b5b