### PR TITLE
Add group spending dashboard with charts

### DIFF
--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<!-- Dashboard focused on group spending details -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Group Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+</head>
+<body class="bg-gray-50 font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
+        <main class="flex-1 p-6">
+            <h1 class="text-2xl font-semibold mb-4">Group Dashboard</h1>
+            <p class="mb-4">Review group spending by month and year.</p>
+            <label for="year-select" class="block">Year:
+                <select id="year-select" class="border p-2 rounded w-full" data-help="Select year"></select>
+            </label>
+
+            <h2 class="text-xl font-semibold mt-6 mb-2">Monthly Totals</h2>
+            <div class="bg-white p-6 rounded shadow">
+                <div id="month-table"></div>
+                <div id="month-chart" class="mt-4" style="height:400px"></div>
+            </div>
+
+            <h2 class="text-xl font-semibold mt-6 mb-2">Yearly Totals</h2>
+            <div class="bg-white p-6 rounded shadow">
+                <div id="year-table"></div>
+                <div id="year-chart" class="mt-4" style="height:400px"></div>
+            </div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script>
+    function totalFormatter(cell){
+        const value = cell.getValue();
+        const el = cell.getElement();
+        el.classList.toggle('text-red-600', value < 0);
+        el.classList.toggle('text-green-600', value > 0);
+        return '£' + parseFloat(value).toFixed(2);
+    }
+
+    function buildMonthTable(data){
+        const el = document.getElementById('month-table');
+        el.innerHTML = '';
+        const monthCols = Array.from({length:12}, (_,i) => ({
+            title: new Date(0,i).toLocaleString('default', {month:'short'}),
+            field: String(i+1),
+            formatter: 'money',
+            formatterParams: { symbol: '£', precision: 2 },
+            hozAlign: 'right',
+            bottomCalc: 'sum',
+            bottomCalcFormatter: totalFormatter
+        }));
+        const columns = [
+            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
+            ...monthCols,
+            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
+        ];
+        tailwindTabulator(el, { data, layout: 'fitColumns', columns });
+    }
+
+    function buildYearTable(data, years){
+        const el = document.getElementById('year-table');
+        el.innerHTML = '';
+        const yearCols = years.map(y => ({
+            title: y,
+            field: String(y),
+            formatter: 'money',
+            formatterParams: { symbol: '£', precision: 2 },
+            hozAlign: 'right',
+            bottomCalc: 'sum',
+            bottomCalcFormatter: totalFormatter
+        }));
+        const columns = [
+            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
+            ...yearCols,
+            { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
+        ];
+        tailwindTabulator(el, { data, layout: 'fitColumns', columns });
+    }
+
+    function buildChart(id, title, data){
+        Highcharts.chart(id, {
+            chart: { type: 'column' },
+            title: { text: title },
+            xAxis: { categories: data.map(d => d.name) },
+            yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value,2); } } },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y,2); } },
+            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)) }]
+        });
+    }
+
+    async function load(){
+        const year = document.getElementById('year-select').value;
+        const res = await fetch('../php_backend/public/group_dashboard.php?year=' + year);
+        const data = await res.json();
+        const select = document.getElementById('year-select');
+        if (!select.options.length){
+            data.years.sort((a,b) => b - a).forEach(y => {
+                const opt = document.createElement('option');
+                opt.value = y;
+                opt.textContent = y;
+                select.appendChild(opt);
+            });
+            select.value = data.year;
+        }
+        buildMonthTable(data.byYear);
+        buildChart('month-chart', 'Group Totals ' + data.year, data.byYear);
+        buildYearTable(data.allYears, data.years);
+        buildChart('year-chart', 'Group Totals by Year', data.allYears);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        load();
+        document.getElementById('year-select').addEventListener('change', load);
+    });
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -16,6 +16,7 @@
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line mr-2"></i> Yearly Dashboard</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar mr-2"></i> All Years Dashboard</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-2"></i> Monthly Dashboard</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="group_dashboard.html"><i class="fa-solid fa-users mr-2"></i> Group Dashboard</a></li>
     </ul>
   </div>
 

--- a/php_backend/public/group_dashboard.php
+++ b/php_backend/public/group_dashboard.php
@@ -1,0 +1,24 @@
+<?php
+// API endpoint returning group spending summaries.
+require_once __DIR__ . '/../models/Log.php';
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+$year = isset($_GET['year']) ? (int)$_GET['year'] : date('Y');
+
+try {
+    $years = Transaction::getAvailableYears();
+    $byYear = Transaction::getGroupTotalsByYear($year);
+    $allYears = Transaction::getGroupTotalsByYears($years);
+    echo json_encode([
+        'year' => $year,
+        'years' => $years,
+        'byYear' => $byYear,
+        'allYears' => $allYears
+    ]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- Add API endpoint `group_dashboard.php` providing group totals by month and year
- Create `group_dashboard.html` displaying monthly and yearly tables with Highcharts and Tabulator
- Link new dashboard from navigation menu

## Testing
- `php -l php_backend/public/group_dashboard.php`
- `apt-get update` *(fails: The repository ... InRelease is not signed)*
- `php php_backend/public/group_dashboard.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68921b3555e4832e9798980594ed3230