### PR TITLE
Enable amount-based transaction search

### DIFF
--- a/frontend/search.html
+++ b/frontend/search.html
@@ -16,6 +16,7 @@
             <p class="mb-4">Find specific transactions using keywords and view the results below.</p>
             <form id="search-form" class="space-y-4">
                 <input type="text" id="term" placeholder="Search value" class="border p-2 rounded w-full" data-help="Value to search across transactions">
+                <input type="number" step="0.01" id="amount" placeholder="Amount (£)" class="border p-2 rounded w-full" data-help="Exact amount to match">
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Search</button>
             </form>
             <div id="results-grid" class="mt-4"></div>
@@ -36,7 +37,10 @@
     document.getElementById('search-form').addEventListener('submit', function(e){
         e.preventDefault();
         const term = document.getElementById('term').value;
-        const params = new URLSearchParams({value: term});
+        const amount = document.getElementById('amount').value;
+        const params = new URLSearchParams();
+        if (term) params.append('value', term);
+        if (amount) params.append('amount', amount);
         fetch('../php_backend/public/search_transactions.php?' + params.toString())
             .then(resp => resp.json())
             .then(data => {

--- a/php_backend/public/search_transactions.php
+++ b/php_backend/public/search_transactions.php
@@ -6,15 +6,16 @@ require_once __DIR__ . '/../models/Transaction.php';
 header('Content-Type: application/json');
 
 $value = $_GET['value'] ?? '';
+$amount = isset($_GET['amount']) ? $_GET['amount'] : null;
 
-if ($value === '') {
+if ($value === '' && $amount === null) {
     http_response_code(400);
-    echo json_encode(['error' => 'Search value is required']);
+    echo json_encode(['error' => 'Search value or amount is required']);
     exit;
 }
 
 try {
-    $results = Transaction::search($value);
+    $results = Transaction::search($value, $amount !== null ? (float)$amount : null);
     $total = 0.0;
     foreach ($results as $row) {
         if ($row['transfer_id'] === null) {


### PR DESCRIPTION
## Summary
- allow search endpoint to filter by amount
- expand transaction search to accept optional amount parameter
- add amount field and logic to search UI

## Testing
- `php -l php_backend/public/search_transactions.php`
- `php -l php_backend/models/Transaction.php`
- `php -r '$_GET["amount"]="1"; include "php_backend/public/search_transactions.php";'` (fails: SQLSTATE[HY000] [2002] No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689245158f78832ea04cd6d0e39b5ae0