### PR TITLE
Add macOS upload progress bars

### DIFF
--- a/frontend/js/upload.js
+++ b/frontend/js/upload.js
@@ -1,0 +1,63 @@
+function isMacOS(ua) {
+    ua = ua || (typeof navigator !== 'undefined' ? navigator.userAgent : '');
+    return /Mac OS X/i.test(ua);
+}
+
+function initUpload() {
+    const form = document.querySelector('form');
+    if (!form) return;
+    const fileInput = form.querySelector('input[type="file"]');
+    const progressContainer = document.getElementById('progress-container');
+
+    form.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const files = fileInput.files;
+        if (isMacOS()) {
+            progressContainer.innerHTML = '';
+            Array.from(files).forEach((file) => {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'w-full bg-gray-200 rounded h-2';
+                const bar = document.createElement('div');
+                bar.className = 'bg-blue-600 h-2 rounded';
+                bar.style.width = '0%';
+                wrapper.appendChild(bar);
+                progressContainer.appendChild(wrapper);
+
+                const fd = new FormData();
+                fd.append('ofx_files[]', file, file.name);
+
+                const xhr = new XMLHttpRequest();
+                xhr.open('POST', form.action);
+                xhr.upload.onprogress = (evt) => {
+                    if (evt.lengthComputable) {
+                        bar.style.width = (evt.loaded / evt.total * 100) + '%';
+                    }
+                };
+                xhr.onload = () => {
+                    if (xhr.status >= 200 && xhr.status < 300) {
+                        bar.classList.add('bg-green-600');
+                        showMessage(xhr.responseText);
+                    } else {
+                        bar.classList.add('bg-red-600');
+                        showMessage('Upload failed');
+                    }
+                };
+                xhr.send(fd);
+            });
+        } else {
+            const data = new FormData(form);
+            fetch(form.action, { method: 'POST', body: data })
+                .then((resp) => resp.text())
+                .then(showMessage)
+                .catch(() => showMessage('Upload failed'));
+        }
+    });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { isMacOS, initUpload };
+}
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', initUpload);
+}

--- a/frontend/js/upload.test.js
+++ b/frontend/js/upload.test.js
@@ -1,0 +1,7 @@
+const assert = require('assert');
+const { isMacOS } = require('./upload.js');
+
+assert.strictEqual(isMacOS('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'), true);
+assert.strictEqual(isMacOS('Mozilla/5.0 (Windows NT 10.0; Win64; x64)'), false);
+
+console.log('upload.js tests passed');

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -16,6 +16,7 @@
             <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                 <input type="file" name="ofx_files[]" accept=".ofx" multiple required class="block w-full" data-help="Select one or more OFX files to upload">
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>
+                <div id="progress-container" class="space-y-2"></div>
             </form>
         </main>
     </div>
@@ -23,19 +24,6 @@
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="js/overlay.js"></script>
-    <script>
-const uploadForm = document.querySelector("form");
-uploadForm.addEventListener("submit", async (e) => {
-    e.preventDefault();
-    const data = new FormData(uploadForm);
-    try {
-        const resp = await fetch(uploadForm.action, {method: "POST", body: data});
-        const text = await resp.text();
-        showMessage(text);
-    } catch (err) {
-        showMessage("Upload failed");
-    }
-});
-    </script>
+    <script src="js/upload.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show individual upload progress bars when importing OFX files on macOS
- expose macOS detection utility and tests

## Testing
- `node frontend/js/upload.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68921c1f2954832eaa38c29883c27779