### PR TITLE
Add debug logging for transaction group updates

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -182,6 +182,7 @@ form.addEventListener('submit', function(e) {
                     const payload = { transaction_id: data.id, account_id: data.account_id, description: data.description };
 
                     payload.group_id = val === '' ? '' : parseInt(val, 10);
+                    console.log('Sending update payload', payload);
                     savingRows.add(data.id);
                     const el = cell.getElement();
                     el.classList.add('opacity-50', 'pointer-events-none');
@@ -190,8 +191,12 @@ form.addEventListener('submit', function(e) {
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify(payload)
                     })
-                    .then(resp => resp.json())
+                    .then(resp => {
+                        console.log('Update response status', resp.status);
+                        return resp.json();
+                    })
                     .then(res => {
+                        console.log('Update response body', res);
                         if (res && res.status === 'ok') {
                             showMessage('Group saved');
                             console.log('Group selected:', val === '' ? 'None' : groupLookup[val], 'for transaction', data.id);
@@ -200,7 +205,8 @@ form.addEventListener('submit', function(e) {
                             cell.setValue(oldVal, true);
                         }
                     })
-                    .catch(() => {
+                    .catch(err => {
+                        console.error('Update request failed', err);
                         showMessage('Failed to save group');
                         cell.setValue(oldVal, true);
                     })

--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -14,6 +14,7 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 $data = json_decode(file_get_contents('php://input'), true);
+Log::write('update_transaction payload: ' . json_encode($data));
 $transactionId = $data['transaction_id'] ?? null;
 $accountId = $data['account_id'] ?? null;
 $description = $data['description'] ?? null;
@@ -39,7 +40,9 @@ try {
     if ($groupId !== null) {
 
         $newGroup = $groupId === '' ? null : (int)$groupId;
+        Log::write('Attempting group update for transaction ' . $transactionId . ' to ' . ($newGroup === null ? 'NULL' : $newGroup));
         $saved = Transaction::setGroup((int)$transactionId, $newGroup);
+        Log::write('setGroup result for transaction ' . $transactionId . ': ' . ($saved ? 'success' : 'failure'));
         if (!$saved) {
             Log::write('Failed to update group for transaction ' . $transactionId, 'ERROR');
             throw new Exception('Failed to update group');


### PR DESCRIPTION
## Summary
- log update payloads and results in `update_transaction.php`
- trace frontend group edits with detailed console logs in `monthly_statement.html`

## Testing
- `php -l php_backend/public/update_transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_68962bb9f70c832e8aaf41a13f4b0dba