### PR TITLE
Fix statement tag auto-application and group update scope

### DIFF
--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -71,6 +71,15 @@ class Tag {
     }
 
     /**
+     * Forcefully set a tag's keyword, overwriting any existing value.
+     */
+    public static function setKeyword(int $tagId, string $keyword): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE `tags` SET `keyword` = :kw WHERE `id` = :id');
+        $stmt->execute(['kw' => $keyword, 'id' => $tagId]);
+    }
+
+    /**
      * Apply tag keywords to untagged transactions for a given account.
      * Returns the number of transactions updated.
      */

--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -28,8 +28,12 @@ if (!$transactionId || !$accountId || !$description) {
 }
 
 try {
+    $tagChanged = false;
+    $categoryChanged = false;
+
     if ($categoryId !== null) {
         Transaction::setCategory((int)$transactionId, $categoryId === '' ? null : (int)$categoryId);
+        $categoryChanged = true;
     }
     if ($groupId !== null) {
         Transaction::setGroup((int)$transactionId, $groupId === '' ? null : (int)$groupId);
@@ -39,13 +43,14 @@ try {
             $tagId = Tag::create($tagName, $description);
             Log::write("Created tag $tagName");
         } else {
-            Tag::setKeywordIfMissing((int)$tagId, $description);
+            Tag::setKeyword((int)$tagId, $description);
         }
         Transaction::setTag((int)$transactionId, (int)$tagId);
+        $tagChanged = true;
     }
 
-    $applied = Tag::applyToAccountTransactions((int)$accountId);
-    $categorised = CategoryTag::applyToAccountTransactions((int)$accountId);
+    $applied = $tagChanged ? Tag::applyToAccountTransactions((int)$accountId) : 0;
+    $categorised = ($tagChanged || $categoryChanged) ? CategoryTag::applyToAccountTransactions((int)$accountId) : 0;
 
     echo json_encode([
         'status' => 'ok',

--- a/php_backend/public/update_transaction_tag.php
+++ b/php_backend/public/update_transaction_tag.php
@@ -29,12 +29,10 @@ if (!$transactionId || !$accountId || (!$tagId && !$tagName) || !$description) {
 
 try {
     if (!$tagId && $tagName) {
-
         $tagId = Tag::create($tagName, $description);
         Log::write("Created tag $tagName");
     } else {
-        Tag::setKeywordIfMissing((int)$tagId, $description);
-
+        Tag::setKeyword((int)$tagId, $description);
     }
 
     Transaction::setTag((int)$transactionId, (int)$tagId);


### PR DESCRIPTION
## Summary
- Add a method to forcefully set a tag's keyword
- Apply auto-tagging only when tags change and keep group edits scoped to one transaction

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/public/update_transaction.php`
- `php -l php_backend/public/update_transaction_tag.php`


------
https://chatgpt.com/codex/tasks/task_e_6891f5f06c88832e8c93e4cf2399cf86