### PR TITLE
Add memo column to monthly statement table

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -301,6 +301,7 @@ function loadTransactions() {
                     const id = cell.getRow().getData().id;
                     return `<a href="transaction.html?id=${id}">${cell.getValue()}</a>`;
                 } },
+                { title: 'Memo', field: 'memo' },
                 {
                     title: 'Category',
                     field: 'category_name',


### PR DESCRIPTION
## Summary
- display memo field in monthly statement Tabulator grid

## Testing
- `php -l php_backend/public/transactions.php`
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_689b50ed9dd0832e9d3371d18a4ec05b