### PR TITLE
Show OFX type on transaction details page

### DIFF
--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -45,6 +45,7 @@
                 <p><strong>Description:</strong> ${tx.description}</p>
                 <p><strong>Memo:</strong> ${tx.memo || ''}</p>
                 <p><strong>Amount:</strong> £${parseFloat(tx.amount).toFixed(2)}</p>
+                <p><strong>OFX Type:</strong> ${tx.ofx_type || ''}</p>
                 <label class="block">Category: <select id="category" class="border p-2 rounded w-full" data-help="Assign a category"></select></label>
                 <label class="block">Tag: <select id="tag" class="border p-2 rounded w-full" data-help="Assign a tag"></select></label>
                 <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Assign a group"></select></label>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -186,7 +186,7 @@ class Transaction {
     public static function get(int $id): ?array {
         $db = Database::getConnection();
         $sql = 'SELECT t.`id`, t.`account_id`, t.`date`, t.`amount`, t.`description`, t.`memo`, '
-             . 't.`category_id`, t.`tag_id`, t.`group_id`, t.`transfer_id`, '
+             . 't.`category_id`, t.`tag_id`, t.`group_id`, t.`transfer_id`, t.`ofx_type`, '
              . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '


### PR DESCRIPTION
## Summary
- expose `ofx_type` field in Transaction model retrieval
- display OFX type on the Transaction details page

## Testing
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6898c7aef838832eb082f41c70cf388f