### PR TITLE
Add total amount column to missing tags view

### DIFF
--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -35,6 +35,7 @@
                     { title: 'Description', field: 'description' },
                     { title: 'Memo', field: 'memo' },
                     { title: 'Count', field: 'count', hozAlign: 'right', sorter: 'number' },
+                    { title: 'Amount', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
                     { title: 'Action', formatter: () => '<button class="bg-blue-600 text-white px-2 py-1 rounded">Auto Tag</button>', width: 120, align: 'center', cellClick: async (e, cell) => {
                         const desc = cell.getRow().getData().description;
                         const name = prompt('Tag Name', desc);

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -531,12 +531,12 @@ class Transaction {
     }
 
     /**
-     * Return descriptions of untagged transactions with occurrence counts.
+     * Return descriptions of untagged transactions with occurrence counts and totals.
      * Results are ordered by most common description first.
      */
     public static function getUntaggedCounts(): array {
         $db = Database::getConnection();
-        $sql = 'SELECT `description`, `memo`, COUNT(*) AS `count` '
+        $sql = 'SELECT `description`, `memo`, COUNT(*) AS `count`, SUM(`amount`) AS `total` '
              . 'FROM `transactions` WHERE `tag_id` IS NULL '
              . 'GROUP BY `description`, `memo` ORDER BY `count` DESC';
         $stmt = $db->query($sql);


### PR DESCRIPTION
## Summary
- include transaction amount totals in untagged query
- display total spend column in Missing Tags table

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/untagged_transactions.php`


------
https://chatgpt.com/codex/tasks/task_e_689220909cb4832e84d364cb0d340ec7