### PR TITLE
Fit tables to data and freeze first column

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -43,7 +43,7 @@
         .then(data => {
             tailwindTabulator(document.getElementById('accounts-table'), {
                 data,
-                layout: 'fitColumns',
+                layout: 'fitData',
                 columns: [
                     { title: 'Name', field: 'name' },
                     { title: 'Transactions', field: 'transactions', hozAlign: 'right' },

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -74,7 +74,7 @@
 
         tailwindTabulator(el, {
             data: data,
-            layout: 'fitColumns',
+            layout: 'fitData',
             columns: columns
         });
     }

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -66,7 +66,7 @@ async function loadBudgets(){
     if(budgetTable){budgetTable.setData(data);}else{
         budgetTable=tailwindTabulator('#budget-table',{
             data:data,
-            layout:'fitColumns',
+            layout:'fitData',
             columns:[
                 {title:'Category',field:'category'},
                 {title:'Budget',field:'amount',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -45,7 +45,7 @@ async function loadCategories() {
     }
     categoryTable = tailwindTabulator('#category-table', {
         data: data,
-        layout: 'fitColumns',
+        layout: 'fitData',
         columns: [
             { title: 'Name', field: 'name', formatter: badgeFormatter('bg-green-200 text-green-800') },
             { title: 'Description', field: 'description' },

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -67,7 +67,7 @@
             ...monthCols,
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
-        tailwindTabulator(el, { data, layout: 'fitColumns', columns });
+        tailwindTabulator(el, { data, layout: 'fitData', columns });
     }
 
     // Render a table of yearly totals for each group
@@ -88,7 +88,7 @@
             ...yearCols,
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
-        tailwindTabulator(el, { data, layout: 'fitColumns', columns });
+        tailwindTabulator(el, { data, layout: 'fitData', columns });
     }
 
     // Create a column chart for the supplied dataset

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -44,7 +44,7 @@ async function loadGroups() {
     }
     groupTable = tailwindTabulator('#group-table', {
         data: groups,
-        layout: 'fitColumns',
+        layout: 'fitData',
         columns: [
             { title: 'Name', field: 'name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
             { title: 'Description', field: 'description', editor: 'input' },

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -34,9 +34,7 @@ function badgeFormatter(colorClasses) {
 // Initialise a Tabulator table with Tailwind styling defaults
 function tailwindTabulator(element, options) {
     options = options || {};
-    if (!options.layout) {
-        options.layout = 'fitColumns';
-    }
+    options.layout = 'fitData';
     const userRowFormatter = options.rowFormatter;
     options.rowFormatter = function(row) {
         if (userRowFormatter) userRowFormatter(row);
@@ -54,6 +52,12 @@ function tailwindTabulator(element, options) {
     options.pagination = options.pagination || 'local';
     options.paginationSize = 20;
     const table = new Tabulator(element, options);
+    table.on('tableBuilt', function() {
+        const cols = table.getColumns();
+        if (cols.length) {
+            cols[0].freeze(true);
+        }
+    });
     const el = table.element;
     el.classList.add('border-0', 'rounded-lg', 'overflow-hidden', 'bg-white', 'shadow-sm');
     const header = el.querySelector('.tabulator-header');

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -30,7 +30,7 @@
         .then(data => {
             tailwindTabulator('#logs-grid', {
                 data: data,
-                layout: 'fitColumns',
+                layout: 'fitData',
                 columns: [
                     { title: 'Time', field: 'created_at' },
                     { title: 'Level', field: 'level' },

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -33,7 +33,7 @@
         } else {
             table = tailwindTabulator('#untagged-table', {
                 data: data,
-                layout: 'fitColumns',
+                layout: 'fitData',
                 initialSort: [{column:'count', dir:'desc'}],
                 columns: [
                     { title: 'Description', field: 'description' },

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -96,7 +96,7 @@
 
         tailwindTabulator(el, {
             data: data,
-            layout: 'fitColumns',
+            layout: 'fitData',
             columns: columns
         });
     }

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -281,7 +281,7 @@ function loadTransactions() {
 
         table = tailwindTabulator('#transactions-grid', {
             data: data,
-            layout: 'fitColumns',
+            layout: 'fitData',
             columns: [
                 { title: 'Date', field: 'date' },
                 { title: 'Description', field: 'description', formatter: function(cell) {

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -38,7 +38,7 @@
                 if(data.results && data.results.length){
                     tailwindTabulator(gridEl, {
                         data: data.results,
-                        layout: 'fitColumns',
+                        layout: 'fitData',
                         columns: [
                             { title: 'Description', field: 'description' },
                             { title: 'Occurrences', field: 'occurrences', hozAlign: 'right' },

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -119,7 +119,7 @@
                 if (Array.isArray(data) && data.length) {
                     tailwindTabulator(gridEl, {
                         data: data,
-                        layout: 'fitColumns',
+                        layout: 'fitData',
                         columns: [
                             { title: 'Date', field: 'date' },
                             { title: 'Description', field: 'description', bottomCalc: function() { return 'Total'; } },

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -52,7 +52,7 @@
                 if (data.results && data.results.length) {
                     tailwindTabulator(gridEl, {
                         data: data.results,
-                        layout: 'fitColumns',
+                        layout: 'fitData',
                         columns: [
                             { title: 'Date', field: 'date' },
                             { title: 'Description', field: 'description', formatter: function(cell){

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -45,7 +45,7 @@ async function loadTags(){
     }
     tagTable = tailwindTabulator('#tag-table', {
         data: tags,
-        layout: 'fitColumns',
+        layout: 'fitData',
         columns: [
             { title: 'Name', field: 'name', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
             { title: 'Keyword', field: 'keyword' },

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -42,7 +42,7 @@
         .then(data => {
             tailwindTabulator(document.getElementById('transfers-table'), {
                 data: data.transfers,
-                layout: 'fitColumns',
+                layout: 'fitData',
                 columns: [
                     { title: 'Date', field: 'date' },
                     { title: 'Description', field: 'description' },
@@ -54,7 +54,7 @@
 
             tailwindTabulator(document.getElementById('ofx-transfers-table'), {
                 data: data.ofx_transfers,
-                layout: 'fitColumns',
+                layout: 'fitData',
                 columns: [
                     { title: 'Date', field: 'date' },
                     { title: 'Description', field: 'description' },

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -78,7 +78,7 @@
 
         tailwindTabulator(el, {
             data: data,
-            layout: 'fitColumns',
+            layout: 'fitData',
             columns: columns
         });
     }


### PR DESCRIPTION
## Summary
- Freeze first column in every Tabulator instance
- Size columns to data using Tabulator's `fitData` layout across all pages

## Testing
- `node --check frontend/js/tabulator-tailwind.js`
- `rg fitColumns -n`

------
https://chatgpt.com/codex/tasks/task_e_689b18157620832eb7e8a5c1f07d59ea