### PR TITLE
Disable browser caching across application

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,8 +1,8 @@
 <?php
 // Simple login page for user authentication.
 session_start();
+require_once __DIR__ . '/php_backend/nocache.php';
 require_once __DIR__ . '/php_backend/models/User.php';
-
 require_once __DIR__ . '/php_backend/models/Log.php';
 
 $error = '';
@@ -29,6 +29,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>Login</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/logout.php
+++ b/logout.php
@@ -1,6 +1,7 @@
 <?php
 // Log out the current user and redirect to login page.
 session_start();
+require_once __DIR__ . '/php_backend/nocache.php';
 session_destroy();
 header('Location: index.php');
 exit;

--- a/php_backend/nocache.php
+++ b/php_backend/nocache.php
@@ -1,0 +1,7 @@
+<?php
+// Send headers to prevent caching
+header('Cache-Control: no-cache, no-store, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
+?>
+

--- a/php_backend/public/account_dashboard.php
+++ b/php_backend/public/account_dashboard.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning account summaries.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Account.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/all_years_dashboard.php
+++ b/php_backend/public/all_years_dashboard.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning totals across all available years for tags, categories, and groups.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -1,6 +1,7 @@
 <?php
 // Exports selected data as JSON. Allows selecting categories, tags, groups,
 // transactions, and budgets via the `parts` query parameter.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/budgets.php
+++ b/php_backend/public/budgets.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint for managing category budgets.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Budget.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint for managing categories and their tag assignments.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Category.php';
 require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/dashboard.php
+++ b/php_backend/public/dashboard.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning monthly spending data for the dashboard.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/group_dashboard.php
+++ b/php_backend/public/group_dashboard.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning group spending summaries.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/groups.php
+++ b/php_backend/public/groups.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint for creating, listing, updating, and deleting transaction groups.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/TransactionGroup.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/index.php
+++ b/php_backend/public/index.php
@@ -1,5 +1,6 @@
 <?php
 // Simple script to insert a sample account for testing.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Account.php';
 

--- a/php_backend/public/link_transfer.php
+++ b/php_backend/public/link_transfer.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint to manually link two transactions as a transfer.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/logs.php
+++ b/php_backend/public/logs.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning recent application log entries.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/monthly_dashboard.php
+++ b/php_backend/public/monthly_dashboard.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning monthly totals for tags, categories, groups and income/outgoings.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/recurring_spend.php
+++ b/php_backend/public/recurring_spend.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint to analyse recurring spending over the past year.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/report.php
+++ b/php_backend/public/report.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint providing transaction reports filtered by various criteria.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -1,5 +1,6 @@
 <?php
 // Restores categories, tags, groups, transactions, and budgets from an uploaded JSON backup.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
 
 try {

--- a/php_backend/public/run_processes.php
+++ b/php_backend/public/run_processes.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint to manually run tagging and categorisation processes.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/search_transactions.php
+++ b/php_backend/public/search_transactions.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint to search transactions across all fields.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/tags.php
+++ b/php_backend/public/tags.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint for creating, listing, updating, and deleting tags.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/transaction.php
+++ b/php_backend/public/transaction.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning a single transaction's details.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/transaction_months.php
+++ b/php_backend/public/transaction_months.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint listing months that contain transaction data.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/transactions.php
+++ b/php_backend/public/transactions.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning transactions for a selected month and year.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/transfers.php
+++ b/php_backend/public/transfers.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint to list transfer pairs and OFX-marked transfer transactions.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/untagged_transactions.php
+++ b/php_backend/public/untagged_transactions.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning most common untagged transactions grouped by description and memo.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint to update tag, category, and group of a transaction.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';

--- a/php_backend/public/update_transaction_tag.php
+++ b/php_backend/public/update_transaction_tag.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint to update a transaction's tag and apply auto-tagging.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -1,5 +1,6 @@
 <?php
 // Handles OFX file uploads and imports transactions into the database.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Account.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/version.php
+++ b/php_backend/public/version.php
@@ -1,5 +1,6 @@
 <?php
 // Outputs the current git commit hash for version display without relying on shell_exec.
+require_once __DIR__ . '/../nocache.php';
 header('Content-Type: application/json');
 $rootDir = dirname(__DIR__, 2);
 $commitHash = '';

--- a/php_backend/public/yearly_dashboard.php
+++ b/php_backend/public/yearly_dashboard.php
@@ -1,5 +1,6 @@
 <?php
 // API endpoint returning yearly totals for tags, categories, and groups.
+require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/users.php
+++ b/users.php
@@ -2,6 +2,7 @@
 // Simple user management page to add users and change passwords.
 session_start();
 require_once __DIR__ . '/php_backend/models/User.php';
+require_once __DIR__ . '/php_backend/nocache.php';
 
 if (!isset($_SESSION['user_id'])) {
     header('Location: index.php');
@@ -40,6 +41,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>User Management</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>


### PR DESCRIPTION
## Summary
- Add shared PHP helper to send no-cache headers
- Apply no-cache headers to all PHP endpoints and pages
- Add no-cache meta tags to login and user management pages

## Testing
- `php -l index.php logout.php users.php php_backend/nocache.php php_backend/public/*.php`

------
https://chatgpt.com/codex/tasks/task_e_6899d1e89be0832ebc0b1f6c43323e3b