### PR TITLE
Show only unassigned tags when assigning to categories

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -50,8 +50,12 @@ async function loadCategories() {
         tagBtn.textContent = 'Assign Tag';
         tagBtn.className = 'ml-2 bg-gray-600 text-white px-2 py-1 rounded';
         tagBtn.addEventListener('click', async () => {
-            const resTags = await fetch('../php_backend/public/tags.php');
+            const resTags = await fetch('../php_backend/public/tags.php?unassigned=1');
             const allTags = await resTags.json();
+            if (allTags.length === 0) {
+                showMessage('No unassigned tags available');
+                return;
+            }
             const tagOptions = allTags.map(t => `${t.id}: ${t.name}`).join('\n');
             const tagId = prompt('Select Tag:\n' + tagOptions);
             if (tagId === null) return;

--- a/php_backend/models/CategoryTag.php
+++ b/php_backend/models/CategoryTag.php
@@ -5,7 +5,12 @@ require_once __DIR__ . '/../Database.php';
 class CategoryTag {
     public static function add(int $categoryId, int $tagId): void {
         $db = Database::getConnection();
-        $stmt = $db->prepare('INSERT IGNORE INTO category_tags (category_id, tag_id) VALUES (:category_id, :tag_id)');
+        $check = $db->prepare('SELECT 1 FROM category_tags WHERE tag_id = :tag_id');
+        $check->execute(['tag_id' => $tagId]);
+        if ($check->fetch()) {
+            throw new Exception('Tag is already assigned to a category');
+        }
+        $stmt = $db->prepare('INSERT INTO category_tags (category_id, tag_id) VALUES (:category_id, :tag_id)');
         $stmt->execute(['category_id' => $categoryId, 'tag_id' => $tagId]);
     }
 

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -16,6 +16,19 @@ class Tag {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Retrieve tags that are not assigned to any category.
+     */
+    public static function unassigned(): array {
+        $db = Database::getConnection();
+        $sql = 'SELECT t.id, t.name, t.keyword '
+             . 'FROM tags t '
+             . 'LEFT JOIN category_tags ct ON t.id = ct.tag_id '
+             . 'WHERE ct.tag_id IS NULL';
+        $stmt = $db->query($sql);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
     public static function update(int $id, string $name, ?string $keyword = null): bool {
         $db = Database::getConnection();
         $stmt = $db->prepare('UPDATE `tags` SET `name` = :name, `keyword` = :keyword WHERE `id` = :id');

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -39,9 +39,15 @@ try {
             case 'add_tag':
                 $categoryId = (int)($data['category_id'] ?? 0);
                 $tagId = (int)($data['tag_id'] ?? 0);
-                CategoryTag::add($categoryId, $tagId);
-                Log::write("Added tag $tagId to category $categoryId");
-                echo json_encode(['status' => 'ok']);
+                try {
+                    CategoryTag::add($categoryId, $tagId);
+                    Log::write("Added tag $tagId to category $categoryId");
+                    echo json_encode(['status' => 'ok']);
+                } catch (Exception $e) {
+                    http_response_code(400);
+                    Log::write('Add tag error: ' . $e->getMessage(), 'ERROR');
+                    echo json_encode(['error' => $e->getMessage()]);
+                }
                 break;
             case 'remove_tag':
                 $categoryId = (int)($data['category_id'] ?? 0);

--- a/php_backend/public/tags.php
+++ b/php_backend/public/tags.php
@@ -28,7 +28,11 @@ if ($method === 'POST') {
     }
 } elseif ($method === 'GET') {
     try {
-        echo json_encode(Tag::all());
+        if (isset($_GET['unassigned'])) {
+            echo json_encode(Tag::unassigned());
+        } else {
+            echo json_encode(Tag::all());
+        }
     } catch (Exception $e) {
         http_response_code(500);
         Log::write('Tag error: ' . $e->getMessage(), 'ERROR');


### PR DESCRIPTION
## Summary
- Add backend support to fetch tags not yet assigned to a category
- Restrict tag-category mapping to one category per tag and expose error on duplicates
- Update category management UI to list only unassigned tags when assigning

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/public/tags.php`
- `php -l php_backend/models/CategoryTag.php`
- `php -l php_backend/public/categories.php`


------
https://chatgpt.com/codex/tasks/task_e_6891ec78bb94832e8584145a0095181a