### PR TITLE
Add category/tag donut charts to dashboards

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -22,6 +22,9 @@
             <div id="categories-table"></div>
             <div id="categories-chart" style="height:400px"></div>
 
+            <h2>Category & Tag Breakdown</h2>
+            <div id="category-tag-donut" style="height:400px"></div>
+
             <h2>Group Totals</h2>
             <div id="groups-table"></div>
             <div id="groups-chart" style="height:400px"></div>
@@ -77,6 +80,34 @@
         });
     }
 
+    function buildDonutChart(id, categories, tags){
+        Highcharts.chart(id, {
+            chart: { type: 'pie' },
+            title: { text: 'Categories and Tags' },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            plotOptions: {
+                pie: {
+                    dataLabels: {
+                        formatter: function(){ return this.point.name + ': £' + Highcharts.numberFormat(this.y, 2); }
+                    }
+                }
+            },
+            series: [
+                {
+                    name: 'Categories',
+                    data: categories.map(c => ({ name: c.name, y: parseFloat(c.total) })),
+                    size: '60%'
+                },
+                {
+                    name: 'Tags',
+                    data: tags.map(t => ({ name: t.name, y: parseFloat(t.total) })),
+                    size: '80%',
+                    innerSize: '60%'
+                }
+            ]
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
         fetch('../php_backend/public/all_years_dashboard.php')
             .then(resp => resp.json())
@@ -85,6 +116,7 @@
                 buildChart('tags-chart', 'Tag Totals', data.tags);
                 buildTable('categories-table', data.categories, data.years);
                 buildChart('categories-chart', 'Category Totals', data.categories);
+                buildDonutChart('category-tag-donut', data.categories, data.tags);
                 buildTable('groups-table', data.groups, data.years);
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -34,6 +34,9 @@
             <div id="categories-table"></div>
             <div id="categories-chart" style="height:400px"></div>
 
+            <h2>Category & Tag Breakdown</h2>
+            <div id="category-tag-donut" style="height:400px"></div>
+
             <h2>Group Totals</h2>
             <div id="groups-table"></div>
             <div id="groups-chart" style="height:400px"></div>
@@ -89,6 +92,34 @@
         });
     }
 
+    function buildDonutChart(id, categories, tags){
+        Highcharts.chart(id, {
+            chart: { type: 'pie' },
+            title: { text: 'Categories and Tags' },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            plotOptions: {
+                pie: {
+                    dataLabels: {
+                        formatter: function(){ return this.point.name + ': £' + Highcharts.numberFormat(this.y, 2); }
+                    }
+                }
+            },
+            series: [
+                {
+                    name: 'Categories',
+                    data: categories.map(c => ({ name: c.name, y: parseFloat(c.total) })),
+                    size: '60%'
+                },
+                {
+                    name: 'Tags',
+                    data: tags.map(t => ({ name: t.name, y: parseFloat(t.total) })),
+                    size: '80%',
+                    innerSize: '60%'
+                }
+            ]
+        });
+    }
+
     function loadMonth(year, month){
         fetch('../php_backend/public/monthly_dashboard.php?year=' + year + '&month=' + month)
             .then(resp => resp.json())
@@ -106,6 +137,7 @@
                 buildChart('tags-chart', 'Tag Totals', data.tags);
                 buildTable('categories-table', data.categories, days);
                 buildChart('categories-chart', 'Category Totals', data.categories);
+                buildDonutChart('category-tag-donut', data.categories, data.tags);
                 buildTable('groups-table', data.groups, days);
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -25,6 +25,9 @@
             <div id="categories-table"></div>
             <div id="categories-chart" style="height:400px"></div>
 
+            <h2>Category & Tag Breakdown</h2>
+            <div id="category-tag-donut" style="height:400px"></div>
+
             <h2>Group Totals</h2>
             <div id="groups-table"></div>
             <div id="groups-chart" style="height:400px"></div>
@@ -80,6 +83,34 @@
         });
     }
 
+    function buildDonutChart(id, categories, tags){
+        Highcharts.chart(id, {
+            chart: { type: 'pie' },
+            title: { text: 'Categories and Tags' },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            plotOptions: {
+                pie: {
+                    dataLabels: {
+                        formatter: function(){ return this.point.name + ': £' + Highcharts.numberFormat(this.y, 2); }
+                    }
+                }
+            },
+            series: [
+                {
+                    name: 'Categories',
+                    data: categories.map(c => ({ name: c.name, y: parseFloat(c.total) })),
+                    size: '60%'
+                },
+                {
+                    name: 'Tags',
+                    data: tags.map(t => ({ name: t.name, y: parseFloat(t.total) })),
+                    size: '80%',
+                    innerSize: '60%'
+                }
+            ]
+        });
+    }
+
     function loadYear(year){
         fetch('../php_backend/public/yearly_dashboard.php?year=' + year)
             .then(resp => resp.json())
@@ -88,6 +119,7 @@
                 buildChart('tags-chart', 'Tag Totals ' + year, data.tags);
                 buildTable('categories-table', data.categories);
                 buildChart('categories-chart', 'Category Totals ' + year, data.categories);
+                buildDonutChart('category-tag-donut', data.categories, data.tags);
                 buildTable('groups-table', data.groups);
                 buildChart('groups-chart', 'Group Totals ' + year, data.groups);
             });


### PR DESCRIPTION
## Summary
- add Category & Tag Breakdown donut chart to monthly, yearly, and all-year dashboards
- show monetary values inside and outside rings via Highcharts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891d3dc61a8832eaeb7ca7302adc295