### PR TITLE
Enable group selection on monthly statements

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -30,6 +30,8 @@ const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
 let tagOptions = [];
 let tagLookup = {};
+let groupOptions = [];
+let groupLookup = {};
 
 fetch('../php_backend/public/transaction_months.php')
     .then(resp => resp.json())
@@ -76,16 +78,25 @@ form.addEventListener('submit', function(e) {
     const year = yearSelect.value;
     Promise.all([
         fetch('../php_backend/public/transactions.php?month=' + month + '&year=' + year).then(r => r.json()),
-        fetch('../php_backend/public/tags.php').then(r => r.json())
-    ]).then(([data, tags]) => {
+        fetch('../php_backend/public/tags.php').then(r => r.json()),
+        fetch('../php_backend/public/groups.php').then(r => r.json())
+    ]).then(([data, tags, groups]) => {
 
         tagOptions = [];
         tagLookup = {};
+        groupOptions = [{ value: '', label: '-- None --' }];
+        groupLookup = { '': '' };
         tags.forEach(t => {
             tagOptions.push({ value: t.id, label: t.name });
             tagLookup[t.id] = t.name;
         });
         tagOptions.push({ value: '__new', label: 'Add New Tag...' });
+
+        groups.forEach(g => {
+            groupOptions.push({ value: g.id, label: g.name });
+            groupLookup[g.id] = g.name;
+        });
+        groupOptions.push({ value: '__new', label: 'Add New Group...' });
 
         new Tabulator('#transactions-grid', {
             data: data,
@@ -106,42 +117,104 @@ form.addEventListener('submit', function(e) {
                         return tagLookup[cell.getValue()] || '';
                     }
                 },
-                { title: 'Group', field: 'group_name' },
+                {
+                    title: 'Group',
+                    field: 'group_id',
+                    editor: 'list',
+                    editorParams: { values: groupOptions },
+                    formatter: function(cell) {
+                        return groupLookup[cell.getValue()] || '';
+                    }
+                },
                 { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
             ],
             cellEdited: function(cell) {
-                if (cell.getField() === 'tag_id') {
+                const field = cell.getField();
+                if (field === 'tag_id' || field === 'group_id') {
                     const val = cell.getValue();
                     const data = cell.getRow().getData();
                     const payload = { transaction_id: data.id, account_id: data.account_id, description: data.description };
-                    if (val === '__new') {
-                        const name = prompt('Enter new tag name:');
-                        if (!name) {
-                            cell.setValue(data.tag_id, true);
-                            return;
-                        }
-                        payload.tag_name = name;
-                    } else {
-                        payload.tag_id = val;
-                    }
-                    fetch('../php_backend/public/update_transaction_tag.php', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify(payload)
-                    })
-                    .then(resp => resp.json())
-                    .then(res => {
-                        if (res && res.status === 'ok') {
-                            form.dispatchEvent(new Event('submit'));
+
+                    if (field === 'tag_id') {
+                        if (val === '__new') {
+                            const name = prompt('Enter new tag name:');
+                            if (!name) {
+                                cell.setValue(data.tag_id, true);
+                                return;
+                            }
+                            payload.tag_name = name;
                         } else {
+                            payload.tag_id = val;
+                        }
+                        fetch('../php_backend/public/update_transaction.php', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(payload)
+                        })
+                        .then(resp => resp.json())
+                        .then(res => {
+                            if (res && res.status === 'ok') {
+                                form.dispatchEvent(new Event('submit'));
+                            } else {
+                                alert('Failed to save tag');
+                                cell.setValue(data.tag_id, true);
+                            }
+                        })
+                        .catch(() => {
                             alert('Failed to save tag');
                             cell.setValue(data.tag_id, true);
+                        });
+                    } else if (field === 'group_id') {
+                        function updateGroup(id) {
+                            payload.group_id = id;
+                            fetch('../php_backend/public/update_transaction.php', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify(payload)
+                            })
+                            .then(resp => resp.json())
+                            .then(res => {
+                                if (res && res.status === 'ok') {
+                                    form.dispatchEvent(new Event('submit'));
+                                } else {
+                                    alert('Failed to save group');
+                                    cell.setValue(data.group_id, true);
+                                }
+                            })
+                            .catch(() => {
+                                alert('Failed to save group');
+                                cell.setValue(data.group_id, true);
+                            });
                         }
-                    })
-                    .catch(() => {
-                        alert('Failed to save tag');
-                        cell.setValue(data.tag_id, true);
-                    });
+
+                        if (val === '__new') {
+                            const name = prompt('Enter new group name:');
+                            if (!name) {
+                                cell.setValue(data.group_id, true);
+                                return;
+                            }
+                            fetch('../php_backend/public/groups.php', {
+                                method: 'POST',
+                                headers: { 'Content-Type': 'application/json' },
+                                body: JSON.stringify({ name })
+                            })
+                            .then(resp => resp.json())
+                            .then(res => {
+                                if (res && res.id) {
+                                    updateGroup(res.id);
+                                } else {
+                                    alert('Failed to save group');
+                                    cell.setValue(data.group_id, true);
+                                }
+                            })
+                            .catch(() => {
+                                alert('Failed to save group');
+                                cell.setValue(data.group_id, true);
+                            });
+                        } else {
+                            updateGroup(val);
+                        }
+                    }
                 }
             }
         });

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -127,7 +127,7 @@ class Transaction {
     public static function getByMonth(int $month, int $year): array {
         $db = Database::getConnection();
         $sql = 'SELECT t.`id`, t.`account_id`, t.`date`, t.`amount`, t.`description`, t.`memo`, '
-             . 't.`category_id`, t.`tag_id`, '
+             . 't.`category_id`, t.`tag_id`, t.`group_id`, '
              . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '


### PR DESCRIPTION
## Summary
- Include group information in monthly transaction queries
- Allow monthly statement table to edit and create transaction groups

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/update_transaction.php`
- `php -l php_backend/public/groups.php`


------
https://chatgpt.com/codex/tasks/task_e_6891d2ee6998832ea707f2a149142896