### PR TITLE
Organize sidebar menu into sections

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -1,20 +1,49 @@
 <!-- Navigation menu shared across pages -->
 <h2 class="text-xl font-semibold mb-4">Menu</h2>
-<ul class="space-y-2">
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="index.html"><i class="fa-solid fa-house mr-2"></i> Home</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="upload.html"><i class="fa-solid fa-upload mr-2"></i> Upload OFX File</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line mr-2"></i> Yearly Dashboard</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar mr-2"></i> All Years Dashboard</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-2"></i> Monthly Dashboard</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-2"></i> View Monthly Statement</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="report.html"><i class="fa-solid fa-table mr-2"></i> Transaction Reports</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="search.html"><i class="fa-solid fa-magnifying-glass mr-2"></i> Search Transactions</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="tags.html"><i class="fa-solid fa-tags mr-2"></i> Manage Tags</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="missing_tags.html"><i class="fa-solid fa-circle-question mr-2"></i> Missing Tags</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="categories.html"><i class="fa-solid fa-folder-open mr-2"></i> Manage Categories</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="groups.html"><i class="fa-solid fa-users mr-2"></i> Manage Groups</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="processes.html"><i class="fa-solid fa-gear mr-2"></i> Run Processes</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="logs.html"><i class="fa-solid fa-clipboard-list mr-2"></i> View Logs</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../users.php"><i class="fa-solid fa-user mr-2"></i> Manage Users</a></li>
-    <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../logout.php"><i class="fa-solid fa-right-from-bracket mr-2"></i> Logout</a></li>
-</ul>
+<div class="space-y-6">
+  <div>
+    <h3 class="text-lg font-semibold mb-2">Overview</h3>
+    <ul class="space-y-2">
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="index.html"><i class="fa-solid fa-house mr-2"></i> Home</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="upload.html"><i class="fa-solid fa-upload mr-2"></i> Upload OFX File</a></li>
+    </ul>
+  </div>
+
+  <div>
+    <h3 class="text-lg font-semibold mb-2">Dashboards</h3>
+    <ul class="space-y-2">
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line mr-2"></i> Yearly Dashboard</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar mr-2"></i> All Years Dashboard</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-2"></i> Monthly Dashboard</a></li>
+    </ul>
+  </div>
+
+  <div>
+    <h3 class="text-lg font-semibold mb-2">Transactions</h3>
+    <ul class="space-y-2">
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-2"></i> View Monthly Statement</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="report.html"><i class="fa-solid fa-table mr-2"></i> Transaction Reports</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="search.html"><i class="fa-solid fa-magnifying-glass mr-2"></i> Search Transactions</a></li>
+    </ul>
+  </div>
+
+  <div>
+    <h3 class="text-lg font-semibold mb-2">Organisation</h3>
+    <ul class="space-y-2">
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="tags.html"><i class="fa-solid fa-tags mr-2"></i> Manage Tags</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="missing_tags.html"><i class="fa-solid fa-circle-question mr-2"></i> Missing Tags</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="categories.html"><i class="fa-solid fa-folder-open mr-2"></i> Manage Categories</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="groups.html"><i class="fa-solid fa-users mr-2"></i> Manage Groups</a></li>
+    </ul>
+  </div>
+
+  <div>
+    <h3 class="text-lg font-semibold mb-2">Administration</h3>
+    <ul class="space-y-2">
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="processes.html"><i class="fa-solid fa-gear mr-2"></i> Run Processes</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="logs.html"><i class="fa-solid fa-clipboard-list mr-2"></i> View Logs</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../users.php"><i class="fa-solid fa-user mr-2"></i> Manage Users</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../logout.php"><i class="fa-solid fa-right-from-bracket mr-2"></i> Logout</a></li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Group left navigation into Overview, Dashboards, Transactions, Organisation and Administration sections for clearer layout

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_6891fd5c8aec832ebae9688f8846c854