### PR TITLE
Enable moving tags between categories via one API call

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -53,8 +53,34 @@ async function loadCategories() {
             { title: 'Description', field: 'description' },
             { title: 'Tags', field: 'tags', formatter: function(cell){
                 const tags = cell.getValue() || [];
+                const rowData = cell.getRow().getData();
                 const container = document.createElement('div');
-                tags.forEach(t => container.appendChild(createBadge(t.name, 'bg-blue-200 text-blue-800')));
+                container.dataset.categoryId = rowData.id;
+                container.addEventListener('dragover', e => e.preventDefault());
+                container.addEventListener('drop', async e => {
+                    e.preventDefault();
+                    const tagId = e.dataTransfer.getData('text/tag-id');
+                    const oldCategoryId = e.dataTransfer.getData('text/old-category-id');
+                    const newCategoryId = container.dataset.categoryId;
+                    if (tagId && oldCategoryId && newCategoryId && oldCategoryId !== newCategoryId) {
+                        await fetch('../php_backend/public/categories.php', {
+                            method: 'POST',
+                            headers: {'Content-Type': 'application/json'},
+                            body: JSON.stringify({action: 'move_tag', category_id: newCategoryId, old_category_id: oldCategoryId, tag_id: tagId})
+                        });
+                        loadCategories();
+                        showMessage('Tag moved');
+                    }
+                });
+                tags.forEach(t => {
+                    const badge = createBadge(t.name, 'bg-blue-200 text-blue-800');
+                    badge.draggable = true;
+                    badge.addEventListener('dragstart', e => {
+                        e.dataTransfer.setData('text/tag-id', t.id);
+                        e.dataTransfer.setData('text/old-category-id', rowData.id);
+                    });
+                    container.appendChild(badge);
+                });
                 return container;
             } },
             { title: 'Actions', formatter: function(cell){

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -58,6 +58,20 @@ try {
                 Log::write("Removed tag $tagId from category $categoryId");
                 echo json_encode(['status' => 'ok']);
                 break;
+            case 'move_tag':
+                $newCategoryId = (int)($data['category_id'] ?? 0);
+                $oldCategoryId = (int)($data['old_category_id'] ?? 0);
+                $tagId = (int)($data['tag_id'] ?? 0);
+                try {
+                    CategoryTag::move($oldCategoryId, $newCategoryId, $tagId);
+                    Log::write("Moved tag $tagId from category $oldCategoryId to $newCategoryId");
+                    echo json_encode(['status' => 'ok']);
+                } catch (Exception $e) {
+                    http_response_code(400);
+                    Log::write('Move tag error: ' . $e->getMessage(), 'ERROR');
+                    echo json_encode(['error' => $e->getMessage()]);
+                }
+                break;
             default:
                 http_response_code(400);
                 echo json_encode(['error' => 'Invalid action']);


### PR DESCRIPTION
## Summary
- Add `move_tag` action to categories endpoint
- Implement `CategoryTag::move` to handle reassignment in a transaction
- Support tag drag-and-drop between categories with single request

## Testing
- `php -l php_backend/public/categories.php`
- `php -l php_backend/models/CategoryTag.php`


------
https://chatgpt.com/codex/tasks/task_e_689b573dc128832e98ead39255cca271