### PR TITLE
Support selective backups and budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Then open `http://localhost:8000/frontend/index.html` in your browser.
 
 Back up and restore your data through the web interface. From the navigation
 menu open **Backup & Restore** under *Administration*. The page lets you
-download a JSON file containing all transactions, categories, tags (and their
-category links), and groups. To restore a backup, choose the JSON file on the
-same page and click **Restore**.
+choose which parts of the database to download—transactions, categories, tags,
+groups, or budgets. To restore a backup, choose the JSON file on the same page
+and click **Restore**; any included sections are imported.
 
 ## Frontend
 

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -15,12 +15,19 @@
             <h1 class="text-2xl font-semibold mb-4">Backup &amp; Restore</h1>
             <section class="bg-white p-6 rounded shadow space-y-4">
                 <h2 class="text-xl font-semibold">Download Backup</h2>
-                <p>Download all transactions, categories, tags, and groups as a JSON file.</p>
+                <p>Select which data to include in the backup JSON file.</p>
+                <div class="space-y-2">
+                    <label class="block"><input type="checkbox" name="parts" value="transactions" class="mr-2">Transactions</label>
+                    <label class="block"><input type="checkbox" name="parts" value="categories" class="mr-2">Categories</label>
+                    <label class="block"><input type="checkbox" name="parts" value="tags" class="mr-2">Tags</label>
+                    <label class="block"><input type="checkbox" name="parts" value="groups" class="mr-2">Groups</label>
+                    <label class="block"><input type="checkbox" name="parts" value="budgets" class="mr-2">Budgets</label>
+                </div>
                 <button id="download-backup" class="bg-blue-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-download mr-2"></i>Download</button>
             </section>
             <section class="bg-white p-6 rounded shadow space-y-4">
                 <h2 class="text-xl font-semibold">Restore Backup</h2>
-                <p>Select a backup JSON file to restore transactions, categories, tags, and groups.</p>
+                <p>Select a backup JSON file to restore any included transactions, categories, tags, groups, or budgets.</p>
                 <form id="restore-form" action="../php_backend/public/restore.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                     <input type="file" id="backup-file" name="backup_file" accept="application/json" required data-help="Choose a previously downloaded backup JSON file">
                     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-upload mr-2"></i>Restore</button>

