### PR TITLE
Use Tabulator Simple theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A basic login page is available at the project root (`index.php`). Users are sto
 - Highcharts is used for graphs, while Tabulator renders interactive tables.
 - Display all monetary values using the pound symbol (£) instead of the dollar sign ($).
 - Tailwind CSS provides the styling and Font Awesome supplies icons. Sections are wrapped in card components.
-- Tabulator tables apply Tailwind utility classes for a consistent look.
+- Tabulator tables apply Tailwind utility classes for a consistent look and use the Simple theme.
 - Form inputs may include a `data-help` attribute to show popover guidance.
 - Transactions identified as transfers are flagged and ignored in totals.
 - The interface is responsive. Each page includes a viewport meta tag and uses Tailwind's responsive utilities so the site works

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Account Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>All Years Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Budgets</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
 <div class="flex min-h-screen">

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Categories</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Group Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Groups</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -34,6 +34,8 @@ function badgeFormatter(colorClasses) {
 // Initialise a Tabulator table with Tailwind styling defaults
 function tailwindTabulator(element, options) {
     options = options || {};
+    // Apply the Simple theme to all Tabulator tables
+    options.theme = 'simple';
     if (!options.layout) {
         options.layout = 'fitColumns';
     }

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Application Logs</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Missing Tags</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Monthly Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Monthly Statement</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 </head>
 <body class="bg-gray-50 font-sans">

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Recurring Spend Detection</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Transaction Reports</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Search Transactions</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Tags</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Account Transfers</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Yearly Dashboard</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">


### PR DESCRIPTION
## Summary
- Load Tabulator's Simple theme on all pages
- Apply Simple theme in Tailwind Tabulator wrapper
- Document use of Tabulator's Simple theme

## Testing
- `node --check frontend/js/tabulator-tailwind.js`


------
https://chatgpt.com/codex/tasks/task_e_689b177ebe88832e9d9a37a6902059ac