### PR TITLE
Style popup overlay and color-code messages

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -72,7 +72,7 @@ async function loadCategories() {
                     const resTags = await fetch('../php_backend/public/tags.php?unassigned=1');
                     const allTags = await resTags.json();
                     if (allTags.length === 0) {
-                        showMessage('No unassigned tags available');
+                        showMessage('No unassigned tags available', 'error');
                         return;
                     }
                     const tagOptions = allTags.map(t => `${t.id}: ${t.name}`).join('\n');

--- a/frontend/js/backup.js
+++ b/frontend/js/backup.js
@@ -22,7 +22,7 @@ function initBackup() {
                         showMessage('Backup downloaded');
                     }
                 })
-                .catch(() => showMessage && showMessage('Download failed'));
+                .catch(() => showMessage && showMessage('Download failed', 'error'));
         });
     }
 
@@ -38,7 +38,7 @@ function initBackup() {
             fetch(form.action, { method: 'POST', body: fd })
                 .then(resp => resp.text())
                 .then(showMessage)
-                .catch(() => showMessage('Restore failed'));
+                .catch(() => showMessage('Restore failed', 'error'));
         });
     }
 }

--- a/frontend/js/overlay.js
+++ b/frontend/js/overlay.js
@@ -5,7 +5,7 @@
         const overlay = document.createElement('div');
         overlay.id = 'overlay';
         overlay.className = 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden';
-        overlay.innerHTML = '<div class="bg-white p-4 rounded shadow"></div>';
+        overlay.innerHTML = '<div class="p-6 rounded shadow text-white"></div>';
         overlay.addEventListener('click', () => overlay.classList.add('hidden'));
         document.body.appendChild(overlay);
         return overlay;
@@ -19,9 +19,16 @@
     let hideTimer;
 
     // Display a temporary message in the overlay
-    window.showMessage = function(msg){
+    window.showMessage = function(msg, type = 'success'){
         const overlay = window.__overlay || document.getElementById('overlay') || createOverlay();
-        overlay.querySelector('div').textContent = msg;
+        const box = overlay.querySelector('div');
+        box.textContent = msg;
+        box.className = 'p-6 rounded shadow text-white';
+        if(type === 'error') {
+            box.classList.add('bg-red-600');
+        } else {
+            box.classList.add('bg-green-600');
+        }
         overlay.classList.remove('hidden');
 
         clearTimeout(hideTimer);

--- a/frontend/js/upload.js
+++ b/frontend/js/upload.js
@@ -41,7 +41,7 @@ function initUpload() {
                         showMessage(xhr.responseText);
                     } else {
                         bar.classList.add('bg-red-600');
-                        showMessage('Upload failed');
+                        showMessage('Upload failed', 'error');
                     }
                 };
                 xhr.send(fd);
@@ -51,7 +51,7 @@ function initUpload() {
             fetch(form.action, { method: 'POST', body: data })
                 .then((resp) => resp.text())
                 .then(showMessage)
-                .catch(() => showMessage('Upload failed'));
+                .catch(() => showMessage('Upload failed', 'error'));
         }
     });
 }

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -181,7 +181,7 @@ form.addEventListener('submit', function(e) {
                         return value === '' || groupLookup.hasOwnProperty(value);
                     },
                     validationFailed: function(cell){
-                        showMessage('Invalid group selection');
+                        showMessage('Invalid group selection', 'error');
                     },
                     formatter: function(cell) {
                         const name = groupLookup[cell.getValue()] || '';
@@ -274,12 +274,12 @@ saveBtn.addEventListener('click', function() {
                 rowEl.classList.remove('bg-yellow-50');
                 pendingChanges.delete(id);
             } else {
-                showMessage('Failed to save group');
+                showMessage('Failed to save group', 'error');
             }
         })
         .catch(err => {
             console.error('Update request failed', err);
-            showMessage('Failed to save group');
+            showMessage('Failed to save group', 'error');
         })
         .finally(() => {
             savingRows.delete(id);

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -45,7 +45,7 @@
             });
             const data = await res.json();
             if(data.error){
-                showMessage('Error: ' + data.error);
+                showMessage('Error: ' + data.error, 'error');
                 return;
             }
             if(action === 'tagging'){


### PR DESCRIPTION
## Summary
- Restyle popup overlay to match site theme and color it green for success and red for errors
- Pass error flag to showMessage calls so failures display with red popup

## Testing
- `node frontend/js/upload.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6899d6453634832e822d21adc1ec50d8