### PR TITLE
Auto retag and categorise after tag creation

### DIFF
--- a/php_backend/models/CategoryTag.php
+++ b/php_backend/models/CategoryTag.php
@@ -32,5 +32,19 @@ class CategoryTag {
         $stmt->execute(['acc' => $accountId]);
         return $stmt->rowCount();
     }
+
+    /**
+     * Apply categories to transactions across all accounts based on their tag.
+     * Returns the total number of transactions updated.
+     */
+    public static function applyToAllTransactions(): int {
+        $db = Database::getConnection();
+        $accountIds = $db->query('SELECT `id` FROM `accounts`')->fetchAll(PDO::FETCH_COLUMN);
+        $total = 0;
+        foreach ($accountIds as $accId) {
+            $total += self::applyToAccountTransactions((int)$accId);
+        }
+        return $total;
+    }
 }
 ?>

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -76,5 +76,19 @@ class Tag {
         }
         return $updated;
     }
+
+    /**
+     * Apply tag keywords to transactions across all accounts.
+     * Returns the total number of transactions updated.
+     */
+    public static function applyToAllTransactions(): int {
+        $db = Database::getConnection();
+        $accountIds = $db->query('SELECT `id` FROM `accounts`')->fetchAll(PDO::FETCH_COLUMN);
+        $total = 0;
+        foreach ($accountIds as $accId) {
+            $total += self::applyToAccountTransactions((int)$accId);
+        }
+        return $total;
+    }
 }
 ?>

--- a/php_backend/public/tags.php
+++ b/php_backend/public/tags.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint for creating, listing, updating, and deleting tags.
 require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');
 
@@ -16,8 +17,10 @@ if ($method === 'POST') {
     }
     try {
         $id = Tag::create($name, $keyword);
-        Log::write("Created tag $name");
-        echo json_encode(['id' => $id]);
+        $tagged = Tag::applyToAllTransactions();
+        $categorised = CategoryTag::applyToAllTransactions();
+        Log::write("Created tag $name; retagged $tagged transactions; categorised $categorised transactions");
+        echo json_encode(['id' => $id, 'tagged' => $tagged, 'categorised' => $categorised]);
     } catch (Exception $e) {
         http_response_code(500);
         Log::write('Tag error: ' . $e->getMessage(), 'ERROR');


### PR DESCRIPTION
## Summary
- Reapply tags to every account via new `Tag::applyToAllTransactions` helper.
- Reapply categories across all accounts with `CategoryTag::applyToAllTransactions`.
- Trigger full retag and categorisation automatically whenever a tag is created.

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/models/CategoryTag.php`
- `php -l php_backend/public/tags.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `apt-get update` *(fails: 403  Forbidden)*
- `apt-get install -y mariadb-server` *(fails: Unable to locate package mariadb-server)*

------
https://chatgpt.com/codex/tasks/task_e_6891e5862620832e8db3ba507dcc660a