### PR TITLE
Prevent runaway table column expansion

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -46,11 +46,16 @@ function tailwindTabulator(element, options) {
     if (tableHolder) tableHolder.classList.add('rounded-b-lg');
     const paginator = el.querySelector('.tabulator-paginator');
     if (paginator) paginator.classList.add('bg-white', 'border-t', 'border-gray-200', 'border-t-[0.5px]', 'p-2', 'rounded-b-lg');
+    let autoFitDone = false;
     table.on('tableBuilt', () => {
-        const cols = table.getColumns();
-        if (cols.length) {
-            cols[0].fitData();
-        }
+        if (autoFitDone) return;
+        autoFitDone = true;
+        requestAnimationFrame(() => {
+            const cols = table.getColumns();
+            if (cols.length) {
+                cols[0].fitData();
+            }
+        });
     });
     return table;
 }


### PR DESCRIPTION
## Summary
- ensure Tabulator's first-column auto-fit runs only once and defers execution to avoid ResizeObserver warnings
- safeguard against component errors by using a one-time flag instead of removing the event listener

## Testing
- `node --check frontend/js/tabulator-tailwind.js`


------
https://chatgpt.com/codex/tasks/task_e_6898c57720f8832ea0196b4f3c09c747