### PR TITLE
Validate Tabulator fitToData support

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -53,10 +53,14 @@ function tailwindTabulator(element, options) {
         autoFitDone = true;
         requestAnimationFrame(() => {
             const cols = table.getColumns();
+            const allHaveFitToData = cols.every(col => typeof col.fitToData === 'function');
 
-            if (cols.length && typeof cols[0].fitToData === 'function') {
-                cols[0].fitToData();
+            if (!allHaveFitToData) {
+                console.warn('Tabulator columns lack fitToData; ensure the ResizeColumns module is included.');
+                return;
             }
+
+            cols.forEach(col => col.fitToData());
         });
 
     });


### PR DESCRIPTION
## Summary
- add runtime check to Tabulator helper to verify all columns provide `fitToData`
- warn developers when required ResizeColumns module is missing and autofit columns when available

## Testing
- `node --check frontend/js/tabulator-tailwind.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_6898d3da0f30832e9b6a23663f40b7f1