### PR TITLE
Add total row to report results

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -109,11 +109,11 @@
                         layout: 'fitColumns',
                         columns: [
                             { title: 'Date', field: 'date' },
-                            { title: 'Description', field: 'description' },
+                            { title: 'Description', field: 'description', bottomCalc: function() { return 'Total'; } },
                             { title: 'Category', field: 'category_name' },
                             { title: 'Tag', field: 'tag_name' },
                             { title: 'Group', field: 'group_name' },
-                            { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+                            { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: function(values) { var total = 0; values.forEach(function(value) { total += parseFloat(value) || 0; }); return total; }, bottomCalcFormatter: 'money', bottomCalcFormatterParams: { symbol: '£', precision: 2 } }
                         ]
                     });
                     const categories = data.map(tx => tx.date);


### PR DESCRIPTION
## Summary
- show total row in report results grid with sum of Amount column

## Testing
- `php -l php_backend/public/report.php`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891c278ddc0832eb70e41eeccc0b3ef