### PR TITLE
Stretch Tabulator tables to full width

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -45,7 +45,7 @@
         .then(data => {
             tailwindTabulator(document.getElementById('accounts-table'), {
                 data,
-                layout: 'fitData',
+                layout: 'fitDataStretch',
                 columns: [
                     { title: 'Name', field: 'name' },
                     { title: 'Transactions', field: 'transactions', hozAlign: 'right' },

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -76,7 +76,7 @@
 
         tailwindTabulator(el, {
             data: data,
-            layout: 'fitData',
+            layout: 'fitDataStretch',
             columns: columns
         });
     }

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -68,7 +68,7 @@ async function loadBudgets(){
     if(budgetTable){budgetTable.setData(data);}else{
         budgetTable=tailwindTabulator('#budget-table',{
             data:data,
-            layout:'fitData',
+            layout: 'fitDataStretch',
             columns:[
                 {title:'Category',field:'category'},
                 {title:'Budget',field:'amount',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -47,7 +47,7 @@ async function loadCategories() {
     }
     categoryTable = tailwindTabulator('#category-table', {
         data: data,
-        layout: 'fitData',
+        layout: 'fitDataStretch',
         columns: [
             { title: 'Name', field: 'name', formatter: badgeFormatter('bg-green-200 text-green-800') },
             { title: 'Description', field: 'description' },

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -69,7 +69,7 @@
             ...monthCols,
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
-        tailwindTabulator(el, { data, layout: 'fitData', columns });
+        tailwindTabulator(el, { data, layout: 'fitDataStretch', columns });
     }
 
     // Render a table of yearly totals for each group
@@ -90,7 +90,7 @@
             ...yearCols,
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
-        tailwindTabulator(el, { data, layout: 'fitData', columns });
+        tailwindTabulator(el, { data, layout: 'fitDataStretch', columns });
     }
 
     // Create a column chart for the supplied dataset

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -46,7 +46,7 @@ async function loadGroups() {
     }
     groupTable = tailwindTabulator('#group-table', {
         data: groups,
-        layout: 'fitData',
+        layout: 'fitDataStretch',
         columns: [
             { title: 'Name', field: 'name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
             { title: 'Description', field: 'description', editor: 'input' },

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -40,7 +40,7 @@ function tailwindTabulator(element, options) {
     options.theme = 'simple';
 
     if (!options.layout) {
-        options.layout = 'fitData';
+        options.layout = 'fitDataStretch';
     }
 
     const userRowFormatter = options.rowFormatter;

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -32,7 +32,7 @@
         .then(data => {
             tailwindTabulator('#logs-grid', {
                 data: data,
-                layout: 'fitData',
+                layout: 'fitDataStretch',
                 columns: [
                     { title: 'Time', field: 'created_at' },
                     { title: 'Level', field: 'level' },

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -35,7 +35,7 @@
         } else {
             table = tailwindTabulator('#untagged-table', {
                 data: data,
-                layout: 'fitData',
+                layout: 'fitDataStretch',
                 initialSort: [{column:'count', dir:'desc'}],
                 columns: [
                     { title: 'Description', field: 'description' },

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -98,7 +98,7 @@
 
         tailwindTabulator(el, {
             data: data,
-            layout: 'fitData',
+            layout: 'fitDataStretch',
             columns: columns
         });
     }

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -294,7 +294,7 @@ function loadTransactions() {
 
         table = tailwindTabulator('#transactions-grid', {
             data: data,
-            layout: 'fitData',
+            layout: 'fitDataStretch',
             columns: [
                 { title: 'Date', field: 'date' },
                 { title: 'Description', field: 'description', formatter: function(cell) {

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -40,7 +40,7 @@
                 if(data.results && data.results.length){
                     tailwindTabulator(gridEl, {
                         data: data.results,
-                        layout: 'fitData',
+                        layout: 'fitDataStretch',
                         columns: [
                             { title: 'Description', field: 'description' },
                             { title: 'Occurrences', field: 'occurrences', hozAlign: 'right' },

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -121,7 +121,7 @@
                 if (Array.isArray(data) && data.length) {
                     tailwindTabulator(gridEl, {
                         data: data,
-                        layout: 'fitData',
+                        layout: 'fitDataStretch',
                         columns: [
                             { title: 'Date', field: 'date' },
                             { title: 'Description', field: 'description', bottomCalc: function() { return 'Total'; } },

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -54,7 +54,7 @@
                 if (data.results && data.results.length) {
                     tailwindTabulator(gridEl, {
                         data: data.results,
-                        layout: 'fitData',
+                        layout: 'fitDataStretch',
                         columns: [
                             { title: 'Date', field: 'date' },
                             { title: 'Description', field: 'description', formatter: function(cell){

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -47,7 +47,7 @@ async function loadTags(){
     }
     tagTable = tailwindTabulator('#tag-table', {
         data: tags,
-        layout: 'fitData',
+        layout: 'fitDataStretch',
         columns: [
             { title: 'Name', field: 'name', formatter: badgeFormatter('bg-blue-200 text-blue-800') },
             { title: 'Keyword', field: 'keyword' },

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -44,7 +44,7 @@
         .then(data => {
             tailwindTabulator(document.getElementById('transfers-table'), {
                 data: data.transfers,
-                layout: 'fitData',
+                layout: 'fitDataStretch',
                 columns: [
                     { title: 'Date', field: 'date' },
                     { title: 'Description', field: 'description' },
@@ -56,7 +56,7 @@
 
             tailwindTabulator(document.getElementById('ofx-transfers-table'), {
                 data: data.ofx_transfers,
-                layout: 'fitData',
+                layout: 'fitDataStretch',
                 columns: [
                     { title: 'Date', field: 'date' },
                     { title: 'Description', field: 'description' },

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -80,7 +80,7 @@
 
         tailwindTabulator(el, {
             data: data,
-            layout: 'fitData',
+            layout: 'fitDataStretch',
             columns: columns
         });
     }


### PR DESCRIPTION
## Summary
- Use `fitDataStretch` as the default Tabulator layout so tables expand to the container width
- Apply `fitDataStretch` to every table initialization for consistent full-width layouts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b4d1210cc832e9bcbb6b3d99049c6