### PR TITLE
Allow updating transaction groups in statement view

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -119,6 +119,8 @@ form.addEventListener('submit', function(e) {
                 const field = cell.getField();
                 if (field === 'group_id') {
                     const val = cell.getValue();
+                    const oldVal = cell.getOldValue();
+                    if (val === oldVal) return;
                     const data = cell.getRow().getData();
                     const payload = { transaction_id: data.id, account_id: data.account_id, description: data.description };
 
@@ -132,12 +134,12 @@ form.addEventListener('submit', function(e) {
                     .then(res => {
                         if (!(res && res.status === 'ok')) {
                             alert('Failed to save group');
-                            cell.setValue(data.group_id, true);
+                            cell.setValue(oldVal, true);
                         }
                     })
                     .catch(() => {
                         alert('Failed to save group');
-                        cell.setValue(data.group_id, true);
+                        cell.setValue(oldVal, true);
                     });
                 }
             }


### PR DESCRIPTION
## Summary
- Allow group column in monthly statement to be edited with Tabulator's list editor
- Persist group changes via `update_transaction.php` and revert on failure

## Testing
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `php php_backend/public/index.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6892264cb4f4832e94d10c6dfb7b4781