### PR TITLE
Apply Algolia-inspired styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,17 +9,21 @@
     <meta http-equiv="Expires" content="0">
     <title>Finance Manager</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+    </style>
 </head>
-<body class="bg-gray-50 font-sans">
+<body class="bg-gradient-to-br from-indigo-50 via-white to-blue-50">
     <div class="flex min-h-screen">
-        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white/80 backdrop-blur border-r p-6 shadow"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
-            <h1 class="text-2xl font-semibold mb-4">Welcome to Finance Manager</h1>
-            <p>Select an option from the menu to get started.</p>
-            <p id="version">Version: loading...</p>
+            <h1 class="text-3xl font-semibold mb-4 text-indigo-700">Welcome to Finance Manager</h1>
+            <p class="text-gray-700">Select an option from the menu to get started.</p>
+            <p id="version" class="text-gray-500">Version: loading...</p>
 
-            <section class="mt-8 bg-white p-6 rounded shadow">
-                <h2 class="text-xl font-semibold mb-4">What You Can Do</h2>
+            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg">
+                <h2 class="text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
                 <ul class="list-disc pl-5 space-y-2">
                     <li>Upload OFX files to import your bank statements.</li>
                     <li>Explore your finances through dashboards:

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -5,65 +5,65 @@
   <div>
     <h3 class="text-lg font-semibold mb-2">Overview</h3>
     <ul class="space-y-2">
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="index.html"><i class="fa-solid fa-house mr-2"></i> Home</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="upload.html"><i class="fa-solid fa-upload mr-2"></i> Upload OFX Files</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="index.html"><i class="fa-solid fa-house mr-2"></i> Home</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="upload.html"><i class="fa-solid fa-upload mr-2"></i> Upload OFX Files</a></li>
     </ul>
   </div>
 
   <div>
     <h3 class="text-lg font-semibold mb-2">Dashboards</h3>
     <ul class="space-y-2">
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line mr-2"></i> Yearly Dashboard</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar mr-2"></i> All Years Dashboard</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-2"></i> Monthly Dashboard</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="group_dashboard.html"><i class="fa-solid fa-users mr-2"></i> Group Dashboard</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="account_dashboard.html"><i class="fa-solid fa-wallet mr-2"></i> Account Dashboard</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="recurring_spend.html"><i class="fa-solid fa-repeat mr-2"></i> Recurring Spend</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line mr-2"></i> Yearly Dashboard</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar mr-2"></i> All Years Dashboard</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-2"></i> Monthly Dashboard</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="group_dashboard.html"><i class="fa-solid fa-users mr-2"></i> Group Dashboard</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="account_dashboard.html"><i class="fa-solid fa-wallet mr-2"></i> Account Dashboard</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="recurring_spend.html"><i class="fa-solid fa-repeat mr-2"></i> Recurring Spend</a></li>
     </ul>
   </div>
 
   <div>
     <h3 class="text-lg font-semibold mb-2">Graphs</h3>
     <ul class="space-y-2">
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="graphs.html"><i class="fa-solid fa-chart-pie mr-2"></i> Graphs</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="graphs.html"><i class="fa-solid fa-chart-pie mr-2"></i> Graphs</a></li>
     </ul>
   </div>
 
   <div>
     <h3 class="text-lg font-semibold mb-2">Budgets</h3>
     <ul class="space-y-2">
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="budgets.html"><i class="fa-solid fa-wallet mr-2"></i> Budgets</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="budgets.html"><i class="fa-solid fa-wallet mr-2"></i> Budgets</a></li>
     </ul>
   </div>
 
   <div>
     <h3 class="text-lg font-semibold mb-2">Transactions</h3>
     <ul class="space-y-2">
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-2"></i> View Monthly Statement</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="report.html"><i class="fa-solid fa-table mr-2"></i> Transaction Reports</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="search.html"><i class="fa-solid fa-magnifying-glass mr-2"></i> Search Transactions</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="transfers.html"><i class="fa-solid fa-right-left mr-2"></i> Transfers</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-2"></i> View Monthly Statement</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="report.html"><i class="fa-solid fa-table mr-2"></i> Transaction Reports</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="search.html"><i class="fa-solid fa-magnifying-glass mr-2"></i> Search Transactions</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="transfers.html"><i class="fa-solid fa-right-left mr-2"></i> Transfers</a></li>
     </ul>
   </div>
 
   <div>
     <h3 class="text-lg font-semibold mb-2">Organisation</h3>
     <ul class="space-y-2">
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="tags.html"><i class="fa-solid fa-tags mr-2"></i> Manage Tags</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="missing_tags.html"><i class="fa-solid fa-circle-question mr-2"></i> Missing Tags</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="categories.html"><i class="fa-solid fa-folder-open mr-2"></i> Manage Categories</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="groups.html"><i class="fa-solid fa-users mr-2"></i> Manage Groups</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="tags.html"><i class="fa-solid fa-tags mr-2"></i> Manage Tags</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="missing_tags.html"><i class="fa-solid fa-circle-question mr-2"></i> Missing Tags</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="categories.html"><i class="fa-solid fa-folder-open mr-2"></i> Manage Categories</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="groups.html"><i class="fa-solid fa-users mr-2"></i> Manage Groups</a></li>
     </ul>
   </div>
 
   <div>
     <h3 class="text-lg font-semibold mb-2">Administration</h3>
     <ul class="space-y-2">
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="processes.html"><i class="fa-solid fa-gear mr-2"></i> Run Processes</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="logs.html"><i class="fa-solid fa-clipboard-list mr-2"></i> View Logs</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="backup.html"><i class="fa-solid fa-database mr-2"></i> Backup &amp; Restore</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../users.php"><i class="fa-solid fa-user mr-2"></i> Manage Users</a></li>
-      <li><a class="flex items-center text-blue-600 hover:text-blue-800" href="../logout.php"><i class="fa-solid fa-right-from-bracket mr-2"></i> Logout</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="processes.html"><i class="fa-solid fa-gear mr-2"></i> Run Processes</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="logs.html"><i class="fa-solid fa-clipboard-list mr-2"></i> View Logs</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="backup.html"><i class="fa-solid fa-database mr-2"></i> Backup &amp; Restore</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="../users.php"><i class="fa-solid fa-user mr-2"></i> Manage Users</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="../logout.php"><i class="fa-solid fa-right-from-bracket mr-2"></i> Logout</a></li>
     </ul>
   </div>
 </div>

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -1,17 +1,17 @@
 
