### PR TITLE
Add basic user authentication and management

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This repository now provides a simple PHP implementation for managing accounts and transactions.
 
+## Authentication
+
+A basic login page is available at the project root (`index.php`). Users are stored in a `users` table. After logging in, visit `users.php` to add new users or change your password.
+
+
 ## Specifications
 
 - Highcharts is used for graphs, while Tabulator renders interactive tables.

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -13,4 +13,6 @@
     <li><a href="categories.html"><i class="fa-solid fa-folder-open"></i> Manage Categories</a></li>
     <li><a href="groups.html"><i class="fa-solid fa-users"></i> Manage Groups</a></li>
     <li><a href="logs.html"><i class="fa-solid fa-clipboard-list"></i> View Logs</a></li>
+    <li><a href="../users.php"><i class="fa-solid fa-user"></i> Manage Users</a></li>
+    <li><a href="../logout.php"><i class="fa-solid fa-right-from-bracket"></i> Logout</a></li>
 </ul>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,38 @@
+<?php
+// Simple login page for user authentication.
+session_start();
+require_once __DIR__ . '/php_backend/models/User.php';
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $userId = User::verify($username, $password);
+    if ($userId !== null) {
+        $_SESSION['user_id'] = $userId;
+        header('Location: frontend/index.html');
+        exit;
+    } else {
+        $error = 'Invalid credentials';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <?php if ($error): ?>
+        <p style="color:red;"><?= htmlspecialchars($error) ?></p>
+    <?php endif; ?>
+    <form method="post">
+        <label>Username: <input type="text" name="username"></label><br>
+        <label>Password: <input type="password" name="password"></label><br>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,7 @@
+<?php
+// Log out the current user and redirect to login page.
+session_start();
+session_destroy();
+header('Location: index.php');
+exit;
+?>

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -8,6 +8,7 @@ $db = Database::getConnection();
 $db->exec("SET FOREIGN_KEY_CHECKS=0");
 $dropSql = <<<SQL
 DROP TABLE IF EXISTS logs;
+DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS transactions;
 DROP TABLE IF EXISTS transaction_groups;
 DROP TABLE IF EXISTS category_tags;
@@ -19,6 +20,12 @@ $db->exec($dropSql);
 $db->exec("SET FOREIGN_KEY_CHECKS=1");
 
 $createSql = <<<SQL
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(100) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS accounts (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL

--- a/php_backend/models/User.php
+++ b/php_backend/models/User.php
@@ -1,0 +1,37 @@
+<?php
+// Model for application users with password authentication.
+require_once __DIR__ . '/../Database.php';
+
+class User {
+    public static function create(string $username, string $password): int {
+        $db = Database::getConnection();
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $stmt = $db->prepare('INSERT INTO `users` (`username`, `password`) VALUES (:username, :password)');
+        $stmt->execute(['username' => $username, 'password' => $hash]);
+        return (int)$db->lastInsertId();
+    }
+
+    public static function findByUsername(string $username): ?array {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT `id`, `username`, `password` FROM `users` WHERE `username` = :username');
+        $stmt->execute(['username' => $username]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
+    public static function verify(string $username, string $password): ?int {
+        $user = self::findByUsername($username);
+        if ($user && password_verify($password, $user['password'])) {
+            return (int)$user['id'];
+        }
+        return null;
+    }
+
+    public static function updatePassword(int $id, string $password): bool {
+        $db = Database::getConnection();
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $stmt = $db->prepare('UPDATE `users` SET `password` = :password WHERE `id` = :id');
+        return $stmt->execute(['password' => $hash, 'id' => $id]);
+    }
+}
+?>

--- a/users.php
+++ b/users.php
@@ -1,0 +1,67 @@
+<?php
+// Simple user management page to add users and change passwords.
+session_start();
+require_once __DIR__ . '/php_backend/models/User.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: index.php');
+    exit;
+}
+
+$message = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? '';
+    if ($action === 'add') {
+        $username = $_POST['username'] ?? '';
+        $password = $_POST['password'] ?? '';
+        if ($username && $password) {
+            try {
+                User::create($username, $password);
+                $message = 'User added.';
+            } catch (Exception $e) {
+                $message = 'Error adding user.';
+            }
+        } else {
+            $message = 'Username and password required.';
+        }
+    } elseif ($action === 'update') {
+        $password = $_POST['password'] ?? '';
+        if ($password) {
+            User::updatePassword((int)$_SESSION['user_id'], $password);
+            $message = 'Password updated.';
+        } else {
+            $message = 'Password required.';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>User Management</title>
+</head>
+<body>
+    <h1>User Management</h1>
+    <p><a href="logout.php">Logout</a> | <a href="frontend/index.html">Home</a></p>
+    <?php if ($message): ?>
+        <p><?= htmlspecialchars($message) ?></p>
+    <?php endif; ?>
+
+    <h2>Add User</h2>
+    <form method="post">
+        <input type="hidden" name="action" value="add">
+        <label>Username: <input type="text" name="username"></label><br>
+        <label>Password: <input type="password" name="password"></label><br>
+        <button type="submit">Add User</button>
+    </form>
+
+    <h2>Update Password</h2>
+    <form method="post">
+        <input type="hidden" name="action" value="update">
+        <label>New Password: <input type="password" name="password"></label><br>
+        <button type="submit">Update Password</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce `users` table and model for password-based authentication
- add root login page and user management page for adding users and changing passwords
- link user pages in frontend navigation and document new authentication steps

## Testing
- `php -l php_backend/models/User.php`
- `php -l php_backend/create_tables.php`
- `php -l index.php`
- `php -l users.php`
- `php -l logout.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891d9c7ffa8832eaa77522749a340fc