### PR TITLE
Add transfers overview and manual linking

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -34,6 +34,7 @@
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-2"></i> View Monthly Statement</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="report.html"><i class="fa-solid fa-table mr-2"></i> Transaction Reports</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="search.html"><i class="fa-solid fa-magnifying-glass mr-2"></i> Search Transactions</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="transfers.html"><i class="fa-solid fa-right-left mr-2"></i> Transfers</a></li>
     </ul>
   </div>
 

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Account Transfers</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+</head>
+<body class="bg-gray-50 font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
+        <main class="flex-1 p-6 space-y-6">
+            <section>
+                <h1 class="text-2xl font-semibold mb-4">Detected Transfers</h1>
+                <div id="transfers-table"></div>
+            </section>
+            <section>
+                <h2 class="text-xl font-semibold mb-4">Link Transactions as Transfer</h2>
+                <form id="link-form" class="space-y-4">
+                    <input type="number" id="id1" placeholder="First transaction ID" class="border p-2 rounded w-full" data-help="ID of the first transaction">
+                    <input type="number" id="id2" placeholder="Second transaction ID" class="border p-2 rounded w-full" data-help="ID of the matching transaction">
+                    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-link mr-2"></i>Link</button>
+                </form>
+            </section>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
+    <script>
+    fetch('../php_backend/public/transfers.php')
+        .then(resp => resp.json())
+        .then(data => {
+            tailwindTabulator(document.getElementById('transfers-table'), {
+                data: data.transfers,
+                layout: 'fitColumns',
+                columns: [
+                    { title: 'Date', field: 'date' },
+                    { title: 'Description', field: 'description' },
+                    { title: 'From', field: 'from_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.from_id}">${cell.getValue()}</a>`; } },
+                    { title: 'To', field: 'to_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.to_id}">${cell.getValue()}</a>`; } },
+                    { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+                ]
+            });
+        });
+
+    document.getElementById('link-form').addEventListener('submit', function(e){
+        e.preventDefault();
+        const id1 = document.getElementById('id1').value;
+        const id2 = document.getElementById('id2').value;
+        fetch('../php_backend/public/link_transfer.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id1: id1, id2: id2 })
+        })
+        .then(resp => resp.json())
+        .then(res => {
+            if (res.status === 'ok') {
+                location.reload();
+            } else {
+                alert(res.error || 'Failed to link transactions');
+            }
+        });
+    });
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/php_backend/public/link_transfer.php
+++ b/php_backend/public/link_transfer.php
@@ -1,0 +1,35 @@
+<?php
+// API endpoint to manually link two transactions as a transfer.
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$id1 = $data['id1'] ?? null;
+$id2 = $data['id2'] ?? null;
+
+if (!$id1 || !$id2) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Both transaction IDs are required']);
+    exit;
+}
+
+try {
+    if (Transaction::linkTransfer((int)$id1, (int)$id2)) {
+        echo json_encode(['status' => 'ok']);
+    } else {
+        http_response_code(400);
+        echo json_encode(['error' => 'Unable to link transactions']);
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Link transfer error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>

--- a/php_backend/public/transfers.php
+++ b/php_backend/public/transfers.php
@@ -1,0 +1,16 @@
+<?php
+// API endpoint to list all detected transfer pairs.
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+try {
+    $transfers = Transaction::getTransfers();
+    echo json_encode(['transfers' => $transfers]);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Fetch transfers error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>


### PR DESCRIPTION
## Summary
- list transfer pairs with new backend endpoint and model helpers
- provide UI to view detected transfers and link two transactions
- extend navigation with Transfers page

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/transfers.php`
- `php -l php_backend/public/link_transfer.php`
- `php php_backend/public/transfers.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895a83cf430832ebcdc828f0a1a86a4