### PR TITLE
Add totals row to dashboard tables

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -31,6 +31,14 @@
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    function totalFormatter(cell){
+        const value = cell.getValue();
+        const el = cell.getElement();
+        el.classList.toggle('negative', value < 0);
+        el.classList.toggle('positive', value > 0);
+        return '£' + parseFloat(value).toFixed(2);
+    }
+
     function buildTable(id, data, years){
         const el = document.getElementById(id);
         el.innerHTML = '';
@@ -40,13 +48,15 @@
             field: String(y),
             formatter: 'money',
             formatterParams: { symbol: '£', precision: 2 },
-            hozAlign: 'right'
+            hozAlign: 'right',
+            bottomCalc: 'sum',
+            bottomCalcFormatter: totalFormatter
         }));
 
         const columns = [
-            { title: 'Name', field: 'name' },
+            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
             ...yearCols,
-            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
 
         new Tabulator(el, {

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -43,6 +43,14 @@
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    function totalFormatter(cell){
+        const value = cell.getValue();
+        const el = cell.getElement();
+        el.classList.toggle('negative', value < 0);
+        el.classList.toggle('positive', value > 0);
+        return '£' + parseFloat(value).toFixed(2);
+    }
+
     function buildTable(id, data, days){
         const el = document.getElementById(id);
         el.innerHTML = '';
@@ -52,13 +60,15 @@
             field: String(i + 1),
             formatter: 'money',
             formatterParams: { symbol: '£', precision: 2 },
-            hozAlign: 'right'
+            hozAlign: 'right',
+            bottomCalc: 'sum',
+            bottomCalcFormatter: totalFormatter
         }));
 
         const columns = [
-            { title: 'Name', field: 'name' },
+            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
             ...dayCols,
-            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
 
         new Tabulator(el, {

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -34,6 +34,14 @@
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    function totalFormatter(cell){
+        const value = cell.getValue();
+        const el = cell.getElement();
+        el.classList.toggle('negative', value < 0);
+        el.classList.toggle('positive', value > 0);
+        return '£' + parseFloat(value).toFixed(2);
+    }
+
     function buildTable(id, data){
         const el = document.getElementById(id);
         el.innerHTML = '';
@@ -43,13 +51,15 @@
             field: String(i + 1),
             formatter: 'money',
             formatterParams: { symbol: '£', precision: 2 },
-            hozAlign: 'right'
+            hozAlign: 'right',
+            bottomCalc: 'sum',
+            bottomCalcFormatter: totalFormatter
         }));
 
         const columns = [
-            { title: 'Name', field: 'name' },
+            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
             ...monthCols,
-            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
 
         new Tabulator(el, {


### PR DESCRIPTION
## Summary
- show overall sums at bottom of monthly dashboard tables with conditional colouring
- add yearly dashboard table totals row with automatic sums
- include totals row across all years dashboard tables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891bdf9e518832ea22442e84076eb72