### PR TITLE
Add category series to graphs

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -33,6 +33,10 @@
         ]).then(([monthly, yearly]) => {
             const months = monthly.map(m => new Date(0, m.month - 1).toLocaleString('default', { month: 'short' }));
             const totals = monthly.map(m => parseFloat(m.spent));
+            const categorySeries = yearly.categories.map(c => ({
+                name: c.name,
+                data: months.map((_, i) => parseFloat(c[String(i + 1)]) || 0)
+            }));
 
             Highcharts.chart('line-chart', {
                 chart: { type: 'line' },
@@ -43,7 +47,7 @@
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
                 tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
-                series: [{ name: String(year), data: totals }]
+                series: [{ name: String(year), data: totals }, ...categorySeries]
             });
 
             Highcharts.chart('column-chart', {
@@ -55,7 +59,7 @@
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
                 tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
-                series: [{ name: String(year), data: totals }]
+                series: [{ name: String(year), data: totals }, ...categorySeries]
             });
 
             const cumulative = totals.reduce((acc, val) => {
@@ -63,6 +67,14 @@
                 acc.push(last + val);
                 return acc;
             }, []);
+            const categoryCumulative = categorySeries.map(cs => ({
+                name: cs.name,
+                data: cs.data.reduce((acc, val) => {
+                    const last = acc.length ? acc[acc.length - 1] : 0;
+                    acc.push(last + val);
+                    return acc;
+                }, [])
+            }));
             Highcharts.chart('area-chart', {
                 chart: { type: 'area' },
                 title: { text: 'Cumulative Spending' },
@@ -72,7 +84,7 @@
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
                 tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
-                series: [{ name: String(year), data: cumulative }]
+                series: [{ name: String(year), data: cumulative }, ...categoryCumulative]
             });
 
             const catData = yearly.categories.map(c => ({ name: c.name, y: parseFloat(c.total) }));


### PR DESCRIPTION
## Summary
- Show categories as separate series in line and column graphs
- Add cumulative category series to area graph

## Testing
- `php -l frontend/graphs.html`

------
https://chatgpt.com/codex/tasks/task_e_68924aad525c832e91e0d13a69f808fd