### PR TITLE
Add tag column to monthly statement table

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -133,6 +133,7 @@ form.addEventListener('submit', function(e) {
                     return `<a href="transaction.html?id=${id}">${cell.getValue()}</a>`;
                 } },
                 { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
+                { title: 'Tag', field: 'tag_name', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
                 {
                     title: 'Group',
                     field: 'group_id',


### PR DESCRIPTION
## Summary
- show tags for each transaction in monthly statement table

## Testing
- `php -l frontend/monthly_statement.html`
- `php -l php_backend/public/transactions.php`


------
https://chatgpt.com/codex/tasks/task_e_68924b0e31f8832ebf76acc6914c990d