### PR TITLE
Auto-load latest monthly statement

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -95,6 +95,11 @@ const form = document.getElementById('statement-form');
 const untaggedOnly = document.getElementById('untagged-only');
 let table;
 
+// Determine initial year and month from query parameters if provided
+const urlParams = new URLSearchParams(window.location.search);
+const paramYear = urlParams.get('year');
+const paramMonth = urlParams.get('month');
+
 const recurringPromise = fetch('../php_backend/public/recurring_spend.php')
     .then(r => r.json())
     .then(d => {
@@ -149,6 +154,19 @@ fetch('../php_backend/public/transaction_months.php')
             yearSelect.selectedIndex = 0;
             populateMonths();
         }
+
+        // Override defaults with query parameters if present
+        if (paramYear && monthsByYear[paramYear]) {
+            yearSelect.value = paramYear;
+            populateMonths();
+            const monthInt = parseInt(paramMonth, 10);
+            if (paramMonth && monthsByYear[paramYear].includes(monthInt)) {
+                monthSelect.value = monthInt;
+            }
+        }
+
+        // Automatically load the initially selected statement
+        loadTransactions();
     })
     .catch(() => {
         const now = new Date();
@@ -167,8 +185,9 @@ fetch('../php_backend/public/transaction_months.php')
             opt.textContent = d.toLocaleString('default', { month: 'long' });
             monthSelect.appendChild(opt);
         }
-        yearSelect.value = currentYear;
-        monthSelect.value = currentMonth;
+        yearSelect.value = paramYear || currentYear;
+        monthSelect.value = paramMonth || currentMonth;
+        loadTransactions();
     });
 
 function loadTransactions() {


### PR DESCRIPTION
## Summary
- Auto load the most recent monthly statement on page load
- Respect `year` and `month` query parameters for deep linking

## Testing
- `php -l php_backend/public/transaction_months.php`
- `node -e "const fs=require('fs');const html=fs.readFileSync('frontend/monthly_statement.html','utf8');const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)].map(m=>m[1]);scripts.forEach((s,i)=>{try{new Function(s);console.log('script',i,'ok');}catch(e){console.error('script',i,'error',e.message);}});"`


------
https://chatgpt.com/codex/tasks/task_e_689b129687fc832e9a9a3bcead47b881