### PR TITLE
Balance Tabulator column widths across tables

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -23,8 +23,8 @@ function badgeFormatter(colorClasses) {
 // Initialise a Tabulator table with Tailwind styling defaults
 function tailwindTabulator(element, options) {
     options = options || {};
-    if (!options.layout || options.layout === 'fitColumns') {
-        options.layout = 'fitDataStretch';
+    if (!options.layout) {
+        options.layout = 'fitColumns';
     }
     const userRowFormatter = options.rowFormatter;
     options.rowFormatter = function(row) {
@@ -46,23 +46,5 @@ function tailwindTabulator(element, options) {
     if (tableHolder) tableHolder.classList.add('rounded-b-lg');
     const paginator = el.querySelector('.tabulator-paginator');
     if (paginator) paginator.classList.add('bg-white', 'border-t', 'border-gray-200', 'border-t-[0.5px]', 'p-2', 'rounded-b-lg');
-
-    let autoFitDone = false;
-    table.on('tableBuilt', () => {
-        if (autoFitDone) return;
-        autoFitDone = true;
-        requestAnimationFrame(() => {
-            const cols = table.getColumns();
-            const allHaveFitToData = cols.every(col => typeof col.fitToData === 'function');
-
-            if (!allHaveFitToData) {
-                console.warn('Tabulator columns lack fitToData; ensure the ResizeColumns module is included.');
-                return;
-            }
-
-            cols.forEach(col => col.fitToData());
-        });
-
-    });
     return table;
 }


### PR DESCRIPTION
## Summary
- Default Tabulator tables to the `fitColumns` layout for even column widths
- Remove automatic fit-to-data sizing that caused the last column to stretch

## Testing
- `node --check frontend/js/tabulator-tailwind.js`


------
https://chatgpt.com/codex/tasks/task_e_6899c09e9600832eb5f58249f0a00eef