### PR TITLE
Enable multiple OFX uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ You can view these entries by opening `frontend/logs.html` which calls the
 `php_backend/public/logs.php` endpoint.
 
 
-To import transactions from an OFX file, use the upload script:
+To import transactions from one or more OFX files, use the upload script:
 ```bash
-curl -F ofx_file=@yourfile.ofx http://localhost/path/to/php_backend/public/upload_ofx.php
+curl -F "ofx_files[]=@first.ofx" -F "ofx_files[]=@second.ofx" http://localhost/path/to/php_backend/public/upload_ofx.php
 ```
 You can try this using the included sample file `sample_data/test.ofx` which
 contains two transactions for a checking account.

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -6,7 +6,7 @@
     <h3 class="text-lg font-semibold mb-2">Overview</h3>
     <ul class="space-y-2">
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="index.html"><i class="fa-solid fa-house mr-2"></i> Home</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="upload.html"><i class="fa-solid fa-upload mr-2"></i> Upload OFX File</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="upload.html"><i class="fa-solid fa-upload mr-2"></i> Upload OFX Files</a></li>
     </ul>
   </div>
 

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -11,10 +11,10 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
         <main class="flex-1 p-6">
-            <h1 class="text-2xl font-semibold mb-4">Upload OFX File</h1>
-            <p class="mb-4">Upload an OFX statement from your bank to import transactions.</p>
+            <h1 class="text-2xl font-semibold mb-4">Upload OFX Files</h1>
+            <p class="mb-4">Upload one or more OFX statements from your bank to import transactions.</p>
             <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data" class="space-y-4">