-<header class="fixed top-0 left-0 right-0 z-50 bg-blue-600 text-white h-16 flex items-center shadow">
+<header class="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur text-gray-800 h-16 flex items-center shadow">
 
   <div class="w-full flex items-center justify-between px-4">
     <div class="flex items-center space-x-4">
-      <button id="menu-toggle" class="md:hidden bg-blue-700 p-2 rounded"><i class="fa-solid fa-bars"></i></button>
-      <div class="font-bold text-lg">Finance Manager</div>
+      <button id="menu-toggle" class="md:hidden bg-indigo-600 text-white p-2 rounded"><i class="fa-solid fa-bars"></i></button>
+      <div class="font-bold text-lg text-indigo-700">Finance Manager</div>
     </div>
     <div class="flex items-center space-x-4">
       <form id="topbar-search" action="search.html" method="get" class="flex">
-        <input type="text" name="value" placeholder="Search transactions" class="p-1 rounded text-black" />
-        <button type="submit" class="ml-2"><i class="fa-solid fa-magnifying-glass"></i></button>
+        <input type="text" name="value" placeholder="Search transactions" class="p-1 rounded border border-gray-300" />
+        <button type="submit" class="ml-2 text-indigo-600"><i class="fa-solid fa-magnifying-glass"></i></button>
       </form>
-      <a id="latest-statement-link" href="monthly_statement.html" class="flex items-center">
+      <a id="latest-statement-link" href="monthly_statement.html" class="flex items-center text-indigo-600">
         <i class="fa-solid fa-file-invoice-dollar mr-1"></i>
         <span id="latest-statement-text">Latest Statement</span>
       </a>


### PR DESCRIPTION
## Summary
- Add Inter font and gradient backgrounds for an Algolia-like feel on the landing page
- Restyle navigation menu with indigo hover cards
- Refresh top bar with translucent white background and indigo accents

## Testing
- `php -l index.php`
- `php -l logout.php`


------
https://chatgpt.com/codex/tasks/task_e_689a00722728832e81e629db1c2300f8