### PR TITLE
Use modern Tabulator theme for tables

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Account Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>All Years Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Budgets</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
 <div class="flex min-h-screen">

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Categories</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Group Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Groups</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Application Logs</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Missing Tags</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Monthly Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Monthly Statement</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body class="bg-gray-50 font-sans">

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Transaction Reports</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Search Transactions</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Tags</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Account Transfers</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Yearly Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">


### PR DESCRIPTION
## Summary
- Switch all HTML pages to Tabulator's modern theme for a cleaner table design.

## Testing
- `rg -l "tabulator_modern.min.css" -g "frontend/*.html"`


------
https://chatgpt.com/codex/tasks/task_e_68977ee4f374832ea0d6a5ecd7330e51