### PR TITLE
Add popover help for form fields

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -13,7 +13,7 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Categories</h1>
             <form id="category-form" class="space-y-4">
-                <label class="block">Category Name<br><input type="text" id="category-name" class="border p-2 rounded w-full"></label>
+                <label class="block">Category Name<br><input type="text" id="category-name" class="border p-2 rounded w-full" data-help="Name for the category"></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create Category</button>
             </form>
             <h2 class="text-xl font-semibold mt-6 mb-2">Existing Categories</h2>
@@ -21,6 +21,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
     <script>
 async function loadCategories() {
     const res = await fetch('../php_backend/public/categories.php');

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -13,7 +13,7 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Groups</h1>
             <form id="group-form" class="space-y-4">
-                <label class="block">Group Name<br><input type="text" id="group-name" class="border p-2 rounded w-full"></label>
+                <label class="block">Group Name<br><input type="text" id="group-name" class="border p-2 rounded w-full" data-help="Name for the group"></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create Group</button>
             </form>
             <h2 class="text-xl font-semibold mt-6 mb-2">Existing Groups</h2>
@@ -21,6 +21,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
     <script>
 async function loadGroups() {
     const res = await fetch('../php_backend/public/groups.php');

--- a/frontend/js/input_help.js
+++ b/frontend/js/input_help.js
@@ -1,0 +1,26 @@
+// Displays popover help for inputs with a data-help attribute.
+document.addEventListener('DOMContentLoaded', () => {
+    const helpBox = document.createElement('div');
+    helpBox.id = 'input-help';
+    helpBox.className = 'absolute bg-white border p-2 rounded shadow hidden z-50 text-sm';
+    document.body.appendChild(helpBox);
+
+    function showHelp(input) {
+        helpBox.textContent = input.dataset.help;
+        const rect = input.getBoundingClientRect();
+        helpBox.style.left = (rect.left + window.scrollX) + 'px';
+        helpBox.style.top = (rect.bottom + window.scrollY) + 'px';
+        helpBox.classList.remove('hidden');
+    }
+
+    function hideHelp() {
+        helpBox.classList.add('hidden');
+    }
+
+    document.querySelectorAll('input[data-help], select[data-help]').forEach(el => {
+        el.addEventListener('focus', () => showHelp(el));
+        el.addEventListener('blur', hideHelp);
+        el.addEventListener('mouseenter', () => showHelp(el));
+        el.addEventListener('mouseleave', hideHelp);
+    });
+});

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -14,10 +14,10 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Monthly Dashboard</h1>
             <label for="year-select" class="block">Year:
-                <select id="year-select" class="border p-2 rounded w-full"></select>
+                <select id="year-select" class="border p-2 rounded w-full" data-help="Select year"></select>
             </label>
             <label for="month-select" class="block mt-2">Month:
-                <select id="month-select" class="border p-2 rounded w-full"></select>
+                <select id="month-select" class="border p-2 rounded w-full" data-help="Select month"></select>
             </label>
 
             <div id="totals" class="mt-4 space-y-1">
@@ -43,6 +43,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -15,10 +15,10 @@
             <h1 class="text-2xl font-semibold mb-4">Monthly Statement</h1>
             <form id="statement-form" class="space-y-4">
                 <label for="year" class="block">Year:
-                    <select id="year" name="year" class="border p-2 rounded w-full"></select>
+                    <select id="year" name="year" class="border p-2 rounded w-full" data-help="Select year"></select>
                 </label>
                 <label for="month" class="block">Month:
-                    <select id="month" name="month" class="border p-2 rounded w-full"></select>
+                    <select id="month" name="month" class="border p-2 rounded w-full" data-help="Select month"></select>
                 </label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">View</button>
             </form>
@@ -26,6 +26,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
 <script>
 const monthSelect = document.getElementById('month');

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -14,19 +14,19 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Transaction Reports</h1>
             <form id="report-form" class="space-y-4">
-                <label class="block">Category: <select id="category" class="border p-2 rounded w-full"></select></label>
-                <label class="block">Tag: <select id="tag" class="border p-2 rounded w-full"></select></label>
-                <label class="block">Group: <select id="group" class="border p-2 rounded w-full"></select></label>
-                <label class="block">Text: <input type="text" id="text" class="border p-2 rounded w-full"></label>
-                <label class="block">Start Date: <input type="date" id="start" class="border p-2 rounded w-full"></label>
-                <label class="block">End Date: <input type="date" id="end" class="border p-2 rounded w-full"></label>
+                <label class="block">Category: <select id="category" class="border p-2 rounded w-full" data-help="Filter by category"></select></label>
+                <label class="block">Tag: <select id="tag" class="border p-2 rounded w-full" data-help="Filter by tag"></select></label>
+                <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Filter by group"></select></label>
+                <label class="block">Text: <input type="text" id="text" class="border p-2 rounded w-full" data-help="Filter by description text"></label>
+                <label class="block">Start Date: <input type="date" id="start" class="border p-2 rounded w-full" data-help="Start date for report"></label>
+                <label class="block">End Date: <input type="date" id="end" class="border p-2 rounded w-full" data-help="End date for report"></label>
                 <div class="space-x-2">
                     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Run Report</button>
                     <button type="button" id="save-report" class="bg-gray-600 text-white px-4 py-2 rounded">Save Report</button>
                 </div>
             </form>
             <div class="mt-4 flex items-center space-x-2">
-                <label class="block flex-1">Saved Reports: <select id="saved-reports" class="border p-2 rounded w-full"></select></label>
+                <label class="block flex-1">Saved Reports: <select id="saved-reports" class="border p-2 rounded w-full" data-help="Load a saved report"></select></label>
                 <button type="button" id="delete-report" class="bg-red-600 text-white px-4 py-2 rounded">Delete</button>
             </div>
             <div id="results-grid" class="mt-4"></div>
@@ -34,6 +34,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script>

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -14,7 +14,7 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Search Transactions</h1>
             <form id="search-form" class="space-y-4">
-                <input type="text" id="term" placeholder="Search value" class="border p-2 rounded w-full">
+                <input type="text" id="term" placeholder="Search value" class="border p-2 rounded w-full" data-help="Value to search across transactions">
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Search</button>
             </form>
             <div id="results-grid" class="mt-4"></div>
@@ -23,6 +23,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -13,8 +13,8 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Tags</h1>
             <form id="tag-form" class="space-y-4">
-                <label class="block">Tag Name<br><input type="text" id="tag-name" class="border p-2 rounded w-full"></label>
-                <label class="block">Keyword (for auto tagging)<br><input type="text" id="tag-keyword" class="border p-2 rounded w-full"></label>
+                <label class="block">Tag Name<br><input type="text" id="tag-name" class="border p-2 rounded w-full" data-help="Name for the tag"></label>
+                <label class="block">Keyword (for auto tagging)<br><input type="text" id="tag-keyword" class="border p-2 rounded w-full" data-help="Keyword used to auto-tag transactions"></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create Tag</button>
             </form>
             <h2 class="text-xl font-semibold mt-6 mb-2">Existing Tags</h2>
@@ -22,6 +22,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
 <script>
 async function loadTags(){
     const res = await fetch('../php_backend/public/tags.php');

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -15,6 +15,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
     <script>
     const params = new URLSearchParams(window.location.search);
     const id = params.get('id');
@@ -40,9 +41,9 @@
                 <p><strong>Description:</strong> ${tx.description}</p>
                 <p><strong>Memo:</strong> ${tx.memo || ''}</p>
                 <p><strong>Amount:</strong> £${parseFloat(tx.amount).toFixed(2)}</p>
-                <label class="block">Category: <select id="category" class="border p-2 rounded w-full"></select></label>
-                <label class="block">Tag: <select id="tag" class="border p-2 rounded w-full"></select></label>
-                <label class="block">Group: <select id="group" class="border p-2 rounded w-full"></select></label>
+                <label class="block">Category: <select id="category" class="border p-2 rounded w-full" data-help="Assign a category"></select></label>
+                <label class="block">Tag: <select id="tag" class="border p-2 rounded w-full" data-help="Assign a tag"></select></label>
+                <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Assign a group"></select></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Save</button>
             `;
             container.appendChild(form);

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -13,14 +13,14 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Upload OFX File</h1>
             <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data" class="space-y-4">
-                <input type="file" name="ofx_file" accept=".ofx" required class="block w-full">
+                <input type="file" name="ofx_file" accept=".ofx" required class="block w-full" data-help="Select an OFX file to upload">
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
             </form>
         </main>
     </div>
 
     <script src="js/menu.js"></script>
-
+    <script src="js/input_help.js"></script>
     <script src="js/overlay.js"></script>
     <script>
 const uploadForm = document.querySelector("form");

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -14,7 +14,7 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Yearly Dashboard</h1>
             <label for="year-select" class="block">Year:
-                <select id="year-select" class="border p-2 rounded w-full"></select>
+                <select id="year-select" class="border p-2 rounded w-full" data-help="Select year to display"></select>
             </label>
 
             <h2 class="text-xl font-semibold mt-6 mb-2">Tag Totals</h2>
@@ -34,6 +34,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>

--- a/index.php
+++ b/index.php
@@ -40,13 +40,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <?php endif; ?>
         <form method="post" class="space-y-4">
             <label class="block">Username:
-                <input type="text" name="username" class="mt-1 w-full border p-2 rounded">
+                <input type="text" name="username" class="mt-1 w-full border p-2 rounded" data-help="Enter your username">
             </label>
             <label class="block">Password:
-                <input type="password" name="password" class="mt-1 w-full border p-2 rounded">
+                <input type="password" name="password" class="mt-1 w-full border p-2 rounded" data-help="Enter your password">
             </label>
             <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded">Login</button>
         </form>
     </div>
+    <script src="frontend/js/input_help.js"></script>
 </body>
 </html>

--- a/users.php
+++ b/users.php
@@ -54,17 +54,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <h2 class="text-xl font-semibold mt-6 mb-2">Add User</h2>
         <form method="post" class="space-y-4 mb-6">
             <input type="hidden" name="action" value="add">
-            <label class="block">Username: <input type="text" name="username" class="border p-2 rounded w-full"></label>
-            <label class="block">Password: <input type="password" name="password" class="border p-2 rounded w-full"></label>
+            <label class="block">Username: <input type="text" name="username" class="border p-2 rounded w-full" data-help="Choose a username"></label>
+            <label class="block">Password: <input type="password" name="password" class="border p-2 rounded w-full" data-help="Set a password"></label>
             <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Add User</button>
         </form>
 
         <h2 class="text-xl font-semibold mt-6 mb-2">Update Password</h2>
         <form method="post" class="space-y-4">
             <input type="hidden" name="action" value="update">
-            <label class="block">New Password: <input type="password" name="password" class="border p-2 rounded w-full"></label>
+            <label class="block">New Password: <input type="password" name="password" class="border p-2 rounded w-full" data-help="Enter your new password"></label>
             <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Update Password</button>
         </form>
     </div>
+    <script src="frontend/js/input_help.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable `input_help.js` to show popover guidance for inputs and selects
- annotate login, user management, and frontend forms with `data-help` text and include the helper script

## Testing
- `php -l index.php`
- `php -l users.php`
- `node --check frontend/js/input_help.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_6891ff851488832ea4d36c66edf53855