### PR TITLE
Add debug output to statement view

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -53,6 +53,10 @@
                 </div>
                 <div id="transactions-grid"></div>
             </div>
+            <div id="debug-panel" class="bg-white p-6 rounded shadow mt-4">
+                <h2 class="text-lg font-semibold mb-2">Debug Output</h2>
+                <pre id="debug-log" class="text-xs whitespace-pre-wrap"></pre>
+            </div>
         </main>
     </div>
     <script src="js/menu.js"></script>
@@ -69,6 +73,13 @@ const pendingChanges = new Map();
 let table;
 const saveBtn = document.getElementById('save-btn');
 saveBtn.disabled = true;
+
+const debugLog = document.getElementById('debug-log');
+function debug(message) {
+    if (debugLog) {
+        debugLog.textContent += message + '\n';
+    }
+}
 
 fetch('../php_backend/public/transaction_months.php')
     .then(resp => resp.json())
@@ -197,21 +208,32 @@ form.addEventListener('submit', function(e) {
                     const origStr = data.original_group_id === null ? '' : String(data.original_group_id);
                     const rowEl = cell.getRow().getElement();
 
-
-                    payload.group_id = val === '' ? '' : parseInt(val, 10);
+                    debug(`Cell edited for transaction ${data.id}: ${origStr} -> ${valStr}`);
+                    const payload = {
+                        transaction_id: data.id,
+                        account_id: data.account_id,
+                        group_id: val === '' ? '' : parseInt(val, 10)
+                    };
+                    debug('Sending update: ' + JSON.stringify(payload));
                     fetch('../php_backend/public/update_transaction.php', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify(payload)
                     })
-                    .then(resp => resp.json())
+                    .then(resp => {
+                        debug('HTTP status: ' + resp.status);
+                        return resp.json();
+                    })
                     .then(res => {
+                        debug('Response: ' + JSON.stringify(res));
                         if (!(res && res.status === 'ok')) {
                             alert('Failed to save group');
+                            debug('Update failed, reverting');
                             cell.setValue(oldVal, true);
                         }
                     })
-                    .catch(() => {
+                    .catch(err => {
+                        debug('Fetch error: ' + err);
                         alert('Failed to save group');
                         cell.setValue(oldVal, true);
                     });
@@ -227,7 +249,9 @@ form.addEventListener('submit', function(e) {
 
 saveBtn.addEventListener('click', function() {
     const updates = Array.from(pendingChanges.entries());
+    debug('Saving changes for transactions: ' + updates.map(u => u[0]).join(', '));
     const promises = updates.map(([id, change]) => {
+        debug('Saving transaction ' + id + ' with ' + JSON.stringify(change));
         savingRows.add(id);
         const row = table.getRow(id);
         const rowEl = row.getElement();
@@ -242,8 +266,12 @@ saveBtn.addEventListener('click', function() {
                 group_id: change.group_id
             })
         })
-        .then(resp => resp.json())
+        .then(resp => {
+            debug('HTTP status for ' + id + ': ' + resp.status);
+            return resp.json();
+        })
         .then(res => {
+            debug('Response for ' + id + ': ' + JSON.stringify(res));
             if (res && res.status === 'ok') {
                 row.getData().original_group_id = change.group_id === '' ? null : change.group_id;
                 rowEl.classList.remove('bg-yellow-50');


### PR DESCRIPTION
## Summary
- Add a debug output panel to the monthly statement page
- Log payload and server responses when updating transaction groups
- Instrument save operations to trace HTTP status and responses

## Testing
- `php -l frontend/monthly_statement.html`
- `php -l php_backend/public/update_transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6899c8cc833c832eba76c6064f2177aa