### PR TITLE
Add rounded corners to Tabulator tables

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -39,11 +39,13 @@ function tailwindTabulator(element, options) {
     options.paginationSize = 20;
     const table = new Tabulator(element, options);
     const el = table.element;
-    el.classList.add('border', 'border-gray-200', 'border-[0.5px]', 'rounded', 'bg-white', 'shadow-sm');
+    el.classList.add('border', 'border-gray-200', 'border-[0.5px]', 'rounded-lg', 'overflow-hidden', 'bg-white', 'shadow-sm');
     const header = el.querySelector('.tabulator-header');
-    if (header) header.classList.add('bg-white', 'border-b', 'border-gray-200', 'border-b-[0.5px]');
+    if (header) header.classList.add('bg-white', 'border-b', 'border-gray-200', 'border-b-[0.5px]', 'rounded-t-lg');
+    const tableHolder = el.querySelector('.tabulator-tableholder');
+    if (tableHolder) tableHolder.classList.add('rounded-b-lg');
     const paginator = el.querySelector('.tabulator-paginator');
-    if (paginator) paginator.classList.add('bg-white', 'border-t', 'border-gray-200', 'border-t-[0.5px]', 'p-2');
+    if (paginator) paginator.classList.add('bg-white', 'border-t', 'border-gray-200', 'border-t-[0.5px]', 'p-2', 'rounded-b-lg');
     table.on('tableBuilt', () => {
         const cols = table.getColumns();
         if (cols.length) {


### PR DESCRIPTION
## Summary
- Apply Tailwind rounded and overflow-hidden classes to Tabulator tables
- Ensure headers and paginators inherit curved corner styling

## Testing
- `node --check frontend/js/tabulator-tailwind.js`


------
https://chatgpt.com/codex/tasks/task_e_689771e58628832e91998068a4253df2