### PR TITLE
Refine sidebar spacing and typography

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,10 +9,10 @@
     <meta http-equiv="Expires" content="0">
     <title>Finance Manager</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;500&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="logo.svg">
     <style>
-        body { font-family: 'Inter', sans-serif; }
+        body { font-family: 'Roboto', sans-serif; font-weight: 300; }
     </style>
 </head>
 <body class="bg-gradient-to-br from-indigo-50 via-white to-blue-50">

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -33,6 +33,17 @@ document.addEventListener('DOMContentLoaded', () => {
       document.head.appendChild(link);
     }
 
+    // Load Roboto font for a lighter appearance
+    if (!document.getElementById('roboto-font')) {
+      const fontLink = document.createElement('link');
+      fontLink.id = 'roboto-font';
+      fontLink.rel = 'stylesheet';
+      fontLink.href = 'https://fonts.googleapis.com/css2?family=Roboto:wght@300;500&display=swap';
+      document.head.appendChild(fontLink);
+    }
+    document.body.style.fontFamily = 'Roboto, sans-serif';
+    document.body.style.fontWeight = '300';
+
     fetch('menu.html')
       .then(resp => resp.text())
       .then(html => {

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -1,18 +1,28 @@
 <!-- Navigation menu shared across pages -->
 <img src="logo.svg" alt="Finance Manager Logo" class="w-32 mb-4 mx-auto">
 <h2 class="text-xl font-semibold mb-4">Menu</h2>
-<div class="space-y-6">
+<div class="space-y-4">
   <div>
-    <h3 class="text-lg font-semibold mb-2">Overview</h3>
-    <ul class="space-y-2">
+    <h3 class="text-lg font-semibold mb-2">General Overview</h3>
+    <ul class="space-y-1">
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="index.html"><i class="fa-solid fa-house mr-2"></i> Home</a></li>
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="upload.html"><i class="fa-solid fa-upload mr-2"></i> Upload OFX Files</a></li>
     </ul>
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Dashboards</h3>
-    <ul class="space-y-2">
+    <h3 class="text-lg font-semibold mb-2">Transaction Hub</h3>
+    <ul class="space-y-1">
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-2"></i> View Monthly Statement</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="report.html"><i class="fa-solid fa-table mr-2"></i> Transaction Reports</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="search.html"><i class="fa-solid fa-magnifying-glass mr-2"></i> Search Transactions</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="transfers.html"><i class="fa-solid fa-right-left mr-2"></i> Transfers</a></li>
+    </ul>
+  </div>
+
+  <div>
+    <h3 class="text-lg font-semibold mb-2">Data Dashboards</h3>
+    <ul class="space-y-1">
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line mr-2"></i> Yearly Dashboard</a></li>
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar mr-2"></i> All Years Dashboard</a></li>
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-2"></i> Monthly Dashboard</a></li>
@@ -23,32 +33,22 @@
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Graphs</h3>
-    <ul class="space-y-2">
+    <h3 class="text-lg font-semibold mb-2">Data Graphs</h3>
+    <ul class="space-y-1">
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="graphs.html"><i class="fa-solid fa-chart-pie mr-2"></i> Graphs</a></li>
     </ul>
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Budgets</h3>
-    <ul class="space-y-2">
+    <h3 class="text-lg font-semibold mb-2">Budget Plans</h3>
+    <ul class="space-y-1">
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="budgets.html"><i class="fa-solid fa-wallet mr-2"></i> Budgets</a></li>
     </ul>
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Transactions</h3>
-    <ul class="space-y-2">
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-2"></i> View Monthly Statement</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="report.html"><i class="fa-solid fa-table mr-2"></i> Transaction Reports</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="search.html"><i class="fa-solid fa-magnifying-glass mr-2"></i> Search Transactions</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="transfers.html"><i class="fa-solid fa-right-left mr-2"></i> Transfers</a></li>
-    </ul>
-  </div>
-
-  <div>
-    <h3 class="text-lg font-semibold mb-2">Organisation</h3>
-    <ul class="space-y-2">
+    <h3 class="text-lg font-semibold mb-2">Data Organisation</h3>
+    <ul class="space-y-1">
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="tags.html"><i class="fa-solid fa-tags mr-2"></i> Manage Tags</a></li>
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="missing_tags.html"><i class="fa-solid fa-circle-question mr-2"></i> Missing Tags</a></li>
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="categories.html"><i class="fa-solid fa-folder-open mr-2"></i> Manage Categories</a></li>
@@ -57,8 +57,8 @@
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Administration</h3>
-    <ul class="space-y-2">
+    <h3 class="text-lg font-semibold mb-2">Admin Tools</h3>
+    <ul class="space-y-1">
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="processes.html"><i class="fa-solid fa-gear mr-2"></i> Run Processes</a></li>
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="logs.html"><i class="fa-solid fa-clipboard-list mr-2"></i> View Logs</a></li>
       <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="backup.html"><i class="fa-solid fa-database mr-2"></i> Backup &amp; Restore</a></li>


### PR DESCRIPTION
## Summary
- switch site to lighter Roboto font
- tighten sidebar spacing and rename sections to two-word titles
- move transaction tools to second section in sidebar

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689a0f08e4dc832ebf5a6ffbba85e0b0