### PR TITLE
chore: upgrade tabulator to 6.3

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Account Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -25,7 +25,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>All Years Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -38,7 +38,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Budgets</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
 <div class="flex min-h-screen">
@@ -36,7 +36,7 @@
 </div>
 <script src="js/menu.js"></script>
 <script src="js/input_help.js"></script>
-<script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+<script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
 <script src="js/tabulator-tailwind.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script>

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Categories</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -29,7 +29,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
 let categoryTable;

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Group Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -36,7 +36,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Groups</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -29,7 +29,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
 let groupTable;

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -4,7 +4,7 @@
 // to fetch it without CORS issues.
 if (typeof Tabulator !== 'undefined' && !(Tabulator.prototype.modules && Tabulator.prototype.modules.resizeColumns)) {
     var script = document.createElement('script');
-    script.src = 'https://unpkg.com/tabulator-tables@5.5.0/dist/js/modules/resizeColumns.js';
+    script.src = 'https://unpkg.com/tabulator-tables@6.3.0/dist/js/modules/resizeColumns.js';
     script.async = false;
     document.head.appendChild(script);
 }

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Application Logs</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -22,7 +22,7 @@
     </div>
 
     <script src="js/menu.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
     fetch('../php_backend/public/logs.php')

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Missing Tags</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -20,7 +20,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
     let table;

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Monthly Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -60,7 +60,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Monthly Statement</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
@@ -82,7 +82,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/highcharts-more.js"></script>

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Recurring Spend Detection</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -23,7 +23,7 @@
         </main>
     </div>
     <script src="js/menu.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
     function formatCurrency(value){

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Transaction Reports</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -40,7 +40,7 @@
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
 

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Search Transactions</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -29,7 +29,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Tags</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -30,7 +30,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
 let tagTable;

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Account Transfers</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -34,7 +34,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
     fetch('../php_backend/public/transfers.php')

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Yearly Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -42,7 +42,7 @@
     </div>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
-    <script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- bump Tabulator CDN links to version 6.3
- update Tabulator Tailwind helper to load resizeColumns module from 6.3

## Testing
- `php -l index.php`
- `rg "tabulator-tables@5.5.0" -n`
- `rg "tabulator-tables@6.3.0" -n`


------
https://chatgpt.com/codex/tasks/task_e_689a245b1bd0832ea9459a66214f1678