### PR TITLE
Add missing tags helper with auto-tag creation

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -10,6 +10,7 @@
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="report.html"><i class="fa-solid fa-table mr-2"></i> Transaction Reports</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="search.html"><i class="fa-solid fa-magnifying-glass mr-2"></i> Search Transactions</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="tags.html"><i class="fa-solid fa-tags mr-2"></i> Manage Tags</a></li>
+    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="missing_tags.html"><i class="fa-solid fa-circle-question mr-2"></i> Missing Tags</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="categories.html"><i class="fa-solid fa-folder-open mr-2"></i> Manage Categories</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="groups.html"><i class="fa-solid fa-users mr-2"></i> Manage Groups</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="logs.html"><i class="fa-solid fa-clipboard-list mr-2"></i> View Logs</a></li>

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Missing Tags</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+</head>
+<body class="bg-gray-50 font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
+        <main class="flex-1 p-6">
+            <h1 class="text-2xl font-semibold mb-4">Missing Tags</h1>
+            <div id="untagged-table"></div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script>
+    let table;
+    async function loadUntagged(){
+        const res = await fetch('../php_backend/public/untagged_transactions.php');
+        const data = await res.json();
+        if (table) {
+            table.setData(data);
+        } else {
+            table = new Tabulator('#untagged-table', {
+                data: data,
+                layout: 'fitColumns',
+                initialSort: [{column:'count', dir:'desc'}],
+                columns: [
+                    { title: 'Description', field: 'description' },
+                    { title: 'Count', field: 'count', hozAlign: 'right' },
+                    { title: 'Action', formatter: () => '<button class="bg-blue-600 text-white px-2 py-1 rounded">Auto Tag</button>', width: 120, align: 'center', cellClick: async (e, cell) => {
+                        const desc = cell.getRow().getData().description;
+                        const name = prompt('Tag Name', desc);
+                        if (!name) return;
+                        await fetch('../php_backend/public/tags.php', {
+                            method: 'POST',
+                            headers: {'Content-Type':'application/json'},
+                            body: JSON.stringify({name: name, keyword: desc})
+                        });
+                        showMessage('Tag created');
+                        loadUntagged();
+                    }}
+                ]
+            });
+        }
+    }
+    loadUntagged();
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -509,5 +509,18 @@ class Transaction {
 
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
+
+    /**
+     * Return descriptions of untagged transactions with occurrence counts.
+     * Results are ordered by most common description first.
+     */
+    public static function getUntaggedCounts(): array {
+        $db = Database::getConnection();
+        $sql = 'SELECT `description`, COUNT(*) AS `count` '
+             . 'FROM `transactions` WHERE `tag_id` IS NULL '
+             . 'GROUP BY `description` ORDER BY `count` DESC';
+        $stmt = $db->query($sql);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }
 ?>

--- a/php_backend/public/untagged_transactions.php
+++ b/php_backend/public/untagged_transactions.php
@@ -1,0 +1,16 @@
+<?php
+// API endpoint returning most common untagged transactions grouped by description.
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+try {
+    $rows = Transaction::getUntaggedCounts();
+    echo json_encode($rows);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Untagged list error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode([]);
+}
+?>


### PR DESCRIPTION
## Summary
- show most common untagged transaction descriptions via new API
- add UI page to create auto tags from missing tag entries

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/untagged_transactions.php`
- `php php_backend/public/untagged_transactions.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891e76e11c8832ebf3b9715704109ed