### PR TITLE
Fix missing month options in statement view

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -31,10 +31,6 @@ const yearSelect = document.getElementById('year');
 let tagOptions = [];
 let tagLookup = {};
 
-let tagOptions = [];
-let tagLookup = {};
-
-
 fetch('../php_backend/public/transaction_months.php')
     .then(resp => resp.json())
     .then(data => {


### PR DESCRIPTION
## Summary
- Remove duplicate variable declarations in `monthly_statement.html` to prevent JavaScript errors
- Ensure the script initializes once and fetches available months correctly

## Testing
- `node - <<'NODE'
const fs = require('fs');
const html = fs.readFileSync('frontend/monthly_statement.html','utf8');
const script = html.match(/<script>([\s\S]*?)<\/script>/)[1];
new Function(script);
console.log('Script parsed successfully');
NODE`
- `php php_backend/public/transaction_months.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891c5dc99b0832eae13cbacf93ed6c5