### PR TITLE
Make tags and categories link to transaction search

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -166,8 +166,32 @@ form.addEventListener('submit', function(e) {
                     const id = cell.getRow().getData().id;
                     return `<a href="transaction.html?id=${id}">${cell.getValue()}</a>`;
                 } },
-                { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
-                { title: 'Tag', field: 'tag_name', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
+                {
+                    title: 'Category',
+                    field: 'category_name',
+                    formatter: function(cell){
+                        const value = cell.getValue();
+                        if (!value) return '';
+                        const badge = createBadge(value, 'bg-green-200 text-green-800');
+                        const link = document.createElement('a');
+                        link.href = `search.html?value=${encodeURIComponent(value)}`;
+                        link.appendChild(badge);
+                        return link;
+                    }
+                },
+                {
+                    title: 'Tag',
+                    field: 'tag_name',
+                    formatter: function(cell){
+                        const value = cell.getValue();
+                        if (!value) return '';
+                        const badge = createBadge(value, 'bg-blue-200 text-blue-800');
+                        const link = document.createElement('a');
+                        link.href = `search.html?value=${encodeURIComponent(value)}`;
+                        link.appendChild(badge);
+                        return link;
+                    }
+                },
                 {
                     title: 'Group',
                     field: 'group_id',

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -38,8 +38,7 @@
         return '£' + parseFloat(value).toFixed(2);
     }
 
-    document.getElementById('search-form').addEventListener('submit', function(e){
-        e.preventDefault();
+    function runSearch(){
         const term = document.getElementById('term').value;
         const amount = document.getElementById('amount').value;
         const params = new URLSearchParams();
@@ -106,7 +105,19 @@
                     chartEl.innerHTML = '';
                 }
             });
+    }
+
+    document.getElementById('search-form').addEventListener('submit', function(e){
+        e.preventDefault();
+        runSearch();
     });
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const initialValue = urlParams.get('value');
+    if (initialValue) {
+        document.getElementById('term').value = initialValue;
+        runSearch();
+    }
     </script>
     <script src="js/overlay.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Allow clicking category or tag in monthly statements to jump to search results for that label
- Autoload search results when search page receives a value query string

## Testing
- `php -l php_backend/public/search_transactions.php`


------
https://chatgpt.com/codex/tasks/task_e_6899e2c583f8832e9de6825cba465dbf