### PR TITLE
Improve transaction table editing UX and validation

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -7,6 +7,7 @@
     <title>Monthly Statement</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -41,7 +42,13 @@
                     <p id="delta-total" class="text-3xl font-bold">£0.00</p>
                 </div>
             </div>
-            <div id="transactions-grid" class="mt-4"></div>
+            <div class="bg-white p-6 rounded shadow mt-4">
+                <div class="flex space-x-2 mb-2">
+                    <button id="undo-btn" class="bg-gray-200 px-2 py-1 rounded" type="button"><i class="fas fa-undo"></i></button>
+                    <button id="redo-btn" class="bg-gray-200 px-2 py-1 rounded" type="button"><i class="fas fa-redo"></i></button>
+                </div>
+                <div id="transactions-grid"></div>
+            </div>
         </main>
     </div>
     <script src="js/menu.js"></script>
@@ -53,6 +60,7 @@ const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
 let groupOptions = [];
 let groupLookup = {};
+const savingRows = new Set();
 
 fetch('../php_backend/public/transaction_months.php')
     .then(resp => resp.json())
@@ -123,9 +131,10 @@ form.addEventListener('submit', function(e) {
         deltaEl.textContent = '£' + delta.toFixed(2);
         deltaEl.className = (delta >= 0 ? 'text-green-600' : 'text-red-600') + ' text-3xl font-bold';
 
-        tailwindTabulator('#transactions-grid', {
+        const table = tailwindTabulator('#transactions-grid', {
             data: data,
             layout: 'fitColumns',
+            history: true,
             columns: [
                 { title: 'Date', field: 'date' },
                 { title: 'Description', field: 'description', formatter: function(cell) {
@@ -139,6 +148,16 @@ form.addEventListener('submit', function(e) {
                     field: 'group_id',
                     editor: 'list',
                     editorParams: { values: groupOptions },
+                    editable: function(cell){
+                        const data = cell.getRow().getData();
+                        return data.transfer_id === null && !savingRows.has(data.id);
+                    },
+                    validator: function(cell, value){
+                        return value === '' || groupLookup.hasOwnProperty(value);
+                    },
+                    validationFailed: function(cell){
+                        showMessage('Invalid group selection');
+                    },
                     formatter: function(cell) {
                         const name = groupLookup[cell.getValue()] || '';
                         return name ? createBadge(name, 'bg-purple-200 text-purple-800') : '';
@@ -146,7 +165,14 @@ form.addEventListener('submit', function(e) {
                 },
                 { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
             ],
+            cellEditing: function(cell){
+                cell.getElement().classList.add('bg-yellow-100');
+            },
+            cellEditCancelled: function(cell){
+                cell.getElement().classList.remove('bg-yellow-100');
+            },
             cellEdited: function(cell) {
+                cell.getElement().classList.remove('bg-yellow-100');
                 const field = cell.getField();
                 if (field === 'group_id') {
                     const val = cell.getValue();
@@ -156,6 +182,9 @@ form.addEventListener('submit', function(e) {
                     const payload = { transaction_id: data.id, account_id: data.account_id, description: data.description };
 
                     payload.group_id = val === '' ? '' : parseInt(val, 10);
+                    savingRows.add(data.id);
+                    const el = cell.getElement();
+                    el.classList.add('opacity-50', 'pointer-events-none');
                     fetch('../php_backend/public/update_transaction.php', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
@@ -167,17 +196,23 @@ form.addEventListener('submit', function(e) {
                             showMessage('Group saved');
                             console.log('Group selected:', val === '' ? 'None' : groupLookup[val], 'for transaction', data.id);
                         } else {
-                            alert('Failed to save group');
+                            showMessage('Failed to save group');
                             cell.setValue(oldVal, true);
                         }
                     })
                     .catch(() => {
-                        alert('Failed to save group');
+                        showMessage('Failed to save group');
                         cell.setValue(oldVal, true);
+                    })
+                    .finally(() => {
+                        savingRows.delete(data.id);
+                        el.classList.remove('opacity-50', 'pointer-events-none');
                     });
                 }
             }
         });
+        document.getElementById('undo-btn').addEventListener('click', () => table.undo());
+        document.getElementById('redo-btn').addEventListener('click', () => table.redo());
 
     });
 });


### PR DESCRIPTION
## Summary
- add Font Awesome and wrap transaction table with undo/redo controls
- validate and conditionally enable group editing, including async save feedback
- enable Tabulator history for undo/redo actions

## Testing
- `npm test` *(fails: package.json missing)*
- `php -l php_backend/public/update_transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_68961e640db4832ea9e01b56f72c8dc0