### PR TITLE
Prevent runaway table column expansion

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -46,7 +46,8 @@ function tailwindTabulator(element, options) {
     if (tableHolder) tableHolder.classList.add('rounded-b-lg');
     const paginator = el.querySelector('.tabulator-paginator');
     if (paginator) paginator.classList.add('bg-white', 'border-t', 'border-gray-200', 'border-t-[0.5px]', 'p-2', 'rounded-b-lg');
-    table.on('tableBuilt', () => {
+    table.on('tableBuilt', function handler() {
+        table.off('tableBuilt', handler);
         const cols = table.getColumns();
         if (cols.length) {
             cols[0].fitData();


### PR DESCRIPTION
## Summary
- ensure Tabulator's first-column auto-fit runs only once to avoid endless width expansion

## Testing
- `node --check frontend/js/tabulator-tailwind.js`


------
https://chatgpt.com/codex/tasks/task_e_6898c57720f8832ea0196b4f3c09c747