### PR TITLE
Add logging for group selection in statement view

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -165,6 +165,7 @@ form.addEventListener('submit', function(e) {
                     .then(res => {
                         if (res && res.status === 'ok') {
                             showMessage('Group saved');
+                            console.log('Group selected:', val === '' ? 'None' : groupLookup[val], 'for transaction', data.id);
                         } else {
                             alert('Failed to save group');
                             cell.setValue(oldVal, true);

--- a/php_backend/models/TransactionGroup.php
+++ b/php_backend/models/TransactionGroup.php
@@ -27,6 +27,14 @@ class TransactionGroup {
         return $stmt->execute(['id' => $id]);
     }
 
+    public static function find(int $id): ?array {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT id, name FROM transaction_groups WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
+
     public static function all(): array {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT id, name FROM transaction_groups ORDER BY id');

--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';
+require_once __DIR__ . '/../models/TransactionGroup.php';
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
@@ -43,7 +44,13 @@ try {
             Log::write('Failed to update group for transaction ' . $transactionId, 'ERROR');
             throw new Exception('Failed to update group');
         }
-        Log::write('Updated group for transaction ' . $transactionId . ' to ' . ($newGroup === null ? 'NULL' : $newGroup));
+
+        $groupName = 'NULL';
+        if ($newGroup !== null) {
+            $group = TransactionGroup::find($newGroup);
+            $groupName = $group ? $group['name'] : $newGroup;
+        }
+        Log::write('Updated group for transaction ' . $transactionId . ' to ' . $groupName);
 
     }
     if ($tagId !== null || $tagName) {


### PR DESCRIPTION
## Summary
- log selected group in monthly statement view
- include group names in transaction update logging
- add TransactionGroup::find helper

## Testing
- `php -l php_backend/models/TransactionGroup.php`
- `php -l php_backend/public/update_transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6896178dc0c4832eafc068cadf6fcde2