### PR TITLE
Fix monthly chart data field on graphs page

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -32,7 +32,7 @@
             fetch('../php_backend/public/yearly_dashboard.php?year=' + year).then(r => r.json())
         ]).then(([monthly, yearly]) => {
             const months = monthly.map(m => new Date(0, m.month - 1).toLocaleString('default', { month: 'short' }));
-            const totals = monthly.map(m => parseFloat(m.total));
+            const totals = monthly.map(m => parseFloat(m.spent));
 
             Highcharts.chart('line-chart', {
                 chart: { type: 'line' },


### PR DESCRIPTION
## Summary
- Use `spent` field from dashboard API when mapping monthly totals so Highcharts charts render correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689216317cc4832e840d72bb8e7e810f