### PR TITLE
Wrap sections in Tailwind cards

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,7 +15,7 @@
             <p>Select an option from the menu to get started.</p>
             <p id="version">Version: loading...</p>
 
-            <section class="mt-8">
+            <section class="mt-8 bg-white p-6 rounded shadow">
                 <h2 class="text-xl font-semibold mb-4">What You Can Do</h2>
                 <ul class="list-disc pl-5 space-y-2">
                     <li>Upload OFX files to import your bank statements.</li>

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -18,4 +18,21 @@ document.addEventListener('DOMContentLoaded', () => {
       })
       .catch(err => console.error('Menu load failed', err));
   }
+
+  // Apply Tailwind card styling to all sections or wrap main content in a card
+  document.querySelectorAll('main').forEach(main => {
+    const sections = main.querySelectorAll('section');
+    if (sections.length > 0) {
+      sections.forEach(section => {
+        section.classList.add('bg-white', 'p-6', 'rounded', 'shadow');
+      });
+    } else {
+      const wrapper = document.createElement('section');
+      wrapper.className = 'bg-white p-6 rounded shadow';
+      while (main.firstChild) {
+        wrapper.appendChild(main.firstChild);
+      }
+      main.appendChild(wrapper);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- style main content sections with Tailwind card classes
- add shared script to apply card styling when section tags are absent

## Testing
- `node -c frontend/js/menu.js && echo "syntax ok"`
- `php -S 0.0.0.0:8000` and `curl http://localhost:8000/frontend/index.html | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68920b010304832ebe7f12b693d2948e