### PR TITLE
Filter statement page for untagged transactions by default

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -28,6 +28,10 @@
                         <label for="month" class="block text-sm font-medium text-gray-700 mb-1">Month</label>
                         <select id="month" name="month" class="border p-2 rounded w-32" data-help="Select month"></select>
                     </div>
+                    <div class="flex items-center space-x-2 mb-1">
+                        <input type="checkbox" id="untagged-only" class="h-4 w-4" checked data-help="Show only untagged transactions">
+                        <label for="untagged-only" class="text-sm text-gray-700">Only untagged</label>
+                    </div>
                     <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">View</button>
                 </form>
             </div>
@@ -99,11 +103,13 @@ fetch('../php_backend/public/transaction_months.php')
     });
 
 const form = document.getElementById('statement-form');
-form.addEventListener('submit', function(e) {
-    e.preventDefault();
+const untaggedOnly = document.getElementById('untagged-only');
+
+function loadTransactions() {
     const month = monthSelect.value;
     const year = yearSelect.value;
-    fetch('../php_backend/public/transactions.php?month=' + month + '&year=' + year)
+    const untaggedParam = untaggedOnly.checked ? '&untagged=1' : '';
+    fetch('../php_backend/public/transactions.php?month=' + month + '&year=' + year + untaggedParam)
         .then(r => r.json())
         .then(data => {
             let income = 0, outgoings = 0;
@@ -168,7 +174,14 @@ form.addEventListener('submit', function(e) {
                 ]
             });
         });
+}
+
+form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    loadTransactions();
 });
+
+untaggedOnly.addEventListener('change', loadTransactions);
 </script>
     <script src="js/overlay.js"></script>
 </body>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -162,8 +162,9 @@ class Transaction {
 
     /**
      * Retrieve all transactions for a specific month and year.
+     * Optionally limit results to only untagged transactions.
      */
-    public static function getByMonth(int $month, int $year): array {
+    public static function getByMonth(int $month, int $year, bool $onlyUntagged = false): array {
         $db = Database::getConnection();
         $sql = 'SELECT t.`id`, t.`account_id`, t.`date`, t.`amount`, t.`description`, t.`memo`, '
              . 't.`category_id`, t.`tag_id`, t.`group_id`, t.`transfer_id`, '
@@ -172,8 +173,11 @@ class Transaction {
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` '
-             . 'WHERE MONTH(t.`date`) = :month AND YEAR(t.`date`) = :year '
-             . 'ORDER BY t.`date`';
+             . 'WHERE MONTH(t.`date`) = :month AND YEAR(t.`date`) = :year';
+        if ($onlyUntagged) {
+            $sql .= ' AND t.`tag_id` IS NULL';
+        }
+        $sql .= ' ORDER BY t.`date`';
         $stmt = $db->prepare($sql);
         $stmt->execute(['month' => $month, 'year' => $year]);
 

--- a/php_backend/public/transactions.php
+++ b/php_backend/public/transactions.php
@@ -8,9 +8,10 @@ header('Content-Type: application/json');
 
 $month = isset($_GET['month']) ? (int)$_GET['month'] : date('n');
 $year = isset($_GET['year']) ? (int)$_GET['year'] : date('Y');
+$onlyUntagged = isset($_GET['untagged']) && $_GET['untagged'] === '1';
 
 try {
-    $transactions = Transaction::getByMonth($month, $year);
+    $transactions = Transaction::getByMonth($month, $year, $onlyUntagged);
     echo json_encode($transactions);
 } catch (Exception $e) {
     http_response_code(500);


### PR DESCRIPTION
## Summary
- Show only untagged transactions by default on the monthly statement page
- Add toggle to view all transactions and pass filter flag to backend
- Support optional untagged filtering in transaction API and model

## Testing
- `php -l php_backend/public/transactions.php`
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_6899f8b30e50832e9c1b55e0e5927620