### PR TITLE
Add account dashboard

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<!-- Dashboard showing account summaries -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Account Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+</head>
+<body class="bg-gray-50 font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
+        <main class="flex-1 p-6">
+            <h1 class="text-2xl font-semibold mb-4">Account Dashboard</h1>
+            <p class="mb-4">Overview of account balances and activity.</p>
+            <div class="bg-white p-6 rounded shadow">
+                <div id="accounts-table"></div>
+                <div id="accounts-chart" class="mt-4" style="height:400px"></div>
+            </div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script>
+    function balanceFormatter(cell){
+        const value = cell.getValue();
+        const el = cell.getElement();
+        el.classList.toggle('text-red-600', value < 0);
+        el.classList.toggle('text-green-600', value > 0);
+        return '£' + parseFloat(value).toFixed(2);
+    }
+
+    fetch('../php_backend/public/account_dashboard.php')
+        .then(resp => resp.json())
+        .then(data => {
+            tailwindTabulator(document.getElementById('accounts-table'), {
+                data,
+                layout: 'fitColumns',
+                columns: [
+                    { title: 'Name', field: 'name' },
+                    { title: 'Transactions', field: 'transactions', hozAlign: 'right' },
+                    { title: 'Balance', field: 'balance', hozAlign: 'right', formatter: balanceFormatter },
+                    { title: 'Last Transaction', field: 'last_transaction' }
+                ]
+            });
+
+            Highcharts.chart('accounts-chart', {
+                chart: { type: 'column' },
+                title: { text: 'Account Balances' },
+                xAxis: { categories: data.map(a => a.name) },
+                yAxis: { title: { text: 'Balance (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
+                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                series: [{ name: 'Balance', data: data.map(a => parseFloat(a.balance)) }]
+            });
+        });
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -17,6 +17,7 @@
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar mr-2"></i> All Years Dashboard</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-2"></i> Monthly Dashboard</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="group_dashboard.html"><i class="fa-solid fa-users mr-2"></i> Group Dashboard</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="account_dashboard.html"><i class="fa-solid fa-wallet mr-2"></i> Account Dashboard</a></li>
     </ul>
   </div>
 

--- a/php_backend/models/Account.php
+++ b/php_backend/models/Account.php
@@ -9,5 +9,21 @@ class Account {
         $stmt->execute(['name' => $name]);
         return (int)$db->lastInsertId();
     }
+
+    /**
+     * Retrieve basic details for all accounts including transaction count and balance.
+     */
+    public static function getSummaries(): array {
+        $db = Database::getConnection();
+        $sql = 'SELECT a.`id`, a.`name`, COUNT(t.`id`) AS `transactions`, '
+             . 'COALESCE(SUM(t.`amount`), 0) AS `balance`, '
+             . 'MAX(t.`date`) AS `last_transaction` '
+             . 'FROM `accounts` a '
+             . 'LEFT JOIN `transactions` t ON t.`account_id` = a.`id` '
+             . 'GROUP BY a.`id`, a.`name` '
+             . 'ORDER BY a.`name`';
+        $stmt = $db->query($sql);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
 }
 ?>

--- a/php_backend/public/account_dashboard.php
+++ b/php_backend/public/account_dashboard.php
@@ -1,0 +1,14 @@
+<?php
+// API endpoint returning account summaries.
+require_once __DIR__ . '/../models/Account.php';
+
+header('Content-Type: application/json');
+
+try {
+    $accounts = Account::getSummaries();
+    echo json_encode($accounts);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- expose account summaries via new backend endpoint
- create account dashboard page with table and chart
- link account dashboard in navigation menu

## Testing
- `php -l php_backend/models/Account.php`
- `php -l php_backend/public/account_dashboard.php`
- `php php_backend/public/account_dashboard.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689222548108832e8db00677c0a252e8