### PR TITLE
Enable Tabulator pagination

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -5,10 +5,14 @@ function tailwindTabulator(element, options) {
         if (userRowFormatter) userRowFormatter(row);
         row.getElement().classList.add('odd:bg-white', 'even:bg-gray-50', 'hover:bg-gray-100');
     };
+    options.pagination = options.pagination || 'local';
+    options.paginationSize = 20;
     const table = new Tabulator(element, options);
     const el = table.element;
     el.classList.add('border', 'border-gray-200', 'rounded', 'bg-white', 'shadow-sm');
     const header = el.querySelector('.tabulator-header');
     if (header) header.classList.add('bg-gray-100');
+    const paginator = el.querySelector('.tabulator-paginator');
+    if (paginator) paginator.classList.add('bg-gray-50', 'border-t', 'border-gray-200', 'p-2');
     return table;
 }


### PR DESCRIPTION
## Summary
- limit Tabulator tables to 20 rows per page and enable local pagination
- apply Tailwind styling to the pagination controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68922532c99c832eb2ab1924652c520e