### PR TITLE
Enable deleting saved reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The monthly statement page (`frontend/monthly_statement.html`) allows selecting 
 
 The frontend also includes a simple reporting page available at `frontend/report.html`.
 It allows running a report to list all transactions filtered by category, tag or group.
+Reports can be saved in the browser for reuse and removed when no longer needed.
 The page sends requests to `php_backend/public/report.php` which returns matching
 transactions as JSON.
 

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -25,8 +25,9 @@
                     <button type="button" id="save-report" class="bg-gray-600 text-white px-4 py-2 rounded">Save Report</button>
                 </div>
             </form>
-            <div class="mt-4">
-                <label class="block">Saved Reports: <select id="saved-reports" class="border p-2 rounded w-full"></select></label>
+            <div class="mt-4 flex items-center space-x-2">
+                <label class="block flex-1">Saved Reports: <select id="saved-reports" class="border p-2 rounded w-full"></select></label>
+                <button type="button" id="delete-report" class="bg-red-600 text-white px-4 py-2 rounded">Delete</button>
             </div>
             <div id="results-grid" class="mt-4"></div>
             <div id="chart" class="mt-6" style="height:400px;"></div>
@@ -82,6 +83,7 @@
             opt.textContent = r.name;
             select.appendChild(opt);
         });
+        document.getElementById('delete-report').disabled = saved.length === 0;
     }
 
     function runReport() {
@@ -168,6 +170,17 @@
         document.getElementById('start').value = r.start || '';
         document.getElementById('end').value = r.end || '';
         runReport();
+    });
+
+    document.getElementById('delete-report').addEventListener('click', function() {
+        const select = document.getElementById('saved-reports');
+        const idx = select.value;
+        if (idx === '') return;
+        const saved = JSON.parse(localStorage.getItem('reports') || '[]');
+        saved.splice(idx, 1);
+        localStorage.setItem('reports', JSON.stringify(saved));
+        loadSavedReports();
+        select.value = '';
     });
 
     loadOptions();


### PR DESCRIPTION
## Summary
- allow users to delete saved reports from `frontend/report.html`
- document saved report deletion in README

## Testing
- `php -l php_backend/public/report.php`


------
https://chatgpt.com/codex/tasks/task_e_6891e5d2e56c832e86a6f6cf90c9ec07