### PR TITLE
Use Tailwind styling for Tabulator tables

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -32,6 +32,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
     function totalFormatter(cell){
@@ -62,7 +63,7 @@
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
 
-        new Tabulator(el, {
+        tailwindTabulator(el, {
             data: data,
             layout: 'fitColumns',
             columns: columns

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -1,0 +1,14 @@
+function tailwindTabulator(element, options) {
+    options = options || {};
+    const userRowFormatter = options.rowFormatter;
+    options.rowFormatter = function(row) {
+        if (userRowFormatter) userRowFormatter(row);
+        row.getElement().classList.add('odd:bg-white', 'even:bg-gray-50', 'hover:bg-gray-100');
+    };
+    const table = new Tabulator(element, options);
+    const el = table.element;
+    el.classList.add('border', 'border-gray-200', 'rounded', 'bg-white', 'shadow-sm');
+    const header = el.querySelector('.tabulator-header');
+    if (header) header.classList.add('bg-gray-100');
+    return table;
+}

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -19,11 +19,12 @@
 
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
     <script>
     fetch('../php_backend/public/logs.php')
         .then(resp => resp.json())
         .then(data => {
-            new Tabulator('#logs-grid', {
+            tailwindTabulator('#logs-grid', {
                 data: data,
                 layout: 'fitColumns',
                 columns: [

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -17,6 +17,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
     <script>
     let table;
     async function loadUntagged(){
@@ -25,7 +26,7 @@
         if (table) {
             table.setData(data);
         } else {
-            table = new Tabulator('#untagged-table', {
+            table = tailwindTabulator('#untagged-table', {
                 data: data,
                 layout: 'fitColumns',
                 initialSort: [{column:'count', dir:'desc'}],

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -44,6 +44,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
     function totalFormatter(cell){
@@ -74,7 +75,7 @@
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
 
-        new Tabulator(el, {
+        tailwindTabulator(el, {
             data: data,
             layout: 'fitColumns',
             columns: columns

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -27,6 +27,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
 <script>
 const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
@@ -100,7 +101,7 @@ form.addEventListener('submit', function(e) {
         });
         groupOptions.push({ value: '__new', label: 'Add New Group...' });
 
-        new Tabulator('#transactions-grid', {
+        tailwindTabulator('#transactions-grid', {
             data: data,
             layout: 'fitColumns',
             columns: [

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -36,6 +36,7 @@
     <script src="js/menu.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
     <script>
 
     async function loadOptions() {
@@ -108,7 +109,7 @@
                 gridEl.innerHTML = '';
                 chartContainer.innerHTML = '';
                 if (Array.isArray(data) && data.length) {
-                    new Tabulator(gridEl, {
+                    tailwindTabulator(gridEl, {
                         data: data,
                         layout: 'fitColumns',
                         columns: [

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -24,6 +24,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
     function formatCurrency(value) {
@@ -40,7 +41,7 @@
                 const gridEl = document.getElementById('results-grid');
                 gridEl.innerHTML = '';
                 if (data.results && data.results.length) {
-                    new Tabulator(gridEl, {
+                    tailwindTabulator(gridEl, {
                         data: data.results,
                         layout: 'fitColumns',
                         columns: [

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -35,6 +35,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
     function totalFormatter(cell){
@@ -65,7 +66,7 @@
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
 
-        new Tabulator(el, {
+        tailwindTabulator(el, {
             data: data,
             layout: 'fitColumns',
             columns: columns


### PR DESCRIPTION
## Summary
- add reusable `tailwindTabulator` helper to wrap Tabulator tables with Tailwind classes
- load new helper across pages and instantiate tables with it for consistent styling

## Testing
- `node --check frontend/js/tabulator-tailwind.js`

------
https://chatgpt.com/codex/tasks/task_e_689201f67204832eb6ee217535db284e