### PR TITLE
Instant group updates on statement table

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -163,7 +163,9 @@ form.addEventListener('submit', function(e) {
                     })
                     .then(resp => resp.json())
                     .then(res => {
-                        if (!(res && res.status === 'ok')) {
+                        if (res && res.status === 'ok') {
+                            showMessage('Group saved');
+                        } else {
                             alert('Failed to save group');
                             cell.setValue(oldVal, true);
                         }


### PR DESCRIPTION
## Summary
- confirm group updates immediately on the monthly statement table

## Testing
- `node frontend/js/upload.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68927f9f8d00832eb160f675aa8fc8d4