### PR TITLE
Prevent side menu from shrinking on wide tables

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Account Dashboard</h1>
             <p class="mb-4">Overview of account balances and activity.</p>
             <div class="bg-white p-6 rounded shadow">

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">All Years Dashboard</h1>
             <p class="mb-4">Compare financial totals across every recorded year.</p>
 

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6 space-y-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4">Backup &amp; Restore</h1>
             <section class="bg-white p-6 rounded shadow space-y-4">
                 <h2 class="text-xl font-semibold">Download Backup</h2>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
 <div class="flex min-h-screen">
-    <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-    <main class="flex-1 p-6 space-y-6">
+    <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+    <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4">Budgets</h1>
         <section>
             <form id="budget-form" class="md:flex md:space-x-4 space-y-4 md:space-y-0">

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Categories</h1>
             <p class="mb-4">Create categories and assign tags to organise your transactions.</p>
             <form id="category-form" class="space-y-4">

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -11,8 +11,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6 space-y-8">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-8">
             <h1 class="text-2xl font-semibold">Graphs</h1>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full"></select>

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Group Dashboard</h1>
             <p class="mb-4">Review group spending by month and year.</p>
             <label for="year-select" class="block">Year:

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Groups</h1>
             <p class="mb-4">Create groups to collect related categories for reporting.</p>
             <form id="group-form" class="space-y-4">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,8 +12,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Welcome to Finance Manager</h1>
             <p>Select an option from the menu to get started.</p>
             <p id="version">Version: loading...</p>

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Application Logs</h1>
             <p class="mb-4">Review recent log entries to monitor system activity.</p>
             <div id="logs-grid" class="mt-4"></div>

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -12,8 +12,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Missing Tags</h1>
             <p class="mb-4">Identify transactions that have not yet been tagged.</p>
             <div id="untagged-table"></div>

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Monthly Dashboard</h1>
             <p class="mb-4">View income and outgoings for a chosen month.</p>
             <label for="year-select" class="block">Year:

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -14,8 +14,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Monthly Statement</h1>
             <p class="mb-4">Select a month to view a detailed list of transactions.</p>
             <div class="bg-white p-6 rounded shadow">

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -12,8 +12,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Run Processes</h1>
             <p class="mb-4">Run background tasks like auto-tagging and category assignment.</p>
             <div class="space-x-4">

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Recurring Spend Detection</h1>
             <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses.</p>
             <button id="run-analysis" class="bg-blue-600 text-white px-4 py-2 rounded mb-4"><i class="fa-solid fa-play mr-2"></i>Run Analysis</button>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Transaction Reports</h1>
             <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria.</p>
             <form id="report-form" class="bg-white p-4 rounded shadow grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Search Transactions</h1>
             <p class="mb-4">Find specific transactions using keywords and view the results below.</p>
             <form id="search-form" class="space-y-4">

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Tags</h1>
             <p class="mb-4">Create new tags and manage existing ones for categorising transactions.</p>
             <form id="tag-form" class="space-y-4">

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -11,8 +11,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Transaction Details</h1>
             <p class="mb-4">Review or edit the information for a single transaction.</p>
             <div id="transaction-details" class="mt-4"></div>

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -12,8 +12,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6 space-y-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <section>
                 <h1 class="text-2xl font-semibold mb-4">Detected Transfers</h1>
                 <div id="transfers-table"></div>

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -12,8 +12,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Upload OFX Files</h1>
             <p class="mb-4">Upload one or more OFX statements from your bank to import transactions.</p>
             <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data" class="space-y-4">

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -13,8 +13,8 @@
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 bg-white border-r p-6"></nav>
-        <main class="flex-1 p-6">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Yearly Dashboard</h1>
             <p class="mb-4">Analyse totals for a single year through charts and tables.</p>
             <label for="year-select" class="block">Year:


### PR DESCRIPTION
## Summary
- Ensure left navigation retains width by preventing flex shrink
- Allow main content area to scroll horizontally when tables overflow

## Testing
- `php -S 127.0.0.1:8000 -t . &` (served app locally)
- `curl -I 127.0.0.1:8000/frontend/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6899c97848f0832eaeb52a0b14e10b73