--- a/frontend/js/backup.js
+++ b/frontend/js/backup.js
@@ -4,7 +4,9 @@ function initBackup() {
     const form = document.getElementById('restore-form');
     if (dlBtn) {
         dlBtn.addEventListener('click', () => {
-            fetch('../php_backend/public/backup.php')
+            const parts = Array.from(document.querySelectorAll('input[name="parts"]:checked')).map(cb => cb.value);
+            const qs = parts.length ? `?parts=${parts.join(',')}` : '';
+            fetch(`../php_backend/public/backup.php${qs}`)
                 .then(resp => resp.blob())
                 .then(blob => {
                     const url = URL.createObjectURL(blob);

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -1,5 +1,6 @@
 <?php
-// Exports categories, tags, groups, and transactions as JSON.
+// Exports selected data as JSON. Allows selecting categories, tags, groups,
+// transactions, and budgets via the `parts` query parameter.
 require_once __DIR__ . '/../Database.php';
 
 header('Content-Type: application/json');
@@ -12,13 +13,30 @@ try {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     };
 
-    $data = [
-        'categories' => $getAll('SELECT id, name FROM categories ORDER BY id'),
-        'tags' => $getAll('SELECT id, name, keyword FROM tags ORDER BY id'),
-        'category_tags' => $getAll('SELECT category_id, tag_id FROM category_tags ORDER BY category_id, tag_id'),
-        'groups' => $getAll('SELECT id, name FROM transaction_groups ORDER BY id'),
-        'transactions' => $getAll('SELECT id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id FROM transactions ORDER BY id')
-    ];
+    $allParts = ['categories','tags','groups','transactions','budgets'];
+    $parts = isset($_GET['parts']) && $_GET['parts'] !== ''
+        ? array_intersect($allParts, explode(',', $_GET['parts']))
+        : $allParts;
+
+    $data = [];
+    if (in_array('categories', $parts)) {
+        $data['categories'] = $getAll('SELECT id, name FROM categories ORDER BY id');
+    }
+    if (in_array('tags', $parts)) {
+        $data['tags'] = $getAll('SELECT id, name, keyword FROM tags ORDER BY id');
+    }
+    if (in_array('categories', $parts) || in_array('tags', $parts)) {
+        $data['category_tags'] = $getAll('SELECT category_id, tag_id FROM category_tags ORDER BY category_id, tag_id');
+    }
+    if (in_array('groups', $parts)) {
+        $data['groups'] = $getAll('SELECT id, name FROM transaction_groups ORDER BY id');
+    }
+    if (in_array('transactions', $parts)) {
+        $data['transactions'] = $getAll('SELECT id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id FROM transactions ORDER BY id');
+    }
+    if (in_array('budgets', $parts)) {
+        $data['budgets'] = $getAll('SELECT category_id, month, year, amount FROM budgets ORDER BY category_id, year, month');
+    }
 
     echo json_encode($data);
 } catch (Exception $e) {

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -1,5 +1,5 @@
 <?php
-// Restores categories, tags, groups, and transactions from an uploaded JSON backup.
+// Restores categories, tags, groups, transactions, and budgets from an uploaded JSON backup.
 require_once __DIR__ . '/../Database.php';
 
 try {
@@ -19,48 +19,71 @@ try {
 
     $db = Database::getConnection();
     $db->exec('SET FOREIGN_KEY_CHECKS=0');
-    $db->exec('TRUNCATE TABLE category_tags');
-    $db->exec('TRUNCATE TABLE transactions');
-    $db->exec('TRUNCATE TABLE tags');
-    $db->exec('TRUNCATE TABLE categories');
-    $db->exec('TRUNCATE TABLE transaction_groups');
+    if (isset($data['category_tags'])) $db->exec('TRUNCATE TABLE category_tags');
+    if (isset($data['transactions'])) $db->exec('TRUNCATE TABLE transactions');
+    if (isset($data['tags'])) $db->exec('TRUNCATE TABLE tags');
+    if (isset($data['categories'])) $db->exec('TRUNCATE TABLE categories');
+    if (isset($data['groups'])) $db->exec('TRUNCATE TABLE transaction_groups');
+    if (isset($data['budgets'])) $db->exec('TRUNCATE TABLE budgets');
     $db->exec('SET FOREIGN_KEY_CHECKS=1');
 
-    $stmtCat = $db->prepare('INSERT INTO categories (id, name) VALUES (:id, :name)');
-    foreach ($data['categories'] as $row) {
-        $stmtCat->execute(['id' => $row['id'], 'name' => $row['name']]);
+    if (isset($data['categories'])) {
+        $stmtCat = $db->prepare('INSERT INTO categories (id, name) VALUES (:id, :name)');
+        foreach ($data['categories'] as $row) {
+            $stmtCat->execute(['id' => $row['id'], 'name' => $row['name']]);
+        }
     }
 
-    $stmtTag = $db->prepare('INSERT INTO tags (id, name, keyword) VALUES (:id, :name, :keyword)');
-    foreach ($data['tags'] as $row) {
-        $stmtTag->execute(['id' => $row['id'], 'name' => $row['name'], 'keyword' => $row['keyword']]);
+    if (isset($data['tags'])) {
+        $stmtTag = $db->prepare('INSERT INTO tags (id, name, keyword) VALUES (:id, :name, :keyword)');
+        foreach ($data['tags'] as $row) {
+            $stmtTag->execute(['id' => $row['id'], 'name' => $row['name'], 'keyword' => $row['keyword']]);
+        }
     }
 
-    $stmtGrp = $db->prepare('INSERT INTO transaction_groups (id, name) VALUES (:id, :name)');
-    foreach ($data['groups'] as $row) {
-        $stmtGrp->execute(['id' => $row['id'], 'name' => $row['name']]);
+    if (isset($data['groups'])) {
+        $stmtGrp = $db->prepare('INSERT INTO transaction_groups (id, name) VALUES (:id, :name)');
+        foreach ($data['groups'] as $row) {
+            $stmtGrp->execute(['id' => $row['id'], 'name' => $row['name']]);
+        }
     }
 
-    $stmtTx = $db->prepare('INSERT INTO transactions (id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id) VALUES (:id, :account_id, :date, :amount, :description, :memo, :category_id, :tag_id, :group_id, :transfer_id, :ofx_id)');
-    foreach ($data['transactions'] as $row) {
-        $stmtTx->execute([
-            'id' => $row['id'],
-            'account_id' => $row['account_id'],
-            'date' => $row['date'],
-            'amount' => $row['amount'],
-            'description' => $row['description'],
-            'memo' => $row['memo'],
-            'category_id' => $row['category_id'],
-            'tag_id' => $row['tag_id'],
-            'group_id' => $row['group_id'],
-            'transfer_id' => $row['transfer_id'],
-            'ofx_id' => $row['ofx_id']
-        ]);
+    if (isset($data['budgets'])) {
+        $stmtBud = $db->prepare('INSERT INTO budgets (category_id, month, year, amount) VALUES (:category_id, :month, :year, :amount)');
+        foreach ($data['budgets'] as $row) {
+            $stmtBud->execute([
+                'category_id' => $row['category_id'],
+                'month' => $row['month'],
+                'year' => $row['year'],
+                'amount' => $row['amount']
+            ]);
+        }
     }
 
-    $stmtCT = $db->prepare('INSERT INTO category_tags (category_id, tag_id) VALUES (:category_id, :tag_id)');
-    foreach ($data['category_tags'] as $row) {
-        $stmtCT->execute(['category_id' => $row['category_id'], 'tag_id' => $row['tag_id']]);
+    if (isset($data['transactions'])) {
+        $stmtTx = $db->prepare('INSERT INTO transactions (id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id) VALUES (:id, :account_id, :date, :amount, :description, :memo, :category_id, :tag_id, :group_id, :transfer_id, :ofx_id)');
+        foreach ($data['transactions'] as $row) {
+            $stmtTx->execute([
+                'id' => $row['id'],
+                'account_id' => $row['account_id'],
+                'date' => $row['date'],
+                'amount' => $row['amount'],
+                'description' => $row['description'],
+                'memo' => $row['memo'],
+                'category_id' => $row['category_id'],
+                'tag_id' => $row['tag_id'],
+                'group_id' => $row['group_id'],
+                'transfer_id' => $row['transfer_id'],
+                'ofx_id' => $row['ofx_id']
+            ]);
+        }
+    }
+
+    if (isset($data['category_tags'])) {
+        $stmtCT = $db->prepare('INSERT INTO category_tags (category_id, tag_id) VALUES (:category_id, :tag_id)');
+        foreach ($data['category_tags'] as $row) {
+            $stmtCT->execute(['category_id' => $row['category_id'], 'tag_id' => $row['tag_id']]);
+        }
     }
 
     echo 'Restore complete.';


### PR DESCRIPTION
## Summary
- Allow choosing which data sets to export (transactions, categories, tags, groups, budgets)
- Add budgets to backup and restore operations
- Enable restoring only the sections present in a backup file

## Testing
- `php -l php_backend/public/backup.php`
- `php -l php_backend/public/restore.php`
- `node --check frontend/js/backup.js`

------
https://chatgpt.com/codex/tasks/task_e_6897044b1a38832e962f3cfdf6b19b5b