### PR TITLE
Return to prior page after transaction save

### DIFF
--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -120,6 +120,13 @@
                 }).then(r => r.json()).then(res => {
                     if (res && res.status === 'ok') {
                         showMessage('Saved');
+                        setTimeout(() => {
+                            if (document.referrer) {
+                                window.location = document.referrer;
+                            } else {
+                                history.back();
+                            }
+                        }, 500);
                     } else {
                         alert('Failed to save');
                     }


### PR DESCRIPTION
## Summary
- After saving a transaction, redirect back to the page the user navigated from for smoother workflow.

## Testing
- `php -l frontend/transaction.html`


------
https://chatgpt.com/codex/tasks/task_e_689a2aa28af8832e8760b5e3593cee9a