### PR TITLE
Show monthly statement graphs side by side

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -74,11 +74,13 @@
             <div class="bg-white p-6 rounded shadow mt-4">
                 <div id="transactions-grid"></div>
             </div>
-            <div class="bg-white p-6 rounded shadow mt-4">
-                <div id="sankey-chart" style="height:400px;"></div>
-            </div>
-            <div class="bg-white p-6 rounded shadow mt-4">
-                <div id="category-bubbles" style="height:400px;"></div>
+            <div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div class="bg-white p-6 rounded shadow">
+                    <div id="sankey-chart" style="height:400px;"></div>
+                </div>
+                <div class="bg-white p-6 rounded shadow">
+                    <div id="category-bubbles" style="height:400px;"></div>
+                </div>
             </div>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- Arrange monthly statement Sankey and bubble charts in a responsive two-column grid so they appear side by side on larger screens.

## Testing
- `php -l frontend/monthly_statement.html`

------
https://chatgpt.com/codex/tasks/task_e_689b288158d4832ebd9b70eaffc56c9d