### PR TITLE
Show transfers flagged in OFX files

### DIFF
--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     'search.html': 'Find specific transactions using keywords and view results.',
     'tags.html': 'Create and manage tags for categorising transactions.',
     'transaction.html': 'Review or edit the information for a single transaction.',
-    'transfers.html': 'List detected transfers between accounts.',
+    'transfers.html': 'List detected transfers between accounts and transactions marked as transfers in uploaded OFX files.',
     'yearly_dashboard.html': 'Analyse totals for a single year through charts and tables.'
   };
 

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -19,6 +19,10 @@
                 <div id="transfers-table"></div>
             </section>
             <section>
+                <h2 class="text-xl font-semibold mb-4">OFX Marked Transfers</h2>
+                <div id="ofx-transfers-table"></div>
+            </section>
+            <section>
                 <h2 class="text-xl font-semibold mb-4">Link Transactions as Transfer</h2>
                 <form id="link-form" class="space-y-4">
                     <input type="number" id="id1" placeholder="First transaction ID" class="border p-2 rounded w-full" data-help="ID of the first transaction">
@@ -44,6 +48,17 @@
                     { title: 'Description', field: 'description' },
                     { title: 'From', field: 'from_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.from_id}">${cell.getValue()}</a>`; } },
                     { title: 'To', field: 'to_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.to_id}">${cell.getValue()}</a>`; } },
+                    { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
+                ]
+            });
+
+            tailwindTabulator(document.getElementById('ofx-transfers-table'), {
+                data: data.ofx_transfers,
+                layout: 'fitColumns',
+                columns: [
+                    { title: 'Date', field: 'date' },
+                    { title: 'Description', field: 'description' },
+                    { title: 'Account', field: 'account_name', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.id}">${cell.getValue()}</a>`; } },
                     { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
                 ]
             });

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -78,6 +78,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     group_id INT DEFAULT NULL,
     transfer_id INT DEFAULT NULL,
     ofx_id VARCHAR(255) UNIQUE,
+    ofx_type VARCHAR(50) DEFAULT NULL,
     FOREIGN KEY (account_id) REFERENCES accounts(id),
     FOREIGN KEY (category_id) REFERENCES categories(id),
     FOREIGN KEY (tag_id) REFERENCES tags(id),
@@ -104,6 +105,12 @@ if ($result->rowCount() === 0) {
 $result = $db->query("SHOW COLUMNS FROM `transactions` LIKE 'transfer_id'");
 if ($result->rowCount() === 0) {
     $db->exec("ALTER TABLE `transactions` ADD COLUMN `transfer_id` INT DEFAULT NULL");
+}
+
+// Ensure ofx_type column exists in transactions
+$result = $db->query("SHOW COLUMNS FROM `transactions` LIKE 'ofx_type'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `transactions` ADD COLUMN `ofx_type` VARCHAR(50) DEFAULT NULL");
 }
 
 echo "Database tables created.\n";

--- a/php_backend/public/transfers.php
+++ b/php_backend/public/transfers.php
@@ -1,5 +1,5 @@
 <?php
-// API endpoint to list all detected transfer pairs.
+// API endpoint to list transfer pairs and OFX-marked transfer transactions.
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 
@@ -7,7 +7,8 @@ header('Content-Type: application/json');
 
 try {
     $transfers = Transaction::getTransfers();
-    echo json_encode(['transfers' => $transfers]);
+    $ofxTransfers = Transaction::getOfxTransfers();
+    echo json_encode(['transfers' => $transfers, 'ofx_transfers' => $ofxTransfers]);
 } catch (Exception $e) {
     http_response_code(500);
     Log::write('Fetch transfers error: ' . $e->getMessage(), 'ERROR');

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -59,6 +59,7 @@ try {
             $amount = (float)trim($am[1]);
             $desc = '';
             $memo = '';
+            $type = null;
             if (preg_match('/<NAME>([^\r\n<]+)/i', $block, $dm)) {
                 $desc = trim($dm[1]);
             }
@@ -68,11 +69,14 @@ try {
                     $desc = $memo;
                 }
             }
+            if (preg_match('/<TRNTYPE>([^\r\n<]+)/i', $block, $tm)) {
+                $type = strtoupper(trim($tm[1]));
+            }
             $ofxId = null;
             if (preg_match('/<FITID>([^\r\n<]+)/i', $block, $om)) {
                 $ofxId = trim($om[1]);
             }
-            Transaction::create($accountId, $date, $amount, $desc, $memo, null, null, null, $ofxId);
+            Transaction::create($accountId, $date, $amount, $desc, $memo, null, null, null, $ofxId, $type);
             $inserted++;
         }
 


### PR DESCRIPTION
## Summary
- Track the OFX transaction type with a new `ofx_type` column.
- Parse TRNTYPE when uploading OFX files and flag single XFER entries as transfers.
- Expose XFER transactions via the transfers API and display them on the Transfers page.

## Testing
- `php -l php_backend/create_tables.php`
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/upload_ofx.php`
- `php -l php_backend/public/transfers.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897808820b0832e9f14391a15ff4660