### PR TITLE
Fix SVG namespace for site icon over HTTPS

### DIFF
--- a/frontend/logo.svg
+++ b/frontend/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="https://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
   <title>Wallet Icon</title>
   <rect x="6" y="18" width="52" height="30" rx="4" ry="4" fill="#1d4ed8" />
   <rect x="6" y="12" width="32" height="12" rx="4" ry="4" fill="#3b82f6" />


### PR DESCRIPTION
## Summary
- Correct SVG namespace in `logo.svg` so the site icon loads over HTTPS

## Testing
- `xmllint frontend/logo.svg` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a22e2a894832ebd53064faac05cb6