### PR TITLE
Style statement form

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -14,15 +14,19 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Monthly Statement</h1>
             <p class="mb-4">Select a month to view a detailed list of transactions.</p>
-            <form id="statement-form" class="space-y-4">
-                <label for="year" class="block">Year:
-                    <select id="year" name="year" class="border p-2 rounded w-full" data-help="Select year"></select>
-                </label>
-                <label for="month" class="block">Month:
-                    <select id="month" name="month" class="border p-2 rounded w-full" data-help="Select month"></select>
-                </label>
-                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">View</button>
-            </form>
+            <div class="bg-white p-6 rounded shadow">
+                <form id="statement-form" class="flex items-end space-x-4">
+                    <div>
+                        <label for="year" class="block text-sm font-medium text-gray-700 mb-1">Year</label>
+                        <select id="year" name="year" class="border p-2 rounded w-32" data-help="Select year"></select>
+                    </div>
+                    <div>
+                        <label for="month" class="block text-sm font-medium text-gray-700 mb-1">Month</label>
+                        <select id="month" name="month" class="border p-2 rounded w-32" data-help="Select month"></select>
+                    </div>
+                    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">View</button>
+                </form>
+            </div>
             <div id="transactions-grid" class="mt-4"></div>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- Display year, month and View button together in a horizontal card on the Monthly Statement page

## Testing
- `tidy -q -e frontend/monthly_statement.html` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)
- `php -S 127.0.0.1:8000` (background) & `curl -I 127.0.0.1:8000/frontend/monthly_statement.html`


------
https://chatgpt.com/codex/tasks/task_e_68921593c304832eab1aa94e6b77c720