### PR TITLE
Name backups using hostname and date

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Then open `https://localhost:8000/frontend/index.html` in your browser.
 Back up and restore your data through the web interface. From the navigation
 menu open **Backup & Restore** under *Administration*. The page lets you
 choose which parts of the database to download—transactions, categories, tags,
-groups, or budgets. To restore a backup, choose the JSON file on the same page
-and click **Restore**; any included sections are imported.
+groups, or budgets. The downloaded JSON file is named after your site's hostname
+and the current date (for example, `example.com-2024-05-15.json`). To restore a
+backup, choose the JSON file on the same page and click **Restore**; any
+included sections are imported.
 
 ## Frontend
 

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -5,6 +5,10 @@ require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
 
 header('Content-Type: application/json');
+$host = $_SERVER['HTTP_HOST'] ?? 'backup';
+$host = preg_replace('/[^A-Za-z0-9_-]/', '_', $host);
+$filename = $host . '-' . date('Y-m-d') . '.json';
+header('Content-Disposition: attachment; filename="' . $filename . '"');
 
 try {
     $db = Database::getConnection();


### PR DESCRIPTION
## Summary
- Include hostname and current date in backup JSON filenames.
- Download script reads `Content-Disposition` header and applies meaningful filename.
- Document backup naming convention in README.

## Testing
- `node frontend/js/backup.js`
- `php -l php_backend/public/backup.php`


------
https://chatgpt.com/codex/tasks/task_e_689b0ec63b18832ea20517c8cc2821a7