### PR TITLE
Add monthly budgets with visual tracking

### DIFF
--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<!-- Page for managing monthly category budgets -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Budgets</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+</head>
+<body class="bg-gray-50 font-sans">
+<div class="flex min-h-screen">
+    <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
+    <main class="flex-1 p-6 space-y-6">
+        <h1 class="text-2xl font-semibold mb-4">Budgets</h1>
+        <section>
+            <form id="budget-form" class="md:flex md:space-x-4 space-y-4 md:space-y-0">
+                <label class="block">Month<br><input type="month" id="month" class="border p-2 rounded" data-help="Month for the budget"></label>
+                <label class="block">Category<br><select id="category" class="border p-2 rounded" data-help="Category to assign the budget"></select></label>
+                <label class="block">Amount (£)<br><input type="number" step="0.01" id="amount" class="border p-2 rounded" data-help="Budget amount in pounds"></label>
+                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded self-end">Set Budget</button>
+            </form>
+        </section>
+        <section>
+            <h2 class="text-xl font-semibold mb-4">Current Budgets</h2>
+            <div id="budget-table"></div>
+        </section>
+        <section>
+            <h2 class="text-xl font-semibold mb-4">Budget Progress</h2>
+            <div id="budget-chart" style="height:400px"></div>
+        </section>
+    </main>
+</div>
+<script src="js/menu.js"></script>
+<script src="js/input_help.js"></script>
+<script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+<script src="js/tabulator-tailwind.js"></script>
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script>
+function formatCurrency(value){return '£'+parseFloat(value).toFixed(2);}
+let budgetTable;
+const monthInput=document.getElementById('month');
+monthInput.value=new Date().toISOString().slice(0,7);
+
+async function loadCategories(){
+    const res=await fetch('../php_backend/public/categories.php');
+    const cats=await res.json();
+    const sel=document.getElementById('category');
+    sel.innerHTML='';
+    cats.forEach(c=>{
+        const opt=document.createElement('option');
+        opt.value=c.id; opt.textContent=c.name; sel.appendChild(opt);
+    });
+}
+
+async function loadBudgets(){
+    const [year,month]=monthInput.value.split('-');
+    const res=await fetch(`../php_backend/public/budgets.php?month=${parseInt(month)}&year=${parseInt(year)}`);
+    const data=await res.json();
+    if(budgetTable){budgetTable.setData(data);}else{
+        budgetTable=tailwindTabulator('#budget-table',{
+            data:data,
+            layout:'fitColumns',
+            columns:[
+                {title:'Category',field:'category'},
+                {title:'Budget',field:'amount',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
+                {title:'Spent',field:'spent',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
+                {title:'Left',field:'left',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'}
+            ]
+        });
+    }
+    Highcharts.chart('budget-chart',{
+        chart:{type:'column'},
+        title:{text:''},
+        xAxis:{categories:data.map(b=>b.category)},
+        yAxis:{title:{text:'£'}},
+        series:[
+            {name:'Budget',data:data.map(b=>parseFloat(b.amount))},
+            {name:'Spent',data:data.map(b=>parseFloat(b.spent))}
+        ]
+    });
+}
+
+monthInput.addEventListener('change',loadBudgets);
+
+document.getElementById('budget-form').addEventListener('submit',async e=>{
+    e.preventDefault();
+    const [year,month]=monthInput.value.split('-');
+    const category=document.getElementById('category').value;
+    const amount=document.getElementById('amount').value;
+    await fetch('../php_backend/public/budgets.php',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({category_id:category,amount:amount,month:parseInt(month),year:parseInt(year)})
+    });
+    document.getElementById('amount').value='';
+    loadBudgets();
+    showMessage('Budget saved');
+});
+
+loadCategories().then(loadBudgets);
+</script>
+<script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -29,6 +29,13 @@
   </div>
 
   <div>
+    <h3 class="text-lg font-semibold mb-2">Budgets</h3>
+    <ul class="space-y-2">
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="budgets.html"><i class="fa-solid fa-wallet mr-2"></i> Budgets</a></li>
+    </ul>
+  </div>
+
+  <div>
     <h3 class="text-lg font-semibold mb-2">Transactions</h3>
     <ul class="space-y-2">
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-2"></i> View Monthly Statement</a></li>

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -13,6 +13,7 @@ DROP TABLE IF EXISTS transactions;
 DROP TABLE IF EXISTS transaction_groups;
 DROP TABLE IF EXISTS category_tags;
 DROP TABLE IF EXISTS tags;
+DROP TABLE IF EXISTS budgets;
 DROP TABLE IF EXISTS categories;
 DROP TABLE IF EXISTS accounts;
 SQL;
@@ -34,6 +35,16 @@ CREATE TABLE IF NOT EXISTS accounts (
 CREATE TABLE IF NOT EXISTS categories (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS budgets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    category_id INT NOT NULL,
+    month TINYINT NOT NULL,
+    year INT NOT NULL,
+    amount DECIMAL(10,2) NOT NULL,
+    UNIQUE KEY unique_budget (category_id, month, year),
+    FOREIGN KEY (category_id) REFERENCES categories(id)
 );
 
 CREATE TABLE IF NOT EXISTS tags (

--- a/php_backend/models/Budget.php
+++ b/php_backend/models/Budget.php
@@ -1,0 +1,45 @@
+<?php
+// Model for category budgets by month.
+require_once __DIR__ . '/../Database.php';
+
+class Budget {
+    /**
+     * Create or update a budget for a category for a given month and year.
+     */
+    public static function set(int $categoryId, int $month, int $year, float $amount): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT INTO budgets (category_id, month, year, amount) VALUES (:cid, :month, :year, :amount) '
+            . 'ON DUPLICATE KEY UPDATE amount = VALUES(amount)');
+        $stmt->execute([
+            'cid' => $categoryId,
+            'month' => $month,
+            'year' => $year,
+            'amount' => $amount
+        ]);
+    }
+
+    /**
+     * Retrieve budgets and spending for a given month and year.
+     * Returns category name, budget amount, spent, and remaining.
+     */
+    public static function getMonthly(int $month, int $year): array {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT b.id, b.category_id, c.name AS category, b.amount '
+            . 'FROM budgets b JOIN categories c ON b.category_id = c.id '
+            . 'WHERE b.month = :month AND b.year = :year ORDER BY c.name');
+        $stmt->execute(['month' => $month, 'year' => $year]);
+        $budgets = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $spentStmt = $db->prepare('SELECT COALESCE(SUM(amount),0) FROM transactions '
+            . 'WHERE category_id = :cid AND MONTH(`date`) = :month AND YEAR(`date`) = :year AND transfer_id IS NULL');
+        foreach ($budgets as &$b) {
+            $spentStmt->execute(['cid' => $b['category_id'], 'month' => $month, 'year' => $year]);
+            $total = (float)$spentStmt->fetchColumn();
+            $spent = $total < 0 ? -$total : 0; // expenses are negative amounts
+            $b['spent'] = $spent;
+            $b['left'] = (float)$b['amount'] - $spent;
+        }
+        return $budgets;
+    }
+}
+?>

--- a/php_backend/public/budgets.php
+++ b/php_backend/public/budgets.php
@@ -1,0 +1,46 @@
+<?php
+// API endpoint for managing category budgets.
+require_once __DIR__ . '/../models/Budget.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    $year = isset($_GET['year']) ? (int)$_GET['year'] : (int)date('Y');
+    $month = isset($_GET['month']) ? (int)$_GET['month'] : (int)date('n');
+    try {
+        echo json_encode(Budget::getMonthly($month, $year));
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Budget fetch error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode([]);
+    }
+    return;
+}
+
+if ($method === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true) ?? [];
+    $category = (int)($data['category_id'] ?? 0);
+    $amount = isset($data['amount']) ? (float)$data['amount'] : null;
+    $month = isset($data['month']) ? (int)$data['month'] : (int)date('n');
+    $year = isset($data['year']) ? (int)$data['year'] : (int)date('Y');
+    if ($category <= 0 || $amount === null) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Invalid data']);
+        return;
+    }
+    try {
+        Budget::set($category, $month, $year, $amount);
+        Log::write("Set budget for category $category to $amount");
+        echo json_encode(['status' => 'ok']);
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Budget save error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode(['error' => 'Server error']);
+    }
+    return;
+}
+
+http_response_code(405);
+?>


### PR DESCRIPTION
## Summary
- introduce budgets table and model to store category budgets per month
- provide API endpoints to manage budgets and calculate spending
- add budgets page with Tabulator table and Highcharts progress chart
- add budgets link to navigation menu

## Testing
- `php -l php_backend/models/Budget.php`
- `php -l php_backend/public/budgets.php`
- `php -l php_backend/create_tables.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895e0935288832ebbf8262893e0c00a