### PR TITLE
Add CORS headers for backend API

### DIFF
--- a/php_backend/nocache.php
+++ b/php_backend/nocache.php
@@ -3,5 +3,15 @@
 header('Cache-Control: no-cache, no-store, must-revalidate');
 header('Pragma: no-cache');
 header('Expires: 0');
+
+// Allow cross-origin requests
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(200);
+    exit;
+}
 ?>
 


### PR DESCRIPTION
## Summary
- allow backend PHP endpoints to be accessed cross-origin by sending CORS headers
- handle OPTIONS preflight requests in shared nocache include

## Testing
- `php -l php_backend/nocache.php`

------
https://chatgpt.com/codex/tasks/task_e_6899d452bc0c832e93084fa5ea45c1cc