-                <input type="file" name="ofx_file" accept=".ofx" required class="block w-full" data-help="Select an OFX file to upload">
+                <input type="file" name="ofx_files[]" accept=".ofx" multiple required class="block w-full" data-help="Select one or more OFX files to upload">
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
             </form>
         </main>

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -8,72 +8,82 @@ require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../Database.php';
 
 try {
-    if (!isset($_FILES['ofx_file']) || $_FILES['ofx_file']['error'] !== UPLOAD_ERR_OK) {
+    if (!isset($_FILES['ofx_files'])) {
         http_response_code(400);
-        echo "No file uploaded.";
+        echo "No files uploaded.";
         exit;
     }
 
-    $ofxData = file_get_contents($_FILES['ofx_file']['tmp_name']);
-    if ($ofxData === false) {
-        http_response_code(400);
-        echo "Unable to read uploaded file.";
-        exit;
-    }
-
-// try to get account name from <ACCTID> tag, fallback to 'Default'
-$accountName = 'Default';
-if (preg_match('/<ACCTID>([^\r\n<]+)/i', $ofxData, $m)) {
-    $accountName = trim($m[1]);
-}
-
-$db = Database::getConnection();
-$stmt = $db->prepare('SELECT id FROM accounts WHERE name = :name LIMIT 1');
-$stmt->execute(['name' => $accountName]);
-$account = $stmt->fetch(PDO::FETCH_ASSOC);
-if ($account) {
-    $accountId = (int)$account['id'];
-} else {
-    $accountId = Account::create($accountName);
-}
-
-preg_match_all('/<STMTTRN>(.*?)<\/STMTTRN>/is', $ofxData, $matches);
-$inserted = 0;
-foreach ($matches[1] as $block) {
-    if (preg_match('/<DTPOSTED>([^\r\n<]+)/i', $block, $m)) {
-        $dateStr = substr(trim($m[1]), 0, 8); // YYYYMMDD
-        $date = date('Y-m-d', strtotime($dateStr));
-    } else {
-        continue; // skip invalid entry
-    }
-    if (!preg_match('/<TRNAMT>([^\r\n<]+)/i', $block, $am)) {
-        continue;
-    }
-    $amount = (float)trim($am[1]);
-    $desc = '';
-    $memo = '';
-    if (preg_match('/<NAME>([^\r\n<]+)/i', $block, $dm)) {
-        $desc = trim($dm[1]);
-    }
-    if (preg_match('/<MEMO>([^\r\n<]+)/i', $block, $mm)) {
-        $memo = trim($mm[1]);
-        if ($desc === '') {
-            $desc = $memo;
+    $files = $_FILES['ofx_files'];
+    $messages = [];
+    for ($i = 0; $i < count($files['name']); $i++) {
+        if ($files['error'][$i] !== UPLOAD_ERR_OK) {
+            $messages[] = "No file uploaded for entry " . ($i + 1) . ".";
+            continue;
         }
-    }
-    $ofxId = null;
-    if (preg_match('/<FITID>([^\r\n<]+)/i', $block, $om)) {
-        $ofxId = trim($om[1]);
-    }
-    Transaction::create($accountId, $date, $amount, $desc, $memo, null, null, null, $ofxId);
-    $inserted++;
-}
 
-$tagged = Tag::applyToAccountTransactions($accountId);
-$categorised = CategoryTag::applyToAccountTransactions($accountId);
+        $ofxData = file_get_contents($files['tmp_name'][$i]);
+        if ($ofxData === false) {
+            $messages[] = "Unable to read uploaded file " . $files['name'][$i] . ".";
+            continue;
+        }
 
-    echo "Inserted $inserted transactions for account $accountName. Tagged $tagged transactions. Categorised $categorised transactions.";
-    Log::write("Inserted $inserted transactions for account $accountName; tagged $tagged transactions; categorised $categorised transactions");
+        // try to get account name from <ACCTID> tag, fallback to 'Default'
+        $accountName = 'Default';
+        if (preg_match('/<ACCTID>([^\r\n<]+)/i', $ofxData, $m)) {
+            $accountName = trim($m[1]);
+        }
+
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT id FROM accounts WHERE name = :name LIMIT 1');
+        $stmt->execute(['name' => $accountName]);
+        $account = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($account) {
+            $accountId = (int)$account['id'];
+        } else {
+            $accountId = Account::create($accountName);
+        }
+
+        preg_match_all('/<STMTTRN>(.*?)<\/STMTTRN>/is', $ofxData, $matches);
+        $inserted = 0;
+        foreach ($matches[1] as $block) {
+            if (preg_match('/<DTPOSTED>([^\r\n<]+)/i', $block, $m)) {
+                $dateStr = substr(trim($m[1]), 0, 8); // YYYYMMDD
+                $date = date('Y-m-d', strtotime($dateStr));
+            } else {
+                continue; // skip invalid entry
+            }
+            if (!preg_match('/<TRNAMT>([^\r\n<]+)/i', $block, $am)) {
+                continue;
+            }
+            $amount = (float)trim($am[1]);
+            $desc = '';
+            $memo = '';
+            if (preg_match('/<NAME>([^\r\n<]+)/i', $block, $dm)) {
+                $desc = trim($dm[1]);
+            }
+            if (preg_match('/<MEMO>([^\r\n<]+)/i', $block, $mm)) {
+                $memo = trim($mm[1]);
+                if ($desc === '') {
+                    $desc = $memo;
+                }
+            }
+            $ofxId = null;
+            if (preg_match('/<FITID>([^\r\n<]+)/i', $block, $om)) {
+                $ofxId = trim($om[1]);
+            }
+            Transaction::create($accountId, $date, $amount, $desc, $memo, null, null, null, $ofxId);
+            $inserted++;
+        }
+
+        $tagged = Tag::applyToAccountTransactions($accountId);
+        $categorised = CategoryTag::applyToAccountTransactions($accountId);
+
+        $messages[] = "Inserted $inserted transactions for account $accountName. Tagged $tagged transactions. Categorised $categorised transactions.";
+        Log::write("Inserted $inserted transactions for account $accountName; tagged $tagged transactions; categorised $categorised transactions");
+    }
+
+    echo implode("\n", $messages);
 } catch (Exception $e) {
     http_response_code(500);
     $msg = 'Error: ' . $e->getMessage();


### PR DESCRIPTION
## Summary
- Allow backend upload endpoint to handle multiple OFX files in one request
- Let upload form select multiple files and update menu wording
- Document new curl usage for uploading several files

## Testing
- `php -l php_backend/public/upload_ofx.php`
- `php -S localhost:8000 &` and `curl -F "ofx_files[]=@sample_data/test.ofx" -F "ofx_files[]=@sample_data/test2.ofx" http://localhost:8000/php_backend/public/upload_ofx.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892151774bc832e93abbe373fafae24