### PR TITLE
Add alert on group dropdown change for statement debugging

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -1,12 +1,12 @@
 // Ensure the ResizeColumns module is available for Tabulator
 if (typeof Tabulator !== 'undefined' && !(Tabulator.prototype.modules && Tabulator.prototype.modules.resizeColumns)) {
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', 'https://unpkg.com/tabulator-tables@5.5.0/dist/js/modules/resizeColumns.min.js', false);
+    xhr.open('GET', 'https://unpkg.com/tabulator-tables@5.5.0/dist/js/modules/resizeColumns.js', false);
     xhr.send(null);
     if (xhr.status === 200) {
         eval(xhr.responseText);
     } else {
-        console.error('Failed to load Tabulator ResizeColumns module');
+        console.error('Failed to load Tabulator ResizeColumns module: ' + xhr.status);
     }
 }
 

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -192,6 +192,16 @@ form.addEventListener('submit', function(e) {
             ],
             cellEditing: function(cell){
                 cell.getElement().classList.add('bg-yellow-100');
+                if (cell.getField() === 'group_id') {
+                    setTimeout(() => {
+                        const editor = cell.getElement().querySelector('select');
+                        if (editor) {
+                            editor.addEventListener('change', e => {
+                                alert('Group dropdown changed to ' + e.target.value);
+                            }, { once: true });
+                        }
+                    }, 0);
+                }
             },
             cellEditCancelled: function(cell){
                 cell.getElement().classList.remove('bg-yellow-100');
@@ -204,6 +214,9 @@ form.addEventListener('submit', function(e) {
                     const oldVal = cell.getOldValue();
                     if (val === oldVal) return;
                     const data = cell.getRow().getData();
+                    const rowEl = cell.getRow().getElement();
+                    showMessage('Group selected: ' + (groupLookup[val] || 'None'));
+                    debug('Group selection changed to ' + val);
                     const payload = { transaction_id: data.id, account_id: data.account_id, description: data.description };
 
                     payload.group_id = val === '' ? '' : parseInt(val, 10);


### PR DESCRIPTION
## Summary
- Attach change listener to group dropdown cells in the monthly statement
- Pop up alert when dropdown selection changes for easier debugging
- Fix Tabulator ResizeColumns module URL to avoid CORS errors

## Testing
- `node --check frontend/js/tabulator-tailwind.js`
- `php -l php_backend/public/update_transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6899d68b5798832eb4e1eea2fdfdfcf2