### PR TITLE
Sort missing tag counts numerically

### DIFF
--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -31,7 +31,7 @@
                 initialSort: [{column:'count', dir:'desc'}],
                 columns: [
                     { title: 'Description', field: 'description' },
-                    { title: 'Count', field: 'count', hozAlign: 'right' },
+                    { title: 'Count', field: 'count', hozAlign: 'right', sorter: 'number' },
                     { title: 'Action', formatter: () => '<button class="bg-blue-600 text-white px-2 py-1 rounded">Auto Tag</button>', width: 120, align: 'center', cellClick: async (e, cell) => {
                         const desc = cell.getRow().getData().description;
                         const name = prompt('Tag Name', desc);


### PR DESCRIPTION
## Summary
- Ensure Missing Tags table sorts the Count column numerically

## Testing
- `php -l php_backend/public/untagged_transactions.php`
- `php php_backend/public/untagged_transactions.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891f0fab374832ea779b8c8a6cc9ec7