### PR TITLE
Add descriptive text to user pages

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -13,6 +13,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">All Years Dashboard</h1>
+            <p class="mb-4">Compare financial totals across every recorded year.</p>
 
             <h2 class="text-xl font-semibold mt-6 mb-2">Tag Totals</h2>
             <div id="tags-table" class="mt-2"></div>

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -12,6 +12,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Categories</h1>
+            <p class="mb-4">Create categories and assign tags to organise your transactions.</p>
             <form id="category-form" class="space-y-4">
                 <label class="block">Category Name<br><input type="text" id="category-name" class="border p-2 rounded w-full"></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create Category</button>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -12,6 +12,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Groups</h1>
+            <p class="mb-4">Create groups to collect related categories for reporting.</p>
             <form id="group-form" class="space-y-4">
                 <label class="block">Group Name<br><input type="text" id="group-name" class="border p-2 rounded w-full"></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create Group</button>

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -13,6 +13,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Application Logs</h1>
+            <p class="mb-4">Review recent log entries to monitor system activity.</p>
             <div id="logs-grid" class="mt-4"></div>
         </main>
     </div>

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -12,6 +12,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Missing Tags</h1>
+            <p class="mb-4">Identify transactions that have not yet been tagged.</p>
             <div id="untagged-table"></div>
         </main>
     </div>

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -13,6 +13,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Monthly Dashboard</h1>
+            <p class="mb-4">View income and outgoings for a chosen month.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full"></select>
             </label>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -13,6 +13,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Monthly Statement</h1>
+            <p class="mb-4">Select a month to view a detailed list of transactions.</p>
             <form id="statement-form" class="space-y-4">
                 <label for="year" class="block">Year:
                     <select id="year" name="year" class="border p-2 rounded w-full"></select>

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -12,6 +12,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Run Processes</h1>
+            <p class="mb-4">Run background tasks like auto-tagging and category assignment.</p>
             <div class="space-x-4">
                 <button id="tagging-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Run Tagging</button>
                 <button id="categories-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Apply Categories</button>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -13,6 +13,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Transaction Reports</h1>
+            <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria.</p>
             <form id="report-form" class="space-y-4">
                 <label class="block">Category: <select id="category" class="border p-2 rounded w-full"></select></label>
                 <label class="block">Tag: <select id="tag" class="border p-2 rounded w-full"></select></label>

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -13,6 +13,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Search Transactions</h1>
+            <p class="mb-4">Find specific transactions using keywords and view the results below.</p>
             <form id="search-form" class="space-y-4">
                 <input type="text" id="term" placeholder="Search value" class="border p-2 rounded w-full">
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Search</button>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -12,6 +12,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Tags</h1>
+            <p class="mb-4">Create new tags and manage existing ones for categorising transactions.</p>
             <form id="tag-form" class="space-y-4">
                 <label class="block">Tag Name<br><input type="text" id="tag-name" class="border p-2 rounded w-full"></label>
                 <label class="block">Keyword (for auto tagging)<br><input type="text" id="tag-keyword" class="border p-2 rounded w-full"></label>

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -11,6 +11,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Transaction Details</h1>
+            <p class="mb-4">Review or edit the information for a single transaction.</p>
             <div id="transaction-details" class="mt-4"></div>
         </main>
     </div>

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -12,6 +12,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Upload OFX File</h1>
+            <p class="mb-4">Upload an OFX statement from your bank to import transactions.</p>
             <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                 <input type="file" name="ofx_file" accept=".ofx" required class="block w-full">
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -13,6 +13,7 @@
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Yearly Dashboard</h1>
+            <p class="mb-4">Analyse totals for a single year through charts and tables.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full"></select>
             </label>

--- a/index.php
+++ b/index.php
@@ -35,6 +35,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <body class="min-h-screen flex items-center justify-center bg-gray-50 font-sans">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow">
         <h1 class="text-2xl font-semibold mb-4 text-center">Login</h1>
+        <p class="mb-4 text-center">Use your account credentials to sign in and access the finance manager.</p>
         <?php if ($error): ?>
             <p class="mb-4 text-red-500 text-center"><?= htmlspecialchars($error) ?></p>
         <?php endif; ?>

--- a/users.php
+++ b/users.php
@@ -46,6 +46,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <body class="min-h-screen bg-gray-50 font-sans p-6">
     <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow">
         <h1 class="text-2xl font-semibold mb-4">User Management</h1>
+        <p class="mb-4">Add new users or update your password from this page.</p>
         <p class="mb-4"><a href="logout.php" class="text-blue-600 hover:underline">Logout</a> | <a href="frontend/index.html" class="text-blue-600 hover:underline">Home</a></p>
         <?php if ($message): ?>
             <p class="mb-4 text-green-600"><?= htmlspecialchars($message) ?></p>


### PR DESCRIPTION
## Summary
- Explain login and user management pages with brief helper text
- Add introductory descriptions to all dashboard and form pages

## Testing
- `php -l index.php users.php`
- `npx htmlhint frontend/...` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689203117b40832eb5e250ca446cdbed