### PR TITLE
Add all years dashboard

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<!-- Dashboard showing totals across all years -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>All Years Dashboard</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar" id="menu"></nav>
+        <main class="content">
+            <h1>All Years Dashboard</h1>
+
+            <h2>Tag Totals</h2>
+            <div id="tags-table"></div>
+            <div id="tags-chart" style="height:400px"></div>
+
+            <h2>Category Totals</h2>
+            <div id="categories-table"></div>
+            <div id="categories-chart" style="height:400px"></div>
+
+            <h2>Group Totals</h2>
+            <div id="groups-table"></div>
+            <div id="groups-chart" style="height:400px"></div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script>
+    function buildTable(id, data, years){
+        const el = document.getElementById(id);
+        el.innerHTML = '';
+
+        const yearCols = years.map(y => ({
+            title: y,
+            field: String(y),
+            formatter: 'money',
+            formatterParams: { symbol: '£', precision: 2 },
+            hozAlign: 'right'
+        }));
+
+        const columns = [
+            { title: 'Name', field: 'name' },
+            ...yearCols,
+            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+        ];
+
+        new Tabulator(el, {
+            data: data,
+            layout: 'fitColumns',
+            columns: columns
+        });
+    }
+
+    function buildChart(id, title, data){
+        Highcharts.chart(id, {
+            chart: { type: 'column' },
+            title: { text: title },
+            xAxis: { categories: data.map(d => d.name) },
+            yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)) }]
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        fetch('../php_backend/public/all_years_dashboard.php')
+            .then(resp => resp.json())
+            .then(data => {
+                buildTable('tags-table', data.tags, data.years);
+                buildChart('tags-chart', 'Tag Totals', data.tags);
+                buildTable('categories-table', data.categories, data.years);
+                buildChart('categories-chart', 'Category Totals', data.categories);
+                buildTable('groups-table', data.groups, data.years);
+                buildChart('groups-chart', 'Group Totals', data.groups);
+            });
+    });
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -4,6 +4,7 @@
     <li><a href="index.html"><i class="fa-solid fa-house"></i> Home</a></li>
     <li><a href="upload.html"><i class="fa-solid fa-upload"></i> Upload OFX File</a></li>
     <li><a href="yearly_dashboard.html"><i class="fa-solid fa-chart-line"></i> Yearly Dashboard</a></li>
+    <li><a href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar"></i> All Years Dashboard</a></li>
     <li><a href="monthly_dashboard.html"><i class="fa-solid fa-chart-column"></i> Monthly Dashboard</a></li>
     <li><a href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar"></i> View Monthly Statement</a></li>
     <li><a href="report.html"><i class="fa-solid fa-table"></i> Transaction Reports</a></li>

--- a/php_backend/public/all_years_dashboard.php
+++ b/php_backend/public/all_years_dashboard.php
@@ -1,0 +1,23 @@
+<?php
+// API endpoint returning totals across all available years for tags, categories, and groups.
+require_once __DIR__ . '/../models/Log.php';
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+try {
+    $years = Transaction::getAvailableYears();
+    $tags = Transaction::getTagTotalsByYears($years);
+    $categories = Transaction::getCategoryTotalsByYears($years);
+    $groups = Transaction::getGroupTotalsByYears($years);
+    echo json_encode([
+        'years' => $years,
+        'tags' => $tags,
+        'categories' => $categories,
+        'groups' => $groups
+    ]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- Add All Years Dashboard showing totals per tag, category, and group across all years
- Provide backend endpoint and model helpers to aggregate yearly totals
- Link new dashboard in navigation menu

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/all_years_dashboard.php`

------
https://chatgpt.com/codex/tasks/task_e_6891b9c9db6c832ea49501d0e92a7d5d