### PR TITLE
Use HTTPS and secure sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,21 @@ You can view these entries by opening `frontend/logs.html` which calls the
 
 To import transactions from one or more OFX files, use the upload script:
 ```bash
-curl -F "ofx_files[]=@first.ofx" -F "ofx_files[]=@second.ofx" http://localhost/path/to/php_backend/public/upload_ofx.php
+curl -F "ofx_files[]=@first.ofx" -F "ofx_files[]=@second.ofx" https://localhost/path/to/php_backend/public/upload_ofx.php
 ```
 You can try this using the included sample file `sample_data/test.ofx` which
 contains two transactions for a checking account.
 
 ## Running a Local Server
 
-To use the upload page the frontend must be served over HTTP so the PHP parser
+To use the upload page the frontend must be served over HTTPS so the PHP parser
 can receive the request. From the repository root run:
 
 ```bash
 php -S localhost:8000
 ```
 
-Then open `http://localhost:8000/frontend/index.html` in your browser.
+Then open `https://localhost:8000/frontend/index.html` in your browser.
 
 
 ## Backup and Recovery

--- a/frontend/logo.svg
+++ b/frontend/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+<svg xmlns="https://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
   <title>Wallet Icon</title>
   <rect x="6" y="18" width="52" height="30" rx="4" ry="4" fill="#1d4ed8" />
   <rect x="6" y="12" width="32" height="12" rx="4" ry="4" fill="#3b82f6" />

--- a/index.php
+++ b/index.php
@@ -1,5 +1,6 @@
 <?php
 // Simple login page for user authentication.
+ini_set('session.cookie_secure', '1');
 session_start();
 require_once __DIR__ . '/php_backend/nocache.php';
 require_once __DIR__ . '/php_backend/models/User.php';

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,6 @@
 <?php
 // Log out the current user and redirect to login page.
+ini_set('session.cookie_secure', '1');
 session_start();
 require_once __DIR__ . '/php_backend/nocache.php';
 session_destroy();

--- a/users.php
+++ b/users.php
@@ -1,5 +1,6 @@
 <?php
 // Simple user management page to add users and change passwords.
+ini_set('session.cookie_secure', '1');
 session_start();
 require_once __DIR__ . '/php_backend/models/User.php';
 require_once __DIR__ . '/php_backend/nocache.php';


### PR DESCRIPTION
## Summary
- Update docs and assets to use HTTPS scheme
- Ensure PHP sessions use secure cookies under HTTPS

## Testing
- `php -l index.php`
- `php -l users.php`
- `php -l logout.php`
- `xmllint --noout frontend/logo.svg` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a1505a698832ebfd232d2e9f974fd