### PR TITLE
Add descriptions for tags, categories and groups

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -19,6 +19,7 @@
             <p class="mb-4">Create categories and assign tags to organise your transactions.</p>
             <form id="category-form" class="space-y-4">
                 <label class="block">Category Name<br><input type="text" id="category-name" class="border p-2 rounded w-full" data-help="Name for the category"></label>
+                <label class="block">Description<br><textarea id="category-description" class="border p-2 rounded w-full" data-help="Description for the category"></textarea></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create Category</button>
             </form>
             <div class="mt-6 bg-white p-4 rounded shadow">
@@ -37,7 +38,7 @@ let categoryTable;
 async function loadCategories() {
     const res = await fetch('../php_backend/public/categories.php');
     const cats = await res.json();
-    const data = cats.map(c => ({id: c.id, name: c.name, tags: c.tags.map(t => t.name)}));
+    const data = cats.map(c => ({id: c.id, name: c.name, description: c.description, tags: c.tags.map(t => t.name)}));
     if (categoryTable) {
         categoryTable.setData(data);
         return;
@@ -47,6 +48,7 @@ async function loadCategories() {
         layout: 'fitColumns',
         columns: [
             { title: 'Name', field: 'name', formatter: badgeFormatter('bg-green-200 text-green-800') },
+            { title: 'Description', field: 'description' },
             { title: 'Tags', field: 'tags', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
             { title: 'Actions', formatter: function(cell){
                 const c = cell.getRow().getData();
@@ -57,10 +59,12 @@ async function loadCategories() {
                 editBtn.addEventListener('click', async () => {
                     const name = prompt('Category Name', c.name);
                     if (name === null) return;
+                    const description = prompt('Description', c.description || '');
+                    if (description === null) return;
                     await fetch('../php_backend/public/categories.php', {
                         method: 'PUT',
                         headers: {'Content-Type': 'application/json'},
-                        body: JSON.stringify({id: c.id, name})
+                        body: JSON.stringify({id: c.id, name, description})
                     });
                     loadCategories();
                     showMessage('Category updated');
@@ -111,12 +115,14 @@ async function loadCategories() {
 document.getElementById('category-form').addEventListener('submit', async e => {
     e.preventDefault();
     const name = document.getElementById('category-name').value;
+    const description = document.getElementById('category-description').value;
     await fetch('../php_backend/public/categories.php', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({name})
+        body: JSON.stringify({name, description})
     });
     document.getElementById('category-name').value = '';
+    document.getElementById('category-description').value = '';
     loadCategories();
     showMessage('Category created');
 });

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -19,6 +19,7 @@
             <p class="mb-4">Create groups to collect related categories for reporting.</p>
             <form id="group-form" class="space-y-4">
                 <label class="block">Group Name<br><input type="text" id="group-name" class="border p-2 rounded w-full" data-help="Name for the group"></label>
+                <label class="block">Description<br><textarea id="group-description" class="border p-2 rounded w-full" data-help="Description for the group"></textarea></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create Group</button>
             </form>
             <div class="mt-6 bg-white p-4 rounded shadow">
@@ -46,6 +47,7 @@ async function loadGroups() {
         layout: 'fitColumns',
         columns: [
             { title: 'Name', field: 'name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
+            { title: 'Description', field: 'description' },
             { title: 'Actions', formatter: function(cell){
                 const g = cell.getRow().getData();
                 const container = document.createElement('div');
@@ -55,10 +57,12 @@ async function loadGroups() {
                 edit.addEventListener('click', async () => {
                     const name = prompt('Group Name', g.name);
                     if (name === null) return;
+                    const description = prompt('Description', g.description || '');
+                    if (description === null) return;
                     await fetch('../php_backend/public/groups.php', {
                         method: 'PUT',
                         headers: {'Content-Type': 'application/json'},
-                        body: JSON.stringify({id: g.id, name})
+                        body: JSON.stringify({id: g.id, name, description})
                     });
                     loadGroups();
                     showMessage('Group updated');
@@ -87,12 +91,14 @@ async function loadGroups() {
 document.getElementById('group-form').addEventListener('submit', async e => {
     e.preventDefault();
     const name = document.getElementById('group-name').value;
+    const description = document.getElementById('group-description').value;
     await fetch('../php_backend/public/groups.php', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({name})
+        body: JSON.stringify({name, description})
     });
     document.getElementById('group-name').value = '';
+    document.getElementById('group-description').value = '';
     loadGroups();
     showMessage('Group created');
 });

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -20,6 +20,7 @@
             <form id="tag-form" class="space-y-4">
                 <label class="block">Tag Name<br><input type="text" id="tag-name" class="border p-2 rounded w-full" data-help="Name for the tag"></label>
                 <label class="block">Keyword (for auto tagging)<br><input type="text" id="tag-keyword" class="border p-2 rounded w-full" data-help="Keyword used to auto-tag transactions"></label>
+                <label class="block">Description<br><textarea id="tag-description" class="border p-2 rounded w-full" data-help="Description for the tag"></textarea></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create Tag</button>
             </form>
             <div class="mt-6 bg-white p-4 rounded shadow">
@@ -48,6 +49,7 @@ async function loadTags(){
         columns: [
             { title: 'Name', field: 'name', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
             { title: 'Keyword', field: 'keyword' },
+            { title: 'Description', field: 'description' },
             { title: 'Actions', formatter: function(cell){
                 const t = cell.getRow().getData();
                 const container = document.createElement('div');
@@ -59,10 +61,12 @@ async function loadTags(){
                     if (name === null) return;
                     const keyword = prompt('Keyword (for auto tagging)', t.keyword || '');
                     if (keyword === null) return;
+                    const description = prompt('Description', t.description || '');
+                    if (description === null) return;
                     await fetch('../php_backend/public/tags.php', {
                         method: 'PUT',
                         headers: {'Content-Type':'application/json'},
-                        body: JSON.stringify({id: t.id, name, keyword})
+                        body: JSON.stringify({id: t.id, name, keyword, description})
                     });
                     loadTags();
                     showMessage('Tag updated');
@@ -92,13 +96,15 @@ document.getElementById('tag-form').addEventListener('submit', async (e)=>{
     e.preventDefault();
     const name = document.getElementById('tag-name').value;
     const keyword = document.getElementById('tag-keyword').value;
+    const description = document.getElementById('tag-description').value;
     await fetch('../php_backend/public/tags.php', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
-        body: JSON.stringify({name, keyword})
+        body: JSON.stringify({name, keyword, description})
     });
     document.getElementById('tag-name').value='';
     document.getElementById('tag-keyword').value='';
+    document.getElementById('tag-description').value='';
     loadTags();
     showMessage("Tag created");
 });

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -34,7 +34,8 @@ CREATE TABLE IF NOT EXISTS accounts (
 
 CREATE TABLE IF NOT EXISTS categories (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(100) NOT NULL
+    name VARCHAR(100) NOT NULL,
+    description TEXT DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS budgets (
@@ -50,7 +51,8 @@ CREATE TABLE IF NOT EXISTS budgets (
 CREATE TABLE IF NOT EXISTS tags (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
-    keyword VARCHAR(100) DEFAULT NULL
+    keyword VARCHAR(100) DEFAULT NULL,
+    description TEXT DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS category_tags (
@@ -63,7 +65,8 @@ CREATE TABLE IF NOT EXISTS category_tags (
 
 CREATE TABLE IF NOT EXISTS transaction_groups (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(100) NOT NULL
+    name VARCHAR(100) NOT NULL,
+    description TEXT DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS transactions (
@@ -99,6 +102,24 @@ $db->exec($createSql);
 $result = $db->query("SHOW COLUMNS FROM `tags` LIKE 'keyword'");
 if ($result->rowCount() === 0) {
     $db->exec("ALTER TABLE `tags` ADD COLUMN `keyword` VARCHAR(100) DEFAULT NULL");
+}
+
+// Ensure description column exists in tags
+$result = $db->query("SHOW COLUMNS FROM `tags` LIKE 'description'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `tags` ADD COLUMN `description` TEXT DEFAULT NULL");
+}
+
+// Ensure description column exists in categories
+$result = $db->query("SHOW COLUMNS FROM `categories` LIKE 'description'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `categories` ADD COLUMN `description` TEXT DEFAULT NULL");
+}
+
+// Ensure description column exists in transaction_groups
+$result = $db->query("SHOW COLUMNS FROM `transaction_groups` LIKE 'description'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `transaction_groups` ADD COLUMN `description` TEXT DEFAULT NULL");
 }
 
 // Ensure transfer_id column exists in transactions

--- a/php_backend/models/Category.php
+++ b/php_backend/models/Category.php
@@ -6,20 +6,20 @@ class Category {
     /**
      * Insert a new category and return its ID.
      */
-    public static function create(string $name): int {
+    public static function create(string $name, ?string $description = null): int {
         $db = Database::getConnection();
-        $stmt = $db->prepare('INSERT INTO categories (name) VALUES (:name)');
-        $stmt->execute(['name' => $name]);
+        $stmt = $db->prepare('INSERT INTO categories (name, description) VALUES (:name, :description)');
+        $stmt->execute(['name' => $name, 'description' => $description]);
         return (int)$db->lastInsertId();
     }
 
     /**
-     * Update the name of an existing category.
+     * Update the name and description of an existing category.
      */
-    public static function update(int $id, string $name): void {
+    public static function update(int $id, string $name, ?string $description = null): void {
         $db = Database::getConnection();
-        $stmt = $db->prepare('UPDATE categories SET name = :name WHERE id = :id');
-        $stmt->execute(['id' => $id, 'name' => $name]);
+        $stmt = $db->prepare('UPDATE categories SET name = :name, description = :description WHERE id = :id');
+        $stmt->execute(['id' => $id, 'name' => $name, 'description' => $description]);
     }
 
     /**
@@ -27,7 +27,7 @@ class Category {
      */
     public static function allWithTags(): array {
         $db = Database::getConnection();
-        $sql = 'SELECT c.id AS category_id, c.name AS category_name, '
+        $sql = 'SELECT c.id AS category_id, c.name AS category_name, c.description AS category_description, '
              . 't.id AS tag_id, t.name AS tag_name '
              . 'FROM categories c '
              . 'LEFT JOIN category_tags ct ON c.id = ct.category_id '
@@ -43,6 +43,7 @@ class Category {
                 $categories[$id] = [
                     'id' => $id,
                     'name' => $row['category_name'],
+                    'description' => $row['category_description'],
                     'tags' => []
                 ];
             }

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -6,19 +6,19 @@ class Tag {
     /**
      * Create a new tag optionally with a keyword for auto tagging.
      */
-    public static function create(string $name, ?string $keyword = null): int {
+    public static function create(string $name, ?string $keyword = null, ?string $description = null): int {
         $db = Database::getConnection();
-        $stmt = $db->prepare('INSERT INTO `tags` (`name`, `keyword`) VALUES (:name, :keyword)');
-        $stmt->execute(['name' => $name, 'keyword' => $keyword]);
+        $stmt = $db->prepare('INSERT INTO `tags` (`name`, `keyword`, `description`) VALUES (:name, :keyword, :description)');
+        $stmt->execute(['name' => $name, 'keyword' => $keyword, 'description' => $description]);
         return (int)$db->lastInsertId();
     }
 
     /**
-     * Retrieve all tags with their IDs, names and keywords.
+     * Retrieve all tags with their IDs, names, keywords and descriptions.
      */
     public static function all(): array {
         $db = Database::getConnection();
-        $stmt = $db->query('SELECT `id`, `name`, `keyword` FROM `tags`');
+        $stmt = $db->query('SELECT `id`, `name`, `keyword`, `description` FROM `tags`');
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
@@ -27,7 +27,7 @@ class Tag {
      */
     public static function unassigned(): array {
         $db = Database::getConnection();
-        $sql = 'SELECT t.id, t.name, t.keyword '
+        $sql = 'SELECT t.id, t.name, t.keyword, t.description '
              . 'FROM tags t '
              . 'LEFT JOIN category_tags ct ON t.id = ct.tag_id '
              . 'WHERE ct.tag_id IS NULL';
@@ -36,12 +36,12 @@ class Tag {
     }
 
     /**
-     * Update a tag's name and keyword.
+     * Update a tag's name, keyword and description.
      */
-    public static function update(int $id, string $name, ?string $keyword = null): bool {
+    public static function update(int $id, string $name, ?string $keyword = null, ?string $description = null): bool {
         $db = Database::getConnection();
-        $stmt = $db->prepare('UPDATE `tags` SET `name` = :name, `keyword` = :keyword WHERE `id` = :id');
-        return $stmt->execute(['name' => $name, 'keyword' => $keyword, 'id' => $id]);
+        $stmt = $db->prepare('UPDATE `tags` SET `name` = :name, `keyword` = :keyword, `description` = :description WHERE `id` = :id');
+        return $stmt->execute(['name' => $name, 'keyword' => $keyword, 'description' => $description, 'id' => $id]);
     }
 
     /**

--- a/php_backend/models/TransactionGroup.php
+++ b/php_backend/models/TransactionGroup.php
@@ -6,20 +6,20 @@ class TransactionGroup {
     /**
      * Create a new transaction group and return its ID.
      */
-    public static function create(string $name): int {
+    public static function create(string $name, ?string $description = null): int {
         $db = Database::getConnection();
-        $stmt = $db->prepare('INSERT INTO transaction_groups (name) VALUES (:name)');
-        $stmt->execute(['name' => $name]);
+        $stmt = $db->prepare('INSERT INTO transaction_groups (name, description) VALUES (:name, :description)');
+        $stmt->execute(['name' => $name, 'description' => $description]);
         return (int)$db->lastInsertId();
     }
 
     /**
      * Rename an existing transaction group.
      */
-    public static function update(int $id, string $name): void {
+    public static function update(int $id, string $name, ?string $description = null): void {
         $db = Database::getConnection();
-        $stmt = $db->prepare('UPDATE transaction_groups SET name = :name WHERE id = :id');
-        $stmt->execute(['id' => $id, 'name' => $name]);
+        $stmt = $db->prepare('UPDATE transaction_groups SET name = :name, description = :description WHERE id = :id');
+        $stmt->execute(['id' => $id, 'name' => $name, 'description' => $description]);
     }
 
     /**
@@ -41,7 +41,7 @@ class TransactionGroup {
      */
     public static function find(int $id): ?array {
         $db = Database::getConnection();
-        $stmt = $db->prepare('SELECT id, name FROM transaction_groups WHERE id = :id');
+        $stmt = $db->prepare('SELECT id, name, description FROM transaction_groups WHERE id = :id');
         $stmt->execute(['id' => $id]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         return $row ?: null;
@@ -52,7 +52,7 @@ class TransactionGroup {
      */
     public static function all(): array {
         $db = Database::getConnection();
-        $stmt = $db->query('SELECT id, name FROM transaction_groups ORDER BY id');
+        $stmt = $db->query('SELECT id, name, description FROM transaction_groups ORDER BY id');
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 }

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -21,16 +21,16 @@ try {
 
     $data = [];
     if (in_array('categories', $parts)) {
-        $data['categories'] = $getAll('SELECT id, name FROM categories ORDER BY id');
+        $data['categories'] = $getAll('SELECT id, name, description FROM categories ORDER BY id');
     }
     if (in_array('tags', $parts)) {
-        $data['tags'] = $getAll('SELECT id, name, keyword FROM tags ORDER BY id');
+        $data['tags'] = $getAll('SELECT id, name, keyword, description FROM tags ORDER BY id');
     }
     if (in_array('categories', $parts) || in_array('tags', $parts)) {
         $data['category_tags'] = $getAll('SELECT category_id, tag_id FROM category_tags ORDER BY category_id, tag_id');
     }
     if (in_array('groups', $parts)) {
-        $data['groups'] = $getAll('SELECT id, name FROM transaction_groups ORDER BY id');
+        $data['groups'] = $getAll('SELECT id, name, description FROM transaction_groups ORDER BY id');
     }
     if (in_array('transactions', $parts)) {
         $data['transactions'] = $getAll('SELECT id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id FROM transactions ORDER BY id');

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -28,12 +28,13 @@ try {
             case null:
             case 'create':
                 $name = trim($data['name'] ?? '');
+                $description = $data['description'] ?? null;
                 if ($name === '') {
                     http_response_code(400);
                     echo json_encode(['error' => 'Name required']);
                     return;
                 }
-                $id = Category::create($name);
+                $id = Category::create($name, $description);
                 Log::write("Created category $name");
                 echo json_encode(['id' => $id]);
                 break;
@@ -74,12 +75,13 @@ try {
     } elseif ($method === 'PUT') {
         $id = (int)($data['id'] ?? 0);
         $name = trim($data['name'] ?? '');
+        $description = $data['description'] ?? null;
         if ($id <= 0 || $name === '') {
             http_response_code(400);
             echo json_encode(['error' => 'ID and name required']);
             return;
         }
-        Category::update($id, $name);
+        Category::update($id, $name, $description);
         Log::write("Updated category $id");
         echo json_encode(['status' => 'ok']);
     } else {

--- a/php_backend/public/groups.php
+++ b/php_backend/public/groups.php
@@ -26,23 +26,25 @@ $data = json_decode(file_get_contents('php://input'), true) ?? [];
 try {
     if ($method === 'POST') {
         $name = trim($data['name'] ?? '');
+        $description = $data['description'] ?? null;
         if ($name === '') {
             http_response_code(400);
             echo json_encode(['error' => 'Name required']);
             return;
         }
-        $id = TransactionGroup::create($name);
+        $id = TransactionGroup::create($name, $description);
         Log::write("Created group $name");
         echo json_encode(['id' => $id]);
     } elseif ($method === 'PUT') {
         $id = (int)($data['id'] ?? 0);
         $name = trim($data['name'] ?? '');
+        $description = $data['description'] ?? null;
         if ($id <= 0 || $name === '') {
             http_response_code(400);
             echo json_encode(['error' => 'ID and name required']);
             return;
         }
-        TransactionGroup::update($id, $name);
+        TransactionGroup::update($id, $name, $description);
         Log::write("Updated group $id");
         echo json_encode(['status' => 'ok']);
     } elseif ($method === 'DELETE') {

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -29,23 +29,23 @@ try {
     $db->exec('SET FOREIGN_KEY_CHECKS=1');
 
     if (isset($data['categories'])) {
-        $stmtCat = $db->prepare('INSERT INTO categories (id, name) VALUES (:id, :name)');
+        $stmtCat = $db->prepare('INSERT INTO categories (id, name, description) VALUES (:id, :name, :description)');
         foreach ($data['categories'] as $row) {
-            $stmtCat->execute(['id' => $row['id'], 'name' => $row['name']]);
+            $stmtCat->execute(['id' => $row['id'], 'name' => $row['name'], 'description' => $row['description'] ?? null]);
         }
     }
 
     if (isset($data['tags'])) {
-        $stmtTag = $db->prepare('INSERT INTO tags (id, name, keyword) VALUES (:id, :name, :keyword)');
+        $stmtTag = $db->prepare('INSERT INTO tags (id, name, keyword, description) VALUES (:id, :name, :keyword, :description)');
         foreach ($data['tags'] as $row) {
-            $stmtTag->execute(['id' => $row['id'], 'name' => $row['name'], 'keyword' => $row['keyword']]);
+            $stmtTag->execute(['id' => $row['id'], 'name' => $row['name'], 'keyword' => $row['keyword'], 'description' => $row['description'] ?? null]);
         }
     }
 
     if (isset($data['groups'])) {
-        $stmtGrp = $db->prepare('INSERT INTO transaction_groups (id, name) VALUES (:id, :name)');
+        $stmtGrp = $db->prepare('INSERT INTO transaction_groups (id, name, description) VALUES (:id, :name, :description)');
         foreach ($data['groups'] as $row) {
-            $stmtGrp->execute(['id' => $row['id'], 'name' => $row['name']]);
+            $stmtGrp->execute(['id' => $row['id'], 'name' => $row['name'], 'description' => $row['description'] ?? null]);
         }
     }
 

--- a/php_backend/public/tags.php
+++ b/php_backend/public/tags.php
@@ -11,13 +11,14 @@ if ($method === 'POST') {
     $data = json_decode(file_get_contents('php://input'), true);
     $name = $data['name'] ?? null;
     $keyword = $data['keyword'] ?? null;
+    $description = $data['description'] ?? null;
     if (!$name) {
         http_response_code(400);
         echo json_encode(['error' => 'Name required']);
         exit;
     }
     try {
-        $id = Tag::create($name, $keyword);
+        $id = Tag::create($name, $keyword, $description);
         $tagged = Tag::applyToAllTransactions();
         $categorised = CategoryTag::applyToAllTransactions();
         Log::write("Created tag $name; retagged $tagged transactions; categorised $categorised transactions");
@@ -44,13 +45,14 @@ if ($method === 'POST') {
     $id = $data['id'] ?? null;
     $name = $data['name'] ?? null;
     $keyword = $data['keyword'] ?? null;
+    $description = $data['description'] ?? null;
     if (!$id || !$name) {
         http_response_code(400);
         echo json_encode(['error' => 'ID and name required']);
         exit;
     }
     try {
-        Tag::update((int)$id, $name, $keyword);
+        Tag::update((int)$id, $name, $keyword, $description);
         Log::write("Updated tag $id");
         echo json_encode(['status' => 'ok']);
     } catch (Exception $e) {


### PR DESCRIPTION
## Summary
- support optional descriptions for tags, categories and transaction groups across database and models
- extend API endpoints and backup/restore to handle description fields
- expose description fields in the tags, categories and groups management pages

## Testing
- `php -l php_backend/models/Tag.php php_backend/models/Category.php php_backend/models/TransactionGroup.php php_backend/public/tags.php php_backend/public/categories.php php_backend/public/groups.php php_backend/create_tables.php php_backend/public/backup.php php_backend/public/restore.php`


------
https://chatgpt.com/codex/tasks/task_e_689a2a5889ac832e825c3b37792c5837