### PR TITLE
Handle bank transfers separately and ignore in reports

### DIFF
--- a/frontend/search.html
+++ b/frontend/search.html
@@ -63,13 +63,17 @@
                     gridEl.innerHTML = 'No transactions found.';
                 }
                 const totalEl = document.getElementById('total');
-                totalEl.textContent = 'Total: ' + formatCurrency(data.total);
+                const total = (data.results || []).reduce((sum, row) => {
+                    return row.transfer_id === null ? sum + parseFloat(row.amount) : sum;
+                }, 0);
+                totalEl.textContent = 'Total: ' + formatCurrency(total);
                 totalEl.classList.add('text-right');
 
                 const chartEl = document.getElementById('monthly-chart');
                 if (data.results && data.results.length) {
                     const monthly = {};
                     data.results.forEach(row => {
+                        if (row.transfer_id !== null) return;
                         const date = row.date.substring(0, 7); // YYYY-MM
                         const amount = parseFloat(row.amount);
                         if (amount < 0) {

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -65,6 +65,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     category_id INT DEFAULT NULL,
     tag_id INT DEFAULT NULL,
     group_id INT DEFAULT NULL,
+    transfer_id INT DEFAULT NULL,
     ofx_id VARCHAR(255) UNIQUE,
     FOREIGN KEY (account_id) REFERENCES accounts(id),
     FOREIGN KEY (category_id) REFERENCES categories(id),
@@ -86,6 +87,12 @@ $db->exec($createSql);
 $result = $db->query("SHOW COLUMNS FROM `tags` LIKE 'keyword'");
 if ($result->rowCount() === 0) {
     $db->exec("ALTER TABLE `tags` ADD COLUMN `keyword` VARCHAR(100) DEFAULT NULL");
+}
+
+// Ensure transfer_id column exists in transactions
+$result = $db->query("SHOW COLUMNS FROM `transactions` LIKE 'transfer_id'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `transactions` ADD COLUMN `transfer_id` INT DEFAULT NULL");
 }
 
 echo "Database tables created.\n";

--- a/php_backend/public/search_transactions.php
+++ b/php_backend/public/search_transactions.php
@@ -17,7 +17,9 @@ try {
     $results = Transaction::search($value);
     $total = 0.0;
     foreach ($results as $row) {
-        $total += (float)$row['amount'];
+        if ($row['transfer_id'] === null) {
+            $total += (float)$row['amount'];
+        }
     }
     echo json_encode(['results' => $results, 'total' => $total]);
 } catch (Exception $e) {


### PR DESCRIPTION
## Summary
- add `transfer_id` column and migration helper
- detect matching debit/credit transactions and assign shared transfer marker
- skip transactions with a transfer marker in spending/reporting queries and search totals
- filter transfer transactions out of client-side search totals and charts

## Testing
- `php -l php_backend/create_tables.php`
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/search_transactions.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68920c8c2208832ea8e593c1e5a9ed8b