### PR TITLE
Add category/tag donut charts to dashboards

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -22,6 +22,9 @@
             <div id="categories-table"></div>
             <div id="categories-chart" style="height:400px"></div>
 
+            <h2>Category & Tag Breakdown</h2>
+            <div id="category-tag-donut" style="height:400px"></div>
+
             <h2>Group Totals</h2>
             <div id="groups-table"></div>
             <div id="groups-chart" style="height:400px"></div>
@@ -77,6 +80,42 @@
         });
     }
 
+    function buildDonutChart(id, categories, tags){
+        const colors = Highcharts.getOptions().colors;
+        const categoryData = [];
+        const tagData = [];
+
+        categories.forEach((c, i) => {
+            const color = colors[i % colors.length];
+            categoryData.push({ name: c.name, y: parseFloat(c.total), color });
+
+            tags.filter(t => t.category === c.name).forEach(t => {
+                tagData.push({
+                    name: t.name,
+                    y: parseFloat(t.total),
+                    color: Highcharts.color(color).brighten(0.1).get()
+                });
+            });
+        });
+
+        Highcharts.chart(id, {
+            chart: { type: 'pie' },
+            title: { text: 'Categories and Tags' },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            plotOptions: {
+                pie: {
+                    dataLabels: {
+                        formatter: function(){ return this.point.name + ': £' + Highcharts.numberFormat(this.y, 2); }
+                    }
+                }
+            },
+            series: [
+                { name: 'Categories', data: categoryData, size: '60%', dataLabels: { distance: -30 } },
+                { name: 'Tags', data: tagData, size: '80%', innerSize: '60%' }
+            ]
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
         fetch('../php_backend/public/all_years_dashboard.php')
             .then(resp => resp.json())
@@ -85,6 +124,7 @@
                 buildChart('tags-chart', 'Tag Totals', data.tags);
                 buildTable('categories-table', data.categories, data.years);
                 buildChart('categories-chart', 'Category Totals', data.categories);
+                buildDonutChart('category-tag-donut', data.categories, data.tags);
                 buildTable('groups-table', data.groups, data.years);
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -34,6 +34,9 @@
             <div id="categories-table"></div>
             <div id="categories-chart" style="height:400px"></div>
 
+            <h2>Category & Tag Breakdown</h2>
+            <div id="category-tag-donut" style="height:400px"></div>
+
             <h2>Group Totals</h2>
             <div id="groups-table"></div>
             <div id="groups-chart" style="height:400px"></div>
@@ -89,6 +92,42 @@
         });
     }
 
+    function buildDonutChart(id, categories, tags){
+        const colors = Highcharts.getOptions().colors;
+        const categoryData = [];
+        const tagData = [];
+
+        categories.forEach((c, i) => {
+            const color = colors[i % colors.length];
+            categoryData.push({ name: c.name, y: parseFloat(c.total), color });
+
+            tags.filter(t => t.category === c.name).forEach(t => {
+                tagData.push({
+                    name: t.name,
+                    y: parseFloat(t.total),
+                    color: Highcharts.color(color).brighten(0.1).get()
+                });
+            });
+        });
+
+        Highcharts.chart(id, {
+            chart: { type: 'pie' },
+            title: { text: 'Categories and Tags' },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            plotOptions: {
+                pie: {
+                    dataLabels: {
+                        formatter: function(){ return this.point.name + ': £' + Highcharts.numberFormat(this.y, 2); }
+                    }
+                }
+            },
+            series: [
+                { name: 'Categories', data: categoryData, size: '60%', dataLabels: { distance: -30 } },
+                { name: 'Tags', data: tagData, size: '80%', innerSize: '60%' }
+            ]
+        });
+    }
+
     function loadMonth(year, month){
         fetch('../php_backend/public/monthly_dashboard.php?year=' + year + '&month=' + month)
             .then(resp => resp.json())
@@ -106,6 +145,7 @@
                 buildChart('tags-chart', 'Tag Totals', data.tags);
                 buildTable('categories-table', data.categories, days);
                 buildChart('categories-chart', 'Category Totals', data.categories);
+                buildDonutChart('category-tag-donut', data.categories, data.tags);
                 buildTable('groups-table', data.groups, days);
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -25,6 +25,9 @@
             <div id="categories-table"></div>
             <div id="categories-chart" style="height:400px"></div>
 
+            <h2>Category & Tag Breakdown</h2>
+            <div id="category-tag-donut" style="height:400px"></div>
+
             <h2>Group Totals</h2>
             <div id="groups-table"></div>
             <div id="groups-chart" style="height:400px"></div>
@@ -80,6 +83,42 @@
         });
     }
 
