### PR TITLE
Fix group ID submission from monthly statement

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -166,7 +166,8 @@ form.addEventListener('submit', function(e) {
                         });
                     } else if (field === 'group_id') {
                         function updateGroup(id) {
-                            payload.group_id = id;
+                            // ensure numeric ids are sent to the backend
+                            payload.group_id = id === '' ? '' : parseInt(id, 10);
                             fetch('../php_backend/public/update_transaction.php', {
                                 method: 'POST',
                                 headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Ensure monthly statement sends a numeric `group_id` when updating transactions

## Testing
- `php -l php_backend/public/update_transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6891dad7a6a4832e931d5340088de1cb