### PR TITLE
Add global top bar with search and statement shortcut

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -17,12 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
       'hidden',
       'md:block',
       'fixed',
-      'md:relative',
-      'top-0',
+      'top-16',
+      'bottom-0',
       'left-0',
-      'h-full',
       'overflow-y-auto',
-      'z-50'
+      'z-40'
     );
 
     // Load Font Awesome for menu icons if not already loaded
@@ -33,17 +32,6 @@ document.addEventListener('DOMContentLoaded', () => {
       link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css';
       document.head.appendChild(link);
     }
-
-    // Button to toggle the menu on mobile devices
-    const toggle = document.createElement('button');
-    toggle.id = 'menu-toggle';
-    toggle.className =
-      'md:hidden fixed top-4 left-4 bg-blue-600 text-white p-2 rounded shadow z-50';
-    toggle.innerHTML = '<i class="fa-solid fa-bars"></i>';
-    toggle.addEventListener('click', () => {
-      menu.classList.toggle('hidden');
-    });
-    document.body.appendChild(toggle);
 
     fetch('menu.html')
       .then(resp => resp.text())
@@ -56,6 +44,48 @@ document.addEventListener('DOMContentLoaded', () => {
       })
       .catch(err => console.error('Menu load failed', err));
   }
+
+  // Load the top bar with site name, search and latest statement link
+  fetch('topbar.html')
+    .then(resp => resp.text())
+    .then(html => {
+      document.body.insertAdjacentHTML('afterbegin', html);
+      const content = document.querySelector('body > div.flex');
+      if (content) {
+        content.classList.add('pt-16', 'h-screen', 'overflow-hidden');
+        const main = content.querySelector('main');
+        if (main) {
+          main.classList.add('h-full', 'overflow-y-auto', 'md:ml-64');
+        }
+      }
+
+      const toggle = document.getElementById('menu-toggle');
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          if (menu) menu.classList.toggle('hidden');
+        });
+      }
+
+      const latestLink = document.getElementById('latest-statement-link');
+      const latestText = document.getElementById('latest-statement-text');
+      if (latestLink && latestText) {
+        fetch('../php_backend/public/transaction_months.php')
+          .then(r => r.json())
+          .then(months => {
+            if (months.length > 0) {
+              const { year, month } = months[0];
+              const names = [
+                'January','February','March','April','May','June',
+                'July','August','September','October','November','December'
+              ];
+              latestLink.href = `monthly_statement.html?year=${year}&month=${month}`;
+              latestText.textContent = `Latest Statement: ${names[month - 1]} ${year}`;
+            }
+          })
+          .catch(err => console.error('Latest statement load failed', err));
+      }
+    })
+    .catch(err => console.error('Top bar load failed', err));
 
   // Apply Tailwind card styling to all sections or wrap main content in a card
   document.querySelectorAll('main').forEach(main => {

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -1,0 +1,18 @@
+<header class="fixed top-0 left-0 right-0 z-50 bg-blue-600 text-white h-16 flex items-center shadow">
+  <div class="w-full flex items-center justify-between px-4">
+    <div class="flex items-center space-x-4">
+      <button id="menu-toggle" class="md:hidden bg-blue-700 p-2 rounded"><i class="fa-solid fa-bars"></i></button>
+      <div class="font-bold text-lg">Personal Finance Manager</div>
+    </div>
+    <div class="flex items-center space-x-4">
+      <form id="topbar-search" action="search.html" method="get" class="flex">
+        <input type="text" name="value" placeholder="Search transactions" class="p-1 rounded text-black" />
+        <button type="submit" class="ml-2"><i class="fa-solid fa-magnifying-glass"></i></button>
+      </form>
+      <a id="latest-statement-link" href="monthly_statement.html" class="flex items-center">
+        <i class="fa-solid fa-file-invoice-dollar mr-1"></i>
+        <span id="latest-statement-text">Latest Statement</span>
+      </a>
+    </div>
+  </div>
+</header>


### PR DESCRIPTION
## Summary
- Add responsive top bar showing site name, quick transaction search and latest statement link
- Load top bar on every page via updated menu script and fetch latest statement month
- Keep top bar and side menu fixed so only main content scrolls

## Testing
- `node --check frontend/js/menu.js`
- `php php_backend/public/transaction_months.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899f9b9a3c0832eb526ab4de41697a2