### PR TITLE
Add recurring spend detection analysis

### DIFF
--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -25,7 +25,8 @@ document.addEventListener('DOMContentLoaded', () => {
     'tags.html': 'Create and manage tags for categorising transactions.',
     'transaction.html': 'Review or edit the information for a single transaction.',
     'transfers.html': 'List detected transfers between accounts and transactions marked as transfers in uploaded OFX files.',
-    'yearly_dashboard.html': 'Analyse totals for a single year through charts and tables.'
+    'yearly_dashboard.html': 'Analyse totals for a single year through charts and tables.',
+    'recurring_spend.html': 'Detect recurring expenses over the past year.'
   };
 
   const helpText = helpTexts[page];

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -18,6 +18,7 @@
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-2"></i> Monthly Dashboard</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="group_dashboard.html"><i class="fa-solid fa-users mr-2"></i> Group Dashboard</a></li>
       <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="account_dashboard.html"><i class="fa-solid fa-wallet mr-2"></i> Account Dashboard</a></li>
+      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="recurring_spend.html"><i class="fa-solid fa-repeat mr-2"></i> Recurring Spend</a></li>
     </ul>
   </div>
 

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!-- Page to run recurring spend detection over the past year -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Recurring Spend Detection</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator_modern.min.css">
+</head>
+<body class="bg-gray-50 font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
+        <main class="flex-1 p-6">
+            <h1 class="text-2xl font-semibold mb-4">Recurring Spend Detection</h1>
+            <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses.</p>
+            <button id="run-analysis" class="bg-blue-600 text-white px-4 py-2 rounded mb-4"><i class="fa-solid fa-play mr-2"></i>Run Analysis</button>
+            <div id="results-grid"></div>
+            <p id="total" class="mt-4 text-right"></p>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
+    <script>
+    function formatCurrency(value){
+        return '£' + parseFloat(value).toFixed(2);
+    }
+    document.getElementById('run-analysis').addEventListener('click', () => {
+        fetch('../php_backend/public/recurring_spend.php')
+            .then(resp => resp.json())
+            .then(data => {
+                const gridEl = document.getElementById('results-grid');
+                gridEl.innerHTML = '';
+                if(data.results && data.results.length){
+                    tailwindTabulator(gridEl, {
+                        data: data.results,
+                        layout: 'fitColumns',
+                        columns: [
+                            { title: 'Description', field: 'description' },
+                            { title: 'Occurrences', field: 'occurrences', hozAlign: 'right' },
+                            { title: 'Yearly Total', field: 'total', hozAlign: 'right', formatter: 'money', formatterParams: { symbol: '£', precision: 2 } }
+                        ]
+                    });
+                    const total = data.results.reduce((sum, row) => sum + parseFloat(row.total), 0);
+                    document.getElementById('total').textContent = 'Total: ' + formatCurrency(total);
+                } else {
+                    gridEl.innerHTML = 'No recurring spend found.';
+                    document.getElementById('total').textContent = '';
+                }
+            });
+    });
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/php_backend/public/recurring_spend.php
+++ b/php_backend/public/recurring_spend.php
@@ -1,0 +1,18 @@
+<?php
+// API endpoint to analyse recurring spending over the past year.
+require_once __DIR__ . '/../models/Transaction.php';
+
+header('Content-Type: application/json');
+
+try {
+    $results = Transaction::getRecurringSpend();
+    $total = 0.0;
+    foreach ($results as $row) {
+        $total += (float)$row['total'];
+    }
+    echo json_encode(['results' => $results, 'total' => $total]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>


### PR DESCRIPTION
## Summary
- add backend query to surface recurring spend over last 12 months
- expose recurring spend analysis via new API endpoint
- add frontend page, menu entry and help overlay for recurring spend detection

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/recurring_spend.php`
- `php php_backend/public/recurring_spend.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6897c0a0387c832e954cfaced5b9bed9