### PR TITLE
Use Tailwind badges for tags, categories, and groups

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -33,7 +33,7 @@ let categoryTable;
 async function loadCategories() {
     const res = await fetch('../php_backend/public/categories.php');
     const cats = await res.json();
-    const data = cats.map(c => ({id: c.id, name: c.name, tags: c.tags.map(t => t.name).join(', ')}));
+    const data = cats.map(c => ({id: c.id, name: c.name, tags: c.tags.map(t => t.name)}));
     if (categoryTable) {
         categoryTable.setData(data);
         return;
@@ -42,8 +42,8 @@ async function loadCategories() {
         data: data,
         layout: 'fitColumns',
         columns: [
-            { title: 'Name', field: 'name' },
-            { title: 'Tags', field: 'tags' },
+            { title: 'Name', field: 'name', formatter: badgeFormatter('bg-green-200 text-green-800') },
+            { title: 'Tags', field: 'tags', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
             { title: 'Actions', formatter: function(cell){
                 const c = cell.getRow().getData();
                 const container = document.createElement('div');

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -41,7 +41,7 @@ async function loadGroups() {
         data: groups,
         layout: 'fitColumns',
         columns: [
-            { title: 'Name', field: 'name' },
+            { title: 'Name', field: 'name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
             { title: 'Actions', formatter: function(cell){
                 const g = cell.getRow().getData();
                 const container = document.createElement('div');

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -1,3 +1,23 @@
+function createBadge(text, colorClasses) {
+    const span = document.createElement('span');
+    span.textContent = text;
+    span.className = `inline-block px-2 py-1 text-xs font-semibold rounded ${colorClasses}`;
+    return span;
+}
+
+function badgeFormatter(colorClasses) {
+    return function (cell) {
+        const value = cell.getValue();
+        if (!value) return '';
+        if (Array.isArray(value)) {
+            const container = document.createElement('div');
+            value.forEach(v => container.appendChild(createBadge(v, colorClasses)));
+            return container;
+        }
+        return createBadge(value, colorClasses);
+    };
+}
+
 function tailwindTabulator(element, options) {
     options = options || {};
     const userRowFormatter = options.rowFormatter;

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -132,14 +132,15 @@ form.addEventListener('submit', function(e) {
                     const id = cell.getRow().getData().id;
                     return `<a href="transaction.html?id=${id}">${cell.getValue()}</a>`;
                 } },
-                { title: 'Category', field: 'category_name' },
+                { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
                 {
                     title: 'Group',
                     field: 'group_id',
                     editor: 'list',
                     editorParams: { values: groupOptions },
                     formatter: function(cell) {
-                        return groupLookup[cell.getValue()] || '';
+                        const name = groupLookup[cell.getValue()] || '';
+                        return name ? createBadge(name, 'bg-purple-200 text-purple-800') : '';
                     }
                 },
                 { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -117,9 +117,9 @@
                         columns: [
                             { title: 'Date', field: 'date' },
                             { title: 'Description', field: 'description', bottomCalc: function() { return 'Total'; } },
-                            { title: 'Category', field: 'category_name' },
-                            { title: 'Tag', field: 'tag_name' },
-                            { title: 'Group', field: 'group_name' },
+                            { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
+                            { title: 'Tag', field: 'tag_name', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
+                            { title: 'Group', field: 'group_name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
                             { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: function(values) { var total = 0; values.forEach(function(value) { total += parseFloat(value) || 0; }); return total; }, bottomCalcFormatter: 'money', bottomCalcFormatterParams: { symbol: '£', precision: 2 } }
                         ]
                     });

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -53,9 +53,9 @@
                                 return `<a href="transaction.html?id=${id}">${cell.getValue()}</a>`;
                             } },
                             { title: 'Memo', field: 'memo' },
-                            { title: 'Category', field: 'category_name' },
-                            { title: 'Tag', field: 'tag_name' },
-                            { title: 'Group', field: 'group_name' },
+                            { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
+                            { title: 'Tag', field: 'tag_name', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
+                            { title: 'Group', field: 'group_name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
                             { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
                         ]
                     });

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -42,7 +42,7 @@ async function loadTags(){
         data: tags,
         layout: 'fitColumns',
         columns: [
-            { title: 'Name', field: 'name' },
+            { title: 'Name', field: 'name', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
             { title: 'Keyword', field: 'keyword' },
             { title: 'Actions', formatter: function(cell){
                 const t = cell.getRow().getData();


### PR DESCRIPTION
## Summary
- add reusable badge utilities for Tailwind-styled labels
- show colored badges for tags, categories, and groups in tables across pages
- display assigned tags as badges in category management

## Testing
- `node --check frontend/js/tabulator-tailwind.js`

------
https://chatgpt.com/codex/tasks/task_e_689245d15504832eb5a164a6bd47ce20