+    function buildDonutChart(id, categories, tags){
+        const colors = Highcharts.getOptions().colors;
+        const categoryData = [];
+        const tagData = [];
+
+        categories.forEach((c, i) => {
+            const color = colors[i % colors.length];
+            categoryData.push({ name: c.name, y: parseFloat(c.total), color });
+
+            tags.filter(t => t.category === c.name).forEach(t => {
+                tagData.push({
+                    name: t.name,
+                    y: parseFloat(t.total),
+                    color: Highcharts.color(color).brighten(0.1).get()
+                });
+            });
+        });
+
+        Highcharts.chart(id, {
+            chart: { type: 'pie' },
+            title: { text: 'Categories and Tags' },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            plotOptions: {
+                pie: {
+                    dataLabels: {
+                        formatter: function(){ return this.point.name + ': £' + Highcharts.numberFormat(this.y, 2); }
+                    }
+                }
+            },
+            series: [
+                { name: 'Categories', data: categoryData, size: '60%', dataLabels: { distance: -30 } },
+                { name: 'Tags', data: tagData, size: '80%', innerSize: '60%' }
+            ]
+        });
+    }
+
     function loadYear(year){
         fetch('../php_backend/public/yearly_dashboard.php?year=' + year)
             .then(resp => resp.json())
@@ -88,6 +127,7 @@
                 buildChart('tags-chart', 'Tag Totals ' + year, data.tags);
                 buildTable('categories-table', data.categories);
                 buildChart('categories-chart', 'Category Totals ' + year, data.categories);
+                buildDonutChart('category-tag-donut', data.categories, data.tags);
                 buildTable('groups-table', data.groups);
                 buildChart('groups-chart', 'Group Totals ' + year, data.groups);
             });

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -264,14 +264,15 @@ class Transaction {
             $dayCases[] = "SUM(CASE WHEN DAY(t.`date`) = $d AND t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `$d`";
         }
 
-        $sql = 'SELECT tg.`name` AS `name`, '
+        $sql = 'SELECT c.`name` AS `category`, tg.`name` AS `name`, '
              . implode(', ', $dayCases)
              . ', SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
              FROM `transactions` t
              JOIN `tags` tg ON t.`tag_id` = tg.`id`
+             JOIN `categories` c ON t.`category_id` = c.`id`
              WHERE MONTH(t.`date`) = :month AND YEAR(t.`date`) = :year
-             GROUP BY tg.`id`, tg.`name`
-             ORDER BY `total` DESC';
+             GROUP BY c.`id`, c.`name`, tg.`id`, tg.`name`
+             ORDER BY c.`name`, `total` DESC';
 
         $stmt = $db->prepare($sql);
         $stmt->execute(['month' => $month, 'year' => $year]);
@@ -343,14 +344,15 @@ class Transaction {
             $monthCases[] = "SUM(CASE WHEN MONTH(t.`date`) = $m AND t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `$m`";
         }
 
-        $sql = 'SELECT tg.`name` AS `name`, '
+        $sql = 'SELECT c.`name` AS `category`, tg.`name` AS `name`, '
              . implode(', ', $monthCases)
              . ', SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
              FROM `transactions` t
              JOIN `tags` tg ON t.`tag_id` = tg.`id`
+             JOIN `categories` c ON t.`category_id` = c.`id`
              WHERE YEAR(t.`date`) = :year
-             GROUP BY tg.`id`, tg.`name`
-             ORDER BY `total` DESC';
+             GROUP BY c.`id`, c.`name`, tg.`id`, tg.`name`
+             ORDER BY c.`name`, `total` DESC';
 
         $stmt = $db->prepare($sql);
         $stmt->execute(['year' => $year]);
@@ -417,13 +419,14 @@ class Transaction {
             $y = (int)$y;
             $yearCases[] = "SUM(CASE WHEN YEAR(t.`date`) = $y AND t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `$y`";
         }
-        $sql = 'SELECT tg.`name` AS `name`, '
+        $sql = 'SELECT c.`name` AS `category`, tg.`name` AS `name`, '
              . implode(', ', $yearCases)
              . ', SUM(CASE WHEN t.`amount` < 0 THEN -t.`amount` ELSE 0 END) AS `total`
              FROM `transactions` t'
              . ' JOIN `tags` tg ON t.`tag_id` = tg.`id`'
-             . ' GROUP BY tg.`id`, tg.`name`'
-             . ' ORDER BY `total` DESC';
+             . ' JOIN `categories` c ON t.`category_id` = c.`id`'
+             . ' GROUP BY c.`id`, c.`name`, tg.`id`, tg.`name`'
+             . ' ORDER BY c.`name`, `total` DESC';
         $stmt = $db->query($sql);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }


### PR DESCRIPTION
## Summary
- add Category & Tag Breakdown donut chart to monthly, yearly, and all-year dashboards
- show monetary values inside and outside rings via Highcharts
- group tag slices under their parent category using shared colors

## Testing
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6891d3dc61a8832eaeb7ca7302adc295