### PR TITLE
Ensure statement view group assignments persist

### DIFF
--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -36,7 +36,10 @@ try {
         $categoryChanged = true;
     }
     if ($groupId !== null) {
-        Transaction::setGroup((int)$transactionId, $groupId === '' ? null : (int)$groupId);
+        $saved = Transaction::setGroup((int)$transactionId, $groupId === '' ? null : (int)$groupId);
+        if (!$saved) {
+            throw new Exception('Failed to update group');
+        }
     }
     if ($tagId !== null || $tagName) {
         if (!$tagId && $tagName) {
@@ -55,6 +58,7 @@ try {
     echo json_encode([
         'status' => 'ok',
         'tag_id' => $tagId ? (int)$tagId : null,
+        'group_id' => $groupId === '' ? null : ($groupId !== null ? (int)$groupId : null),
         'auto_tagged' => $applied,
         'auto_categorised' => $categorised
     ]);


### PR DESCRIPTION
## Summary
- Ensure updating a transaction's group from the statement view persists to the database
- Return the updated group identifier from the update API and surface failures

## Testing
- `php -l php_backend/public/update_transaction.php`

------
https://chatgpt.com/codex/tasks/task_e_68960b7e4e6c832e8dabdbccea900a4a