### PR TITLE
Ensure Tabulator ResizeColumns module is loaded

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -1,3 +1,15 @@
+// Ensure the ResizeColumns module is available for Tabulator
+if (typeof Tabulator !== 'undefined' && !(Tabulator.prototype.modules && Tabulator.prototype.modules.resizeColumns)) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'https://unpkg.com/tabulator-tables@5.5.0/dist/js/modules/resizeColumns.min.js', false);
+    xhr.send(null);
+    if (xhr.status === 200) {
+        eval(xhr.responseText);
+    } else {
+        console.error('Failed to load Tabulator ResizeColumns module');
+    }
+}
+
 // Create a coloured badge element used in table cells
 function createBadge(text, colorClasses) {
     const span = document.createElement('span');


### PR DESCRIPTION
## Summary
- load Tabulator ResizeColumns module in shared Tabulator helper to prevent missing module warnings on table pages

## Testing
- `node frontend/js/upload.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6899c7ad0738832ea2f845d28fb3bc3e