### PR TITLE
Add memo column to Missing Tags table

### DIFF
--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -33,6 +33,7 @@
                 initialSort: [{column:'count', dir:'desc'}],
                 columns: [
                     { title: 'Description', field: 'description' },
+                    { title: 'Memo', field: 'memo' },
                     { title: 'Count', field: 'count', hozAlign: 'right', sorter: 'number' },
                     { title: 'Action', formatter: () => '<button class="bg-blue-600 text-white px-2 py-1 rounded">Auto Tag</button>', width: 120, align: 'center', cellClick: async (e, cell) => {
                         const desc = cell.getRow().getData().description;

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -536,9 +536,9 @@ class Transaction {
      */
     public static function getUntaggedCounts(): array {
         $db = Database::getConnection();
-        $sql = 'SELECT `description`, COUNT(*) AS `count` '
+        $sql = 'SELECT `description`, `memo`, COUNT(*) AS `count` '
              . 'FROM `transactions` WHERE `tag_id` IS NULL '
-             . 'GROUP BY `description` ORDER BY `count` DESC';
+             . 'GROUP BY `description`, `memo` ORDER BY `count` DESC';
         $stmt = $db->query($sql);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }

--- a/php_backend/public/untagged_transactions.php
+++ b/php_backend/public/untagged_transactions.php
@@ -1,5 +1,5 @@
 <?php
-// API endpoint returning most common untagged transactions grouped by description.
+// API endpoint returning most common untagged transactions grouped by description and memo.
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 


### PR DESCRIPTION
## Summary
- Include memo field when retrieving untagged transaction counts
- Show memo column on Missing Tags page for easier identification
- Update endpoint documentation for new grouping

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/untagged_transactions.php`


------
https://chatgpt.com/codex/tasks/task_e_68921bcbaf14832eabbe9b5d1ee05351