### PR TITLE
Show monthly totals in cards

### DIFF
--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -21,10 +21,19 @@
                 <select id="month-select" class="border p-2 rounded w-full" data-help="Select month"></select>
             </label>
 
-            <div id="totals" class="mt-4 space-y-1">
-                <p>Income: <span id="income-total">£0.00</span></p>
-                <p>Outgoings: <span id="outgoings-total">£0.00</span></p>
-                <p>Delta: <span id="delta-total">£0.00</span></p>
+            <div id="totals" class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div class="bg-white p-4 rounded shadow text-center">
+                    <p class="text-gray-500">Income</p>
+                    <p id="income-total" class="text-3xl font-bold">£0.00</p>
+                </div>
+                <div class="bg-white p-4 rounded shadow text-center">
+                    <p class="text-gray-500">Outgoings</p>
+                    <p id="outgoings-total" class="text-3xl font-bold">£0.00</p>
+                </div>
+                <div class="bg-white p-4 rounded shadow text-center">
+                    <p class="text-gray-500">Delta</p>
+                    <p id="delta-total" class="text-3xl font-bold">£0.00</p>
+                </div>
             </div>
 
             <h2 class="text-xl font-semibold mt-6 mb-2">Tag Totals</h2>
@@ -144,7 +153,7 @@
                 document.getElementById('outgoings-total').textContent = '£' + parseFloat(totals.outgoings).toFixed(2);
                 const deltaEl = document.getElementById('delta-total');
                 deltaEl.textContent = '£' + parseFloat(totals.delta).toFixed(2);
-                deltaEl.className = totals.delta >= 0 ? 'text-green-600' : 'text-red-600';
+                deltaEl.className = (totals.delta >= 0 ? 'text-green-600' : 'text-red-600') + ' text-3xl font-bold';
 
                 const days = new Date(year, month, 0).getDate();
 


### PR DESCRIPTION
## Summary
- Display monthly income, outgoings, and delta as three horizontal cards with prominent values on the dashboard
- Preserve value styling and apply colour coding for delta via JavaScript

## Testing
- `php -S localhost:8000 >/tmp/php-server.log 2>&1 &`
- `curl -I localhost:8000/frontend/monthly_dashboard.html`


------
https://chatgpt.com/codex/tasks/task_e_68920d43a144832ebab076254ef7cdbe