### PR TITLE
Arrange transaction report filters in card grid

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -14,14 +14,14 @@
         <main class="flex-1 p-6">
             <h1 class="text-2xl font-semibold mb-4">Transaction Reports</h1>
             <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria.</p>
-            <form id="report-form" class="space-y-4">
+            <form id="report-form" class="bg-white p-4 rounded shadow grid grid-cols-1 md:grid-cols-3 gap-4">
                 <label class="block">Category: <select id="category" class="border p-2 rounded w-full" data-help="Filter by category"></select></label>
                 <label class="block">Tag: <select id="tag" class="border p-2 rounded w-full" data-help="Filter by tag"></select></label>
                 <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Filter by group"></select></label>
                 <label class="block">Text: <input type="text" id="text" class="border p-2 rounded w-full" data-help="Filter by description text"></label>
                 <label class="block">Start Date: <input type="date" id="start" class="border p-2 rounded w-full" data-help="Start date for report"></label>
                 <label class="block">End Date: <input type="date" id="end" class="border p-2 rounded w-full" data-help="End date for report"></label>
-                <div class="space-x-2">
+                <div class="md:col-span-3 space-x-2">
                     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Run Report</button>
                     <button type="button" id="save-report" class="bg-gray-600 text-white px-4 py-2 rounded">Save Report</button>
                 </div>


### PR DESCRIPTION
## Summary
- Lay out transaction report selectors in a two-row grid
- Place filter form inside a card for clearer grouping

## Testing
- `php -l frontend/report.html`


------
https://chatgpt.com/codex/tasks/task_e_689215c4cce4832e8cafe551f13e6103