### PR TITLE
Add explanatory comments for all page functions

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -26,6 +26,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    // Format balance cells with currency and positive/negative colouring
     function balanceFormatter(cell){
         const value = cell.getValue();
         const el = cell.getElement();

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -39,6 +39,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    // Format totals with currency and colour
     function totalFormatter(cell){
         const value = cell.getValue();
         const el = cell.getElement();
@@ -47,6 +48,7 @@
         return '£' + parseFloat(value).toFixed(2);
     }
 
+    // Render a table with yearly totals across multiple years
     function buildTable(id, data, years){
         const el = document.getElementById(id);
         el.innerHTML = '';
@@ -74,6 +76,7 @@
         });
     }
 
+    // Draw a column chart summarising totals
     function buildChart(id, title, data){
         Highcharts.chart(id, {
             chart: { type: 'column' },
@@ -85,10 +88,12 @@
         });
     }
 
+    // Build nested donut charts for categories and tags across all years
     function buildDonutCharts(incomeId, outgoingsId, categories, tags){
 
         const colors = Highcharts.getOptions().colors;
 
+        // Assemble chart data for either income or outgoing values
         function createData(isIncome){
             const categoryData = [];
             const tagData = [];
@@ -111,6 +116,7 @@
             return { categoryData, tagData };
         }
 
+        // Render a donut chart into a container
         function render(id, title, data){
             Highcharts.chart(id, {
                 chart: { type: 'pie' },

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -37,11 +37,13 @@
 <script src="js/tabulator-tailwind.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script>
+// Format a number as currency with a pound symbol
 function formatCurrency(value){return '£'+parseFloat(value).toFixed(2);}
 let budgetTable;
 const monthInput=document.getElementById('month');
 monthInput.value=new Date().toISOString().slice(0,7);
 
+// Populate the category select with options from the server
 async function loadCategories(){
     const res=await fetch('../php_backend/public/categories.php');
     const cats=await res.json();
@@ -53,6 +55,7 @@ async function loadCategories(){
     });
 }
 
+// Fetch and display budgets for the selected month
 async function loadBudgets(){
     const [year,month]=monthInput.value.split('-');
     const res=await fetch(`../php_backend/public/budgets.php?month=${parseInt(month)}&year=${parseInt(year)}`);

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -30,6 +30,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script>
 let categoryTable;
+// Fetch categories and render them with their tags
 async function loadCategories() {
     const res = await fetch('../php_backend/public/categories.php');
     const cats = await res.json();

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -26,6 +26,7 @@
     <script src="js/menu.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    // Retrieve data for the chosen year and draw a variety of charts
     function loadYear(year){
         Promise.all([
             fetch('../php_backend/public/dashboard.php?year=' + year).then(r => r.json()),

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -37,6 +37,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    // Format totals with currency and highlight positive/negative values
     function totalFormatter(cell){
         const value = cell.getValue();
         const el = cell.getElement();
@@ -45,6 +46,7 @@
         return '£' + parseFloat(value).toFixed(2);
     }
 
+    // Render a table of monthly totals for each group
     function buildMonthTable(data){
         const el = document.getElementById('month-table');
         el.innerHTML = '';
@@ -65,6 +67,7 @@
         tailwindTabulator(el, { data, layout: 'fitColumns', columns });
     }
 
+    // Render a table of yearly totals for each group
     function buildYearTable(data, years){
         const el = document.getElementById('year-table');
         el.innerHTML = '';
@@ -85,6 +88,7 @@
         tailwindTabulator(el, { data, layout: 'fitColumns', columns });
     }
 
+    // Create a column chart for the supplied dataset
     function buildChart(id, title, data){
         Highcharts.chart(id, {
             chart: { type: 'column' },
@@ -96,6 +100,7 @@
         });
     }
 
+    // Fetch dashboard data for the selected year and populate tables and charts
     async function load(){
         const year = document.getElementById('year-select').value;
         const res = await fetch('../php_backend/public/group_dashboard.php?year=' + year);

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -30,6 +30,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script>
 let groupTable;
+// Fetch groups from the server and render them in the table
 async function loadGroups() {
     const res = await fetch('../php_backend/public/groups.php');
     const groups = await res.json();

--- a/frontend/js/backup.js
+++ b/frontend/js/backup.js
@@ -1,4 +1,5 @@
 // Handles downloading and restoring backups
+// Set up handlers for downloading and restoring backups
 function initBackup() {
     const dlBtn = document.getElementById('download-backup');
     const form = document.getElementById('restore-form');

--- a/frontend/js/input_help.js
+++ b/frontend/js/input_help.js
@@ -5,6 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
     helpBox.className = 'absolute bg-white border p-2 rounded shadow hidden z-50 text-sm';
     document.body.appendChild(helpBox);
 
+    // Display the help popover near the focused input
     function showHelp(input) {
         helpBox.textContent = input.dataset.help;
         const rect = input.getBoundingClientRect();
@@ -13,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
         helpBox.classList.remove('hidden');
     }
 
+    // Hide the help popover
     function hideHelp() {
         helpBox.classList.add('hidden');
     }

--- a/frontend/js/overlay.js
+++ b/frontend/js/overlay.js
@@ -1,5 +1,6 @@
 // Provides a simple overlay for displaying temporary messages.
 (function(){
+    // Build the overlay element and insert it into the DOM
     function createOverlay(){
         const overlay = document.createElement('div');
         overlay.id = 'overlay';
@@ -17,6 +18,7 @@
 
     let hideTimer;
 
+    // Display a temporary message in the overlay
     window.showMessage = function(msg){
         const overlay = window.__overlay || document.getElementById('overlay') || createOverlay();
         overlay.querySelector('div').textContent = msg;

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -1,3 +1,4 @@
+// Create a coloured badge element used in table cells
 function createBadge(text, colorClasses) {
     const span = document.createElement('span');
     span.textContent = text;
@@ -5,6 +6,7 @@ function createBadge(text, colorClasses) {
     return span;
 }
 
+// Return a Tabulator formatter that displays values as badges
 function badgeFormatter(colorClasses) {
     return function (cell) {
         const value = cell.getValue();
@@ -18,6 +20,7 @@ function badgeFormatter(colorClasses) {
     };
 }
 
+// Initialise a Tabulator table with Tailwind styling defaults
 function tailwindTabulator(element, options) {
     options = options || {};
     if (!options.layout || options.layout === 'fitColumns') {

--- a/frontend/js/upload.js
+++ b/frontend/js/upload.js
@@ -1,8 +1,10 @@
+// Detect whether the user agent represents macOS
 function isMacOS(ua) {
     ua = ua || (typeof navigator !== 'undefined' ? navigator.userAgent : '');
     return /Mac OS X/i.test(ua);
 }
 
+// Configure the upload form and progress display
 function initUpload() {
     const form = document.querySelector('form');
     if (!form) return;

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -21,6 +21,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script>
     let table;
+    // Retrieve untagged transaction summaries and display them
     async function loadUntagged(){
         const res = await fetch('../php_backend/public/untagged_transactions.php');
         const data = await res.json();

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -61,6 +61,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    // Format totals with currency and sign-based colouring
     function totalFormatter(cell){
         const value = cell.getValue();
         const el = cell.getElement();
@@ -69,6 +70,7 @@
         return '£' + parseFloat(value).toFixed(2);
     }
 
+    // Render a table showing daily totals for the month
     function buildTable(id, data, days){
         const el = document.getElementById(id);
         el.innerHTML = '';
@@ -96,6 +98,7 @@
         });
     }
 
+    // Draw a column chart visualising totals
     function buildChart(id, title, data){
         Highcharts.chart(id, {
             chart: { type: 'column' },
@@ -107,10 +110,12 @@
         });
     }
 
+    // Render paired donut charts for categories and tags
     function buildDonutCharts(incomeId, outgoingsId, categories, tags){
 
         const colors = Highcharts.getOptions().colors;
 
+        // Build chart data arrays for income or outgoings
         function createData(isIncome){
             const categoryData = [];
             const tagData = [];
@@ -133,6 +138,7 @@
             return { categoryData, tagData };
         }
 
+        // Render a donut chart into the given element
         function render(id, title, data){
             Highcharts.chart(id, {
                 chart: { type: 'pie' },
@@ -158,6 +164,7 @@
         render(outgoingsId, 'Outgoings Categories and Tags', outData);
     }
 
+    // Fetch and display dashboard data for a specific month
     function loadMonth(year, month){
         fetch('../php_backend/public/monthly_dashboard.php?year=' + year + '&month=' + month)
             .then(resp => resp.json())
@@ -201,6 +208,7 @@
                 });
 
                 const monthSelect = document.getElementById('month-select');
+                // Populate the month dropdown based on available data
                 function populateMonths(){
                     const y = yearSelect.value;
                     monthSelect.innerHTML = '';

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -89,6 +89,7 @@ fetch('../php_backend/public/transaction_months.php')
             monthsByYear[y].sort((a, b) => b - a);
         });
 
+        // Fill the month dropdown based on the selected year
         function populateMonths() {
             const year = yearSelect.value;
             monthSelect.innerHTML = '';

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -24,6 +24,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script>
+    // Trigger a backend process with a progress indicator
     async function run(action){
         const progressContainer = document.getElementById('progress-container');
         const progressBar = document.getElementById('progress-bar');

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -41,6 +41,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script>
 
+    // Load filter options for categories, tags and groups
     async function loadOptions() {
         const [catRes, tagRes, grpRes] = await Promise.all([
             fetch('../php_backend/public/categories.php'),
@@ -76,6 +77,7 @@
         });
     }
 
+    // Populate the saved reports dropdown from localStorage
     function loadSavedReports() {
         const saved = JSON.parse(localStorage.getItem('reports') || '[]');
         const select = document.getElementById('saved-reports');
@@ -89,6 +91,7 @@
         document.getElementById('delete-report').disabled = saved.length === 0;
     }
 
+    // Execute the report query and render results and chart
     function runReport() {
         const category = document.getElementById('category').value;
         const tag = document.getElementById('tag').value;

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -30,6 +30,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    // Format a numeric value as pounds and pence
     function formatCurrency(value) {
         return '£' + parseFloat(value).toFixed(2);
     }

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -31,6 +31,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script>
 let tagTable;
+// Load all tags and display them in the table
 async function loadTags(){
     const res = await fetch('../php_backend/public/tags.php');
     const tags = await res.json();

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -43,6 +43,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    // Format totals with currency and colour coding
     function totalFormatter(cell){
         const value = cell.getValue();
         const el = cell.getElement();
@@ -51,6 +52,7 @@
         return '£' + parseFloat(value).toFixed(2);
     }
 
+    // Render a Tabulator table showing monthly breakdowns
     function buildTable(id, data){
         const el = document.getElementById(id);
         el.innerHTML = '';
@@ -78,6 +80,7 @@
         });
     }
 
+    // Draw a column chart for the provided data set
     function buildChart(id, title, data){
         Highcharts.chart(id, {
             chart: { type: 'column' },
@@ -89,10 +92,12 @@
         });
     }
 
+    // Create nested donut charts for income and outgoings categories/tags
     function buildDonutCharts(incomeId, outgoingsId, categories, tags){
 
         const colors = Highcharts.getOptions().colors;
 
+        // Build series data filtered by income or outgoings
         function createData(isIncome){
             const categoryData = [];
             const tagData = [];
@@ -115,6 +120,7 @@
             return { categoryData, tagData };
         }
 
+        // Render a donut chart into the specified element
         function render(id, title, data){
             Highcharts.chart(id, {
                 chart: { type: 'pie' },
@@ -140,6 +146,7 @@
         render(outgoingsId, 'Outgoings Categories and Tags', outData);
     }
 
+    // Load dashboard data for a specific year and update the UI
     function loadYear(year){
         fetch('../php_backend/public/yearly_dashboard.php?year=' + year)
             .then(resp => resp.json())

--- a/php_backend/Database.php
+++ b/php_backend/Database.php
@@ -3,6 +3,9 @@
 class Database {
     private static $instance = null;
 
+    /**
+     * Return a singleton PDO connection using environment credentials.
+     */
     public static function getConnection(): PDO {
         if (self::$instance === null) {
             $host = getenv('DB_HOST') ?: 'localhost';

--- a/php_backend/models/Account.php
+++ b/php_backend/models/Account.php
@@ -3,6 +3,9 @@
 require_once __DIR__ . '/../Database.php';
 
 class Account {
+    /**
+     * Create a new account with the provided name.
+     */
     public static function create(string $name): int {
         $db = Database::getConnection();
         $stmt = $db->prepare('INSERT INTO accounts (name) VALUES (:name)');

--- a/php_backend/models/Category.php
+++ b/php_backend/models/Category.php
@@ -3,6 +3,9 @@
 require_once __DIR__ . '/../Database.php';
 
 class Category {
+    /**
+     * Insert a new category and return its ID.
+     */
     public static function create(string $name): int {
         $db = Database::getConnection();
         $stmt = $db->prepare('INSERT INTO categories (name) VALUES (:name)');
@@ -10,12 +13,18 @@ class Category {
         return (int)$db->lastInsertId();
     }
 
+    /**
+     * Update the name of an existing category.
+     */
     public static function update(int $id, string $name): void {
         $db = Database::getConnection();
         $stmt = $db->prepare('UPDATE categories SET name = :name WHERE id = :id');
         $stmt->execute(['id' => $id, 'name' => $name]);
     }
 
+    /**
+     * Retrieve all categories and their associated tags.
+     */
     public static function allWithTags(): array {
         $db = Database::getConnection();
         $sql = 'SELECT c.id AS category_id, c.name AS category_name, '

--- a/php_backend/models/CategoryTag.php
+++ b/php_backend/models/CategoryTag.php
@@ -3,6 +3,9 @@
 require_once __DIR__ . '/../Database.php';
 
 class CategoryTag {
+    /**
+     * Link a tag to a category, ensuring it isn't already assigned.
+     */
     public static function add(int $categoryId, int $tagId): void {
         $db = Database::getConnection();
         $check = $db->prepare('SELECT 1 FROM category_tags WHERE tag_id = :tag_id');
@@ -14,6 +17,9 @@ class CategoryTag {
         $stmt->execute(['category_id' => $categoryId, 'tag_id' => $tagId]);
     }
 
+    /**
+     * Remove the association between a category and a tag.
+     */
     public static function remove(int $categoryId, int $tagId): void {
         $db = Database::getConnection();
         $stmt = $db->prepare('DELETE FROM category_tags WHERE category_id = :category_id AND tag_id = :tag_id');

--- a/php_backend/models/Log.php
+++ b/php_backend/models/Log.php
@@ -3,6 +3,9 @@
 require_once __DIR__ . '/../Database.php';
 
 class Log {
+    /**
+     * Persist a message and level to the logs table.
+     */
     public static function write(string $message, string $level = 'INFO'): void {
         try {
             $db = Database::getConnection();
@@ -14,6 +17,9 @@ class Log {
         }
     }
 
+    /**
+     * Fetch the most recent log entries up to the provided limit.
+     */
     public static function all(int $limit = 100): array {
         $db = Database::getConnection();
         $sql = 'SELECT id, level, message, created_at FROM logs ORDER BY created_at DESC';
@@ -24,6 +30,9 @@ class Log {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Register global error and exception handlers that log automatically.
+     */
     public static function registerHandlers(): void {
 
         error_reporting(E_ALL);

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -3,6 +3,9 @@
 require_once __DIR__ . '/../Database.php';
 
 class Tag {
+    /**
+     * Create a new tag optionally with a keyword for auto tagging.
+     */
     public static function create(string $name, ?string $keyword = null): int {
         $db = Database::getConnection();
         $stmt = $db->prepare('INSERT INTO `tags` (`name`, `keyword`) VALUES (:name, :keyword)');
@@ -10,6 +13,9 @@ class Tag {
         return (int)$db->lastInsertId();
     }
 
+    /**
+     * Retrieve all tags with their IDs, names and keywords.
+     */
     public static function all(): array {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT `id`, `name`, `keyword` FROM `tags`');
@@ -29,12 +35,18 @@ class Tag {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Update a tag's name and keyword.
+     */
     public static function update(int $id, string $name, ?string $keyword = null): bool {
         $db = Database::getConnection();
         $stmt = $db->prepare('UPDATE `tags` SET `name` = :name, `keyword` = :keyword WHERE `id` = :id');
         return $stmt->execute(['name' => $name, 'keyword' => $keyword, 'id' => $id]);
     }
 
+    /**
+     * Remove a tag and any references to it.
+     */
     public static function delete(int $id): bool {
         $db = Database::getConnection();
         // remove any relationships to categories
@@ -50,6 +62,9 @@ class Tag {
         return $stmt->execute(['id' => $id]);
     }
 
+    /**
+     * Find a tag whose keyword appears in the provided text.
+     */
     public static function findMatch(string $text): ?int {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT `id`, `keyword` FROM `tags` WHERE `keyword` IS NOT NULL AND `keyword` != ""');

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -4,6 +4,9 @@ require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/Tag.php';
 
 class Transaction {
+    /**
+     * Insert a new transaction and attempt to auto-tag and link transfers.
+     */
     public static function create(int $account, string $date, float $amount, string $description, ?string $memo = null, ?int $category = null, ?int $tag = null, ?int $group = null, ?string $ofx_id = null): int {
         if ($tag === null) {
             $tag = Tag::findMatch($description);
@@ -53,6 +56,9 @@ class Transaction {
     }
 
 
+    /**
+     * Return transactions for a given category excluding transfers.
+     */
     public static function getByCategory(int $categoryId): array {
         $db = Database::getConnection();
         $sql = 'SELECT t.`date`, t.`amount`, t.`description`, '
@@ -67,6 +73,9 @@ class Transaction {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Return transactions for a given tag excluding transfers.
+     */
     public static function getByTag(int $tagId): array {
         $db = Database::getConnection();
         $sql = 'SELECT t.`date`, t.`amount`, t.`description`, '
@@ -81,6 +90,9 @@ class Transaction {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Return transactions for a given group excluding transfers.
+     */
     public static function getByGroup(int $groupId): array {
         $db = Database::getConnection();
         $sql = 'SELECT t.`date`, t.`amount`, t.`description`, '
@@ -95,6 +107,9 @@ class Transaction {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Filter transactions by optional category, tag, group, text and date range.
+     */
     public static function filter(?int $category = null, ?int $tag = null, ?int $group = null, ?string $text = null, ?string $start = null, ?string $end = null): array {
         if ($category === null && $tag === null && $group === null && $text === null && $start === null && $end === null) {
             return [];
@@ -141,6 +156,9 @@ class Transaction {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Retrieve all transactions for a specific month and year.
+     */
     public static function getByMonth(int $month, int $year): array {
         $db = Database::getConnection();
         $sql = 'SELECT t.`id`, t.`account_id`, t.`date`, t.`amount`, t.`description`, t.`memo`, '
@@ -204,12 +222,18 @@ class Transaction {
         return $stmt->execute(['grp' => $groupId, 'id' => $transactionId]);
     }
 
+    /**
+     * List months that have at least one transaction recorded.
+     */
     public static function getAvailableMonths(): array {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT DISTINCT YEAR(`date`) AS year, MONTH(`date`) AS month FROM `transactions` ORDER BY YEAR(`date`) DESC, MONTH(`date`) DESC');
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * List years that have at least one transaction recorded.
+     */
     public static function getAvailableYears(): array {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT DISTINCT YEAR(`date`) AS year FROM `transactions` ORDER BY YEAR(`date`)');
@@ -428,6 +452,9 @@ class Transaction {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Retrieve tag totals across multiple years.
+     */
     public static function getTagTotalsByYears(array $years): array {
         if (empty($years)) { return []; }
         $db = Database::getConnection();
@@ -449,6 +476,9 @@ class Transaction {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Retrieve category totals across multiple years.
+     */
     public static function getCategoryTotalsByYears(array $years): array {
         if (empty($years)) { return []; }
         $db = Database::getConnection();
@@ -469,6 +499,9 @@ class Transaction {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    /**
+     * Retrieve group totals across multiple years.
+     */
     public static function getGroupTotalsByYears(array $years): array {
         if (empty($years)) { return []; }
         $db = Database::getConnection();

--- a/php_backend/models/TransactionGroup.php
+++ b/php_backend/models/TransactionGroup.php
@@ -3,6 +3,9 @@
 require_once __DIR__ . '/../Database.php';
 
 class TransactionGroup {
+    /**
+     * Create a new transaction group and return its ID.
+     */
     public static function create(string $name): int {
         $db = Database::getConnection();
         $stmt = $db->prepare('INSERT INTO transaction_groups (name) VALUES (:name)');
@@ -10,12 +13,18 @@ class TransactionGroup {
         return (int)$db->lastInsertId();
     }
 
+    /**
+     * Rename an existing transaction group.
+     */
     public static function update(int $id, string $name): void {
         $db = Database::getConnection();
         $stmt = $db->prepare('UPDATE transaction_groups SET name = :name WHERE id = :id');
         $stmt->execute(['id' => $id, 'name' => $name]);
     }
 
+    /**
+     * Delete a transaction group and clear any references to it.
+     */
     public static function delete(int $id): bool {
         $db = Database::getConnection();
         // clear references from transactions
@@ -27,6 +36,9 @@ class TransactionGroup {
         return $stmt->execute(['id' => $id]);
     }
 
+    /**
+     * Find a transaction group by ID.
+     */
     public static function find(int $id): ?array {
         $db = Database::getConnection();
         $stmt = $db->prepare('SELECT id, name FROM transaction_groups WHERE id = :id');
@@ -35,6 +47,9 @@ class TransactionGroup {
         return $row ?: null;
     }
 
+    /**
+     * Return all transaction groups.
+     */
     public static function all(): array {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT id, name FROM transaction_groups ORDER BY id');

--- a/php_backend/models/User.php
+++ b/php_backend/models/User.php
@@ -3,6 +3,9 @@
 require_once __DIR__ . '/../Database.php';
 
 class User {
+    /**
+     * Create a new user with the given username and password.
+     */
     public static function create(string $username, string $password): int {
         $db = Database::getConnection();
         $hash = password_hash($password, PASSWORD_DEFAULT);
@@ -11,6 +14,9 @@ class User {
         return (int)$db->lastInsertId();
     }
 
+    /**
+     * Look up a user record by username.
+     */
     public static function findByUsername(string $username): ?array {
         $db = Database::getConnection();
         $stmt = $db->prepare('SELECT `id`, `username`, `password` FROM `users` WHERE `username` = :username');
@@ -20,6 +26,9 @@ class User {
     }
 
 
+    /**
+     * Verify a username and password, returning the user ID or null on failure.
+     */
     public static function verify(string $username, string $password, ?string &$reason = null): ?int {
         $user = self::findByUsername($username);
         if (!$user) {
@@ -34,6 +43,9 @@ class User {
         return null;
     }
 
+    /**
+     * Update the password for the specified user ID.
+     */
     public static function updatePassword(int $id, string $password): bool {
         $db = Database::getConnection();
         $hash = password_hash($password, PASSWORD_DEFAULT);


### PR DESCRIPTION
## Summary
- Document backend models with PHPDoc comments for clarity
- Explain frontend utility functions and dashboard helpers with inline comments

## Testing
- `php -l php_backend/Database.php php_backend/models/Log.php php_backend/models/Category.php php_backend/models/User.php php_backend/models/Tag.php php_backend/models/Account.php php_backend/models/CategoryTag.php php_backend/models/TransactionGroup.php php_backend/models/Transaction.php`
- `node frontend/js/upload.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689703d16d30832e8bfba49d284aa394