### PR TITLE
Allow deleting transaction groups

### DIFF
--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -45,8 +45,22 @@ async function loadGroups() {
             loadGroups();
             showMessage('Group updated');
         });
+        const del = document.createElement('button');
+        del.textContent = 'Delete';
+        del.className = 'ml-2 bg-red-600 text-white px-2 py-1 rounded';
+        del.addEventListener('click', async () => {
+            if (!confirm('Delete this group?')) return;
+            await fetch('../php_backend/public/groups.php', {
+                method: 'DELETE',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({id: g.id})
+            });
+            loadGroups();
+            showMessage('Group deleted');
+        });
         li.appendChild(span);
         li.appendChild(btn);
+        li.appendChild(del);
         list.appendChild(li);
     });
 }

--- a/php_backend/models/TransactionGroup.php
+++ b/php_backend/models/TransactionGroup.php
@@ -16,6 +16,17 @@ class TransactionGroup {
         $stmt->execute(['id' => $id, 'name' => $name]);
     }
 
+    public static function delete(int $id): bool {
+        $db = Database::getConnection();
+        // clear references from transactions
+        $stmt = $db->prepare('UPDATE transactions SET group_id = NULL WHERE group_id = :id');
+        $stmt->execute(['id' => $id]);
+
+        // delete the group itself
+        $stmt = $db->prepare('DELETE FROM transaction_groups WHERE id = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+
     public static function all(): array {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT id, name FROM transaction_groups ORDER BY id');

--- a/php_backend/public/groups.php
+++ b/php_backend/public/groups.php
@@ -1,5 +1,5 @@
 <?php
-// API endpoint for creating, listing and updating transaction groups.
+// API endpoint for creating, listing, updating, and deleting transaction groups.
 require_once __DIR__ . '/../models/TransactionGroup.php';
 require_once __DIR__ . '/../models/Log.php';
 
@@ -43,6 +43,16 @@ try {
         }
         TransactionGroup::update($id, $name);
         Log::write("Updated group $id");
+        echo json_encode(['status' => 'ok']);
+    } elseif ($method === 'DELETE') {
+        $id = (int)($data['id'] ?? 0);
+        if ($id <= 0) {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID required']);
+            return;
+        }
+        TransactionGroup::delete($id);
+        Log::write("Deleted group $id");
         echo json_encode(['status' => 'ok']);
     } else {
         http_response_code(405);


### PR DESCRIPTION
## Summary
- add ability to delete transaction groups and clear their references from transactions
- expose group deletion via API endpoint
- update groups management page with delete buttons

## Testing
- `php -l php_backend/models/TransactionGroup.php`
- `php -l php_backend/public/groups.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891e64eba34832e8634405c7526059e