### PR TITLE
Add transaction detail view with editable fields

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -86,7 +86,10 @@ form.addEventListener('submit', function(e) {
             layout: 'fitColumns',
             columns: [
                 { title: 'Date', field: 'date' },
-                { title: 'Description', field: 'description' },
+                { title: 'Description', field: 'description', formatter: function(cell) {
+                    const id = cell.getRow().getData().id;
+                    return `<a href="transaction.html?id=${id}">${cell.getValue()}</a>`;
+                } },
                 { title: 'Category', field: 'category_name' },
                 {
                     title: 'Tag',

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -45,7 +45,10 @@
                         layout: 'fitColumns',
                         columns: [
                             { title: 'Date', field: 'date' },
-                            { title: 'Description', field: 'description' },
+                            { title: 'Description', field: 'description', formatter: function(cell){
+                                const id = cell.getRow().getData().id;
+                                return `<a href="transaction.html?id=${id}">${cell.getValue()}</a>`;
+                            } },
                             { title: 'Memo', field: 'memo' },
                             { title: 'Category', field: 'category_name' },
                             { title: 'Tag', field: 'tag_name' },

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Transaction Details</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div class="container">
+        <nav class="sidebar" id="menu"></nav>
+        <main class="content">
+            <h1>Transaction Details</h1>
+            <div id="transaction-details"></div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script>
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    const container = document.getElementById('transaction-details');
+    if (!id) {
+        container.textContent = 'No transaction id provided.';
+    } else {
+        Promise.all([
+            fetch('../php_backend/public/transaction.php?id=' + id).then(r => r.json()),
+            fetch('../php_backend/public/categories.php').then(r => r.json()),
+            fetch('../php_backend/public/tags.php').then(r => r.json()),
+            fetch('../php_backend/public/groups.php').then(r => r.json())
+        ]).then(([tx, categories, tags, groups]) => {
+            if (tx.error) {
+                container.textContent = 'Transaction not found.';
+                return;
+            }
+
+            const form = document.createElement('form');
+            form.innerHTML = `
+                <p><strong>Date:</strong> ${tx.date}</p>
+                <p><strong>Description:</strong> ${tx.description}</p>
+                <p><strong>Memo:</strong> ${tx.memo || ''}</p>
+                <p><strong>Amount:</strong> £${parseFloat(tx.amount).toFixed(2)}</p>
+                <label>Category: <select id="category"></select></label><br>
+                <label>Tag: <select id="tag"></select></label><br>
+                <label>Group: <select id="group"></select></label><br>
+                <button type="submit">Save</button>
+            `;
+            container.appendChild(form);
+
+            const catSel = form.querySelector('#category');
+            const blankCat = document.createElement('option');
+            blankCat.value = '';
+            blankCat.textContent = '-- None --';
+            catSel.appendChild(blankCat);
+            categories.forEach(c => {
+                const opt = document.createElement('option');
+                opt.value = c.id;
+                opt.textContent = c.name;
+                if (c.id == tx.category_id) opt.selected = true;
+                catSel.appendChild(opt);
+            });
+
+            const tagSel = form.querySelector('#tag');
+            const blankTag = document.createElement('option');
+            blankTag.value = '';
+            blankTag.textContent = '-- None --';
+            tagSel.appendChild(blankTag);
+            tags.forEach(t => {
+                const opt = document.createElement('option');
+                opt.value = t.id;
+                opt.textContent = t.name;
+                if (t.id == tx.tag_id) opt.selected = true;
+                tagSel.appendChild(opt);
+            });
+            const newOpt = document.createElement('option');
+            newOpt.value = '__new';
+            newOpt.textContent = 'Add New Tag...';
+            tagSel.appendChild(newOpt);
+
+            const groupSel = form.querySelector('#group');
+            const blankGrp = document.createElement('option');
+            blankGrp.value = '';
+            blankGrp.textContent = '-- None --';
+            groupSel.appendChild(blankGrp);
+            groups.forEach(g => {
+                const opt = document.createElement('option');
+                opt.value = g.id;
+                opt.textContent = g.name;
+                if (g.id == tx.group_id) opt.selected = true;
+                groupSel.appendChild(opt);
+            });
+
+            form.addEventListener('submit', function(ev){
+                ev.preventDefault();
+                const payload = {
+                    transaction_id: tx.id,
+                    account_id: tx.account_id,
+                    description: tx.description
+                };
+                if (catSel.value !== '') payload.category_id = catSel.value;
+                if (groupSel.value !== '') payload.group_id = groupSel.value;
+                if (tagSel.value === '__new') {
+                    const name = prompt('Enter new tag name:');
+                    if (!name) return;
+                    payload.tag_name = name;
+                } else if (tagSel.value !== '') {
+                    payload.tag_id = tagSel.value;
+                }
+
+                fetch('../php_backend/public/update_transaction.php', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload)
+                }).then(r => r.json()).then(res => {
+                    if (res && res.status === 'ok') {
+                        showMessage('Saved');
+                    } else {
+                        alert('Failed to save');
+                    }
+                }).catch(() => alert('Failed to save'));
+            });
+        });
+    }
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -142,12 +142,49 @@ class Transaction {
     }
 
     /**
+     * Retrieve a single transaction by its ID including related names.
+     */
+    public static function get(int $id): ?array {
+        $db = Database::getConnection();
+        $sql = 'SELECT t.`id`, t.`account_id`, t.`date`, t.`amount`, t.`description`, t.`memo`, ' 
+             . 't.`category_id`, t.`tag_id`, t.`group_id`, ' 
+             . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name ' 
+             . 'FROM `transactions` t ' 
+             . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` ' 
+             . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` ' 
+             . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` ' 
+             . 'WHERE t.`id` = :id LIMIT 1';
+        $stmt = $db->prepare($sql);
+        $stmt->execute(['id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ? $row : null;
+    }
+
+    /**
      * Update the tag of a specific transaction.
      */
     public static function setTag(int $transactionId, int $tagId): bool {
         $db = Database::getConnection();
         $stmt = $db->prepare('UPDATE `transactions` SET `tag_id` = :tag WHERE `id` = :id');
         return $stmt->execute(['tag' => $tagId, 'id' => $transactionId]);
+    }
+
+    /**
+     * Update the category of a specific transaction.
+     */
+    public static function setCategory(int $transactionId, ?int $categoryId): bool {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE `transactions` SET `category_id` = :cat WHERE `id` = :id');
+        return $stmt->execute(['cat' => $categoryId, 'id' => $transactionId]);
+    }
+
+    /**
+     * Update the group of a specific transaction.
+     */
+    public static function setGroup(int $transactionId, ?int $groupId): bool {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE `transactions` SET `group_id` = :grp WHERE `id` = :id');
+        return $stmt->execute(['grp' => $groupId, 'id' => $transactionId]);
     }
 
     public static function getAvailableMonths(): array {

--- a/php_backend/public/transaction.php
+++ b/php_backend/public/transaction.php
@@ -1,0 +1,26 @@
+<?php
+// API endpoint returning a single transaction's details.
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if (!$id) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid id']);
+    exit;
+}
+
+try {
+    $tx = Transaction::get($id);
+    if ($tx) {
+        echo json_encode($tx);
+    } else {
+        http_response_code(404);
+        echo json_encode(['error' => 'Transaction not found']);
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -1,0 +1,61 @@
+<?php
+// API endpoint to update tag, category, and group of a transaction.
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/CategoryTag.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$transactionId = $data['transaction_id'] ?? null;
+$accountId = $data['account_id'] ?? null;
+$description = $data['description'] ?? null;
+$tagId = $data['tag_id'] ?? null;
+$tagName = $data['tag_name'] ?? null;
+$categoryId = $data['category_id'] ?? null;
+$groupId = $data['group_id'] ?? null;
+
+if (!$transactionId || !$accountId || !$description) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid parameters']);
+    exit;
+}
+
+try {
+    if ($categoryId !== null) {
+        Transaction::setCategory((int)$transactionId, $categoryId === '' ? null : (int)$categoryId);
+    }
+    if ($groupId !== null) {
+        Transaction::setGroup((int)$transactionId, $groupId === '' ? null : (int)$groupId);
+    }
+    if ($tagId !== null || $tagName) {
+        if (!$tagId && $tagName) {
+            $tagId = Tag::create($tagName, $description);
+            Log::write("Created tag $tagName");
+        } else {
+            Tag::setKeywordIfMissing((int)$tagId, $description);
+        }
+        Transaction::setTag((int)$transactionId, (int)$tagId);
+    }
+
+    $applied = Tag::applyToAccountTransactions((int)$accountId);
+    $categorised = CategoryTag::applyToAccountTransactions((int)$accountId);
+
+    echo json_encode([
+        'status' => 'ok',
+        'tag_id' => $tagId ? (int)$tagId : null,
+        'auto_tagged' => $applied,
+        'auto_categorised' => $categorised
+    ]);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Update transaction error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>


### PR DESCRIPTION
## Summary
- add transaction model utilities for fetching and updating tag, category and group
- expose APIs to fetch and update individual transaction records
- create UI for viewing and editing a transaction and link existing tables to it

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/transaction.php`
- `php -l php_backend/public/update_transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6891bb7b89c8832e8ec9dc3f662b4882