### PR TITLE
Add category deletion with data cleanup

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -86,8 +86,22 @@ async function loadCategories() {
                     loadCategories();
                     showMessage('Tag assigned');
                 });
+                const delBtn = document.createElement('button');
+                delBtn.textContent = 'Delete';
+                delBtn.className = 'bg-red-600 text-white px-2 py-1 rounded ml-2';
+                delBtn.addEventListener('click', async () => {
+                    if (!confirm('Delete this category?')) return;
+                    await fetch('../php_backend/public/categories.php', {
+                        method: 'DELETE',
+                        headers: {'Content-Type': 'application/json'},
+                        body: JSON.stringify({id: c.id})
+                    });
+                    loadCategories();
+                    showMessage('Category deleted');
+                });
                 container.appendChild(editBtn);
                 container.appendChild(tagBtn);
+                container.appendChild(delBtn);
                 return container;
             }}
         ]

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -60,6 +60,16 @@ try {
                 http_response_code(400);
                 echo json_encode(['error' => 'Invalid action']);
         }
+    } elseif ($method === 'DELETE') {
+        $id = (int)($data['id'] ?? 0);
+        if ($id <= 0) {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID required']);
+            return;
+        }
+        Category::delete($id);
+        Log::write("Deleted category $id");
+        echo json_encode(['status' => 'ok']);
     } elseif ($method === 'PUT') {
         $id = (int)($data['id'] ?? 0);
         $name = trim($data['name'] ?? '');


### PR DESCRIPTION
## Summary
- allow categories to be deleted through API and frontend
- tidy budgets, tags, and transactions when deleting categories

## Testing
- `php -l php_backend/models/Category.php`
- `php -l php_backend/public/categories.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899cbc7ae74832eab6c1a1060752c28