### PR TITLE
feat: add web backup and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ php -S localhost:8000
 Then open `http://localhost:8000/frontend/index.html` in your browser.
 
 
+## Backup and Recovery
+
+Back up and restore your data through the web interface. From the navigation
+menu open **Backup & Restore** under *Administration*. The page lets you
+download a JSON file containing all transactions, categories, tags (and their
+category links), and groups. To restore a backup, choose the JSON file on the
+same page and click **Restore**.
+
 ## Frontend
 
 

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<!-- Page for backing up and restoring data -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Backup & Restore</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-1P4Wf2M1yGvdfq3NzfIgVVP8341/ySfWaSrtwE0NtP28s8Qd8VVS6I5aOQSXgjOaX4nHCqB6f+GO6zkRgLpmMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body class="bg-gray-50 font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
+        <main class="flex-1 p-6 space-y-6">
+            <h1 class="text-2xl font-semibold mb-4">Backup &amp; Restore</h1>
+            <section class="bg-white p-6 rounded shadow space-y-4">
+                <h2 class="text-xl font-semibold">Download Backup</h2>
+                <p>Download all transactions, categories, tags, and groups as a JSON file.</p>
+                <button id="download-backup" class="bg-blue-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-download mr-2"></i>Download</button>
+            </section>
+            <section class="bg-white p-6 rounded shadow space-y-4">
+                <h2 class="text-xl font-semibold">Restore Backup</h2>
+                <p>Select a backup JSON file to restore transactions, categories, tags, and groups.</p>
+                <form id="restore-form" action="../php_backend/public/restore.php" method="POST" enctype="multipart/form-data" class="space-y-4">
+                    <input type="file" id="backup-file" name="backup_file" accept="application/json" required data-help="Choose a previously downloaded backup JSON file">
+                    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-upload mr-2"></i>Restore</button>
+                </form>
+            </section>
+        </main>
+    </div>
+
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="js/overlay.js"></script>
+    <script src="js/backup.js"></script>
+</body>
+</html>

--- a/frontend/js/backup.js
+++ b/frontend/js/backup.js
@@ -1,0 +1,49 @@
+// Handles downloading and restoring backups
+function initBackup() {
+    const dlBtn = document.getElementById('download-backup');
+    const form = document.getElementById('restore-form');
+    if (dlBtn) {
+        dlBtn.addEventListener('click', () => {
+            fetch('../php_backend/public/backup.php')
+                .then(resp => resp.blob())
+                .then(blob => {
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = 'backup.json';
+                    document.body.appendChild(a);
+                    a.click();
+                    document.body.removeChild(a);
+                    URL.revokeObjectURL(url);
+                    if (typeof showMessage !== 'undefined') {
+                        showMessage('Backup downloaded');
+                    }
+                })
+                .catch(() => showMessage && showMessage('Download failed'));
+        });
+    }
+
+    if (form) {
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const fileInput = document.getElementById('backup-file');
+            if (!fileInput.files.length) {
+                return;
+            }
+            const fd = new FormData();
+            fd.append('backup_file', fileInput.files[0]);
+            fetch(form.action, { method: 'POST', body: fd })
+                .then(resp => resp.text())
+                .then(showMessage)
+                .catch(() => showMessage('Restore failed'));
+        });
+    }
+}
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', initBackup);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { initBackup };
+}

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -60,6 +60,7 @@
     <ul class="space-y-2">
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="processes.html"><i class="fa-solid fa-gear mr-2"></i> Run Processes</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="logs.html"><i class="fa-solid fa-clipboard-list mr-2"></i> View Logs</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="backup.html"><i class="fa-solid fa-database mr-2"></i> Backup &amp; Restore</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../users.php"><i class="fa-solid fa-user mr-2"></i> Manage Users</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../logout.php"><i class="fa-solid fa-right-from-bracket mr-2"></i> Logout</a></li>
     </ul>

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -1,0 +1,27 @@
+<?php
+// Exports categories, tags, groups, and transactions as JSON.
+require_once __DIR__ . '/../Database.php';
+
+header('Content-Type: application/json');
+
+try {
+    $db = Database::getConnection();
+
+    $getAll = function(string $sql) use ($db) {
+        $stmt = $db->query($sql);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    };
+
+    $data = [
+        'categories' => $getAll('SELECT id, name FROM categories ORDER BY id'),
+        'tags' => $getAll('SELECT id, name, keyword FROM tags ORDER BY id'),
+        'category_tags' => $getAll('SELECT category_id, tag_id FROM category_tags ORDER BY category_id, tag_id'),
+        'groups' => $getAll('SELECT id, name FROM transaction_groups ORDER BY id'),
+        'transactions' => $getAll('SELECT id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id FROM transactions ORDER BY id')
+    ];
+
+    echo json_encode($data);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -1,0 +1,70 @@
+<?php
+// Restores categories, tags, groups, and transactions from an uploaded JSON backup.
+require_once __DIR__ . '/../Database.php';
+
+try {
+    if (!isset($_FILES['backup_file']) || $_FILES['backup_file']['error'] !== UPLOAD_ERR_OK) {
+        http_response_code(400);
+        echo 'No backup file uploaded.';
+        exit;
+    }
+
+    $json = file_get_contents($_FILES['backup_file']['tmp_name']);
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        http_response_code(400);
+        echo 'Invalid backup data.';
+        exit;
+    }
+
+    $db = Database::getConnection();
+    $db->exec('SET FOREIGN_KEY_CHECKS=0');
+    $db->exec('TRUNCATE TABLE category_tags');
+    $db->exec('TRUNCATE TABLE transactions');
+    $db->exec('TRUNCATE TABLE tags');
+    $db->exec('TRUNCATE TABLE categories');
+    $db->exec('TRUNCATE TABLE transaction_groups');
+    $db->exec('SET FOREIGN_KEY_CHECKS=1');
+
+    $stmtCat = $db->prepare('INSERT INTO categories (id, name) VALUES (:id, :name)');
+    foreach ($data['categories'] as $row) {
+        $stmtCat->execute(['id' => $row['id'], 'name' => $row['name']]);
+    }
+
+    $stmtTag = $db->prepare('INSERT INTO tags (id, name, keyword) VALUES (:id, :name, :keyword)');
+    foreach ($data['tags'] as $row) {
+        $stmtTag->execute(['id' => $row['id'], 'name' => $row['name'], 'keyword' => $row['keyword']]);
+    }
+
+    $stmtGrp = $db->prepare('INSERT INTO transaction_groups (id, name) VALUES (:id, :name)');
+    foreach ($data['groups'] as $row) {
+        $stmtGrp->execute(['id' => $row['id'], 'name' => $row['name']]);
+    }
+
+    $stmtTx = $db->prepare('INSERT INTO transactions (id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id) VALUES (:id, :account_id, :date, :amount, :description, :memo, :category_id, :tag_id, :group_id, :transfer_id, :ofx_id)');
+    foreach ($data['transactions'] as $row) {
+        $stmtTx->execute([
+            'id' => $row['id'],
+            'account_id' => $row['account_id'],
+            'date' => $row['date'],
+            'amount' => $row['amount'],
+            'description' => $row['description'],
+            'memo' => $row['memo'],
+            'category_id' => $row['category_id'],
+            'tag_id' => $row['tag_id'],
+            'group_id' => $row['group_id'],
+            'transfer_id' => $row['transfer_id'],
+            'ofx_id' => $row['ofx_id']
+        ]);
+    }
+
+    $stmtCT = $db->prepare('INSERT INTO category_tags (category_id, tag_id) VALUES (:category_id, :tag_id)');
+    foreach ($data['category_tags'] as $row) {
+        $stmtCT->execute(['category_id' => $row['category_id'], 'tag_id' => $row['tag_id']]);
+    }
+
+    echo 'Restore complete.';
+} catch (Exception $e) {
+    http_response_code(500);
+    echo 'Error: ' . $e->getMessage();
+}


### PR DESCRIPTION
## Summary
- add PHP endpoints to export and restore transactions, categories, tags and groups
- introduce a Backup & Restore page with download and upload features
- document how to use the new web backup system

## Testing
- `php -l php_backend/public/backup.php`
- `php -l php_backend/public/restore.php`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68961ad9fa20832e9a8b6d5e2f70907c