### PR TITLE
Add manual controls for tagging and categorisation processes

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -12,6 +12,7 @@
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="tags.html"><i class="fa-solid fa-tags mr-2"></i> Manage Tags</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="categories.html"><i class="fa-solid fa-folder-open mr-2"></i> Manage Categories</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="groups.html"><i class="fa-solid fa-users mr-2"></i> Manage Groups</a></li>
+    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="processes.html"><i class="fa-solid fa-gear mr-2"></i> Run Processes</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="logs.html"><i class="fa-solid fa-clipboard-list mr-2"></i> View Logs</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../users.php"><i class="fa-solid fa-user mr-2"></i> Manage Users</a></li>
     <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../logout.php"><i class="fa-solid fa-right-from-bracket mr-2"></i> Logout</a></li>

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!-- Page for manually running tagging and categorisation processes -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Run Processes</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
+        <main class="flex-1 p-6">
+            <h1 class="text-2xl font-semibold mb-4">Run Processes</h1>
+            <div class="space-x-4">
+                <button id="tagging-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Run Tagging</button>
+                <button id="categories-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Apply Categories</button>
+            </div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script>
+    async function run(action){
+        const res = await fetch('../php_backend/public/run_processes.php', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({action})
+        });
+        const data = await res.json();
+        if(data.error){
+            showMessage('Error: ' + data.error);
+            return;
+        }
+        if(action === 'tagging'){
+            showMessage(`Tagged ${data.tagged} transactions`);
+        } else if(action === 'categories') {
+            showMessage(`Categorised ${data.categorised} transactions`);
+        }
+    }
+    document.getElementById('tagging-btn').addEventListener('click', ()=>run('tagging'));
+    document.getElementById('categories-btn').addEventListener('click', ()=>run('categories'));
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/php_backend/public/run_processes.php
+++ b/php_backend/public/run_processes.php
@@ -1,0 +1,46 @@
+<?php
+// API endpoint to manually run tagging and categorisation processes.
+require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/CategoryTag.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if ($method !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$action = $data['action'] ?? '';
+
+try {
+    $response = [];
+    if ($action === 'tagging') {
+        $tagged = Tag::applyToAllTransactions();
+        Log::write("Manual tagging applied to $tagged transactions");
+        $response['tagged'] = $tagged;
+    } elseif ($action === 'categories') {
+        $categorised = CategoryTag::applyToAllTransactions();
+        Log::write("Manual categorisation applied to $categorised transactions");
+        $response['categorised'] = $categorised;
+    } elseif ($action === 'both') {
+        $tagged = Tag::applyToAllTransactions();
+        $categorised = CategoryTag::applyToAllTransactions();
+        Log::write("Manual tagging applied to $tagged transactions; categorised $categorised transactions");
+        $response['tagged'] = $tagged;
+        $response['categorised'] = $categorised;
+    } else {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid action']);
+        exit;
+    }
+    echo json_encode($response);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Run processes error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>


### PR DESCRIPTION
## Summary
- Link new "Run Processes" page from the navigation menu
- Implement endpoint to trigger tagging and categorisation across transactions
- Add frontend page with buttons to manually run tagging or category assignment

## Testing
- `php -l php_backend/public/run_processes.php`
- `php php_backend/public/run_processes.php` *(fails: Method not allowed, no DB configured)*

------
https://chatgpt.com/codex/tasks/task_e_6891e90ddc04832eac211d61d6f86ba0