### PR TITLE
Fix version number display without shell_exec

### DIFF
--- a/frontend/js/version.js
+++ b/frontend/js/version.js
@@ -5,9 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
   fetch('../php_backend/public/version.php')
     .then((response) => response.json())
     .then((data) => {
-      if (data.version) {
-        target.textContent = `Version: ${data.version}`;
-      }
+      const version = data.version || 'unknown';
+      target.textContent = `Version: ${version}`;
     })
     .catch(() => {
       target.textContent = 'Version: unknown';

--- a/php_backend/public/version.php
+++ b/php_backend/public/version.php
@@ -1,7 +1,19 @@
 <?php
-// Outputs the current git commit hash for version display.
+// Outputs the current git commit hash for version display without relying on shell_exec.
 header('Content-Type: application/json');
 $rootDir = dirname(__DIR__, 2);
-$commitHash = trim(shell_exec('git -C ' . escapeshellarg($rootDir) . ' rev-parse --short HEAD'));
+$commitHash = '';
+$headPath = $rootDir . '/.git/HEAD';
+if (is_readable($headPath)) {
+    $ref = trim(file_get_contents($headPath));
+    if (strpos($ref, 'ref: ') === 0) {
+        $refPath = $rootDir . '/.git/' . substr($ref, 5);
+        if (is_readable($refPath)) {
+            $commitHash = trim(file_get_contents($refPath));
+        }
+    } else {
+        $commitHash = $ref;
+    }
+}
+$commitHash = $commitHash ? substr($commitHash, 0, 7) : null;
 echo json_encode(['version' => $commitHash]);
-


### PR DESCRIPTION
## Summary
- use .git files to determine commit hash
- show 'unknown' when version not available

## Testing
- `php php_backend/public/version.php`
- `php -l php_backend/public/version.php`


------
https://chatgpt.com/codex/tasks/task_e_6891b863d500832e8405babb10a3d9a3