### PR TITLE
Fix unassigned column visibility in category manager

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -23,7 +23,10 @@
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Create Category</button>
             </form>
 
-            <div id="category-container" class="mt-6 flex gap-4 overflow-x-auto items-start"></div>
+            <div id="category-layout" class="mt-6 flex items-start gap-4">
+                <div id="unassigned" class="flex-shrink-0"></div>
+                <div id="category-container" class="flex-1 flex gap-4 overflow-x-auto items-start"></div>
+            </div>
         </main>
     </div>
     <script src="js/menu.js"></script>

--- a/frontend/js/category_drag.js
+++ b/frontend/js/category_drag.js
@@ -125,9 +125,11 @@
     ]);
     const cats = await catRes.json();
     const unassigned = await untagRes.json();
+    const unassignedWrap = document.getElementById('unassigned');
     const container = document.getElementById('category-container');
+    unassignedWrap.innerHTML = '';
     container.innerHTML = '';
-    container.appendChild(createUnassignedCard(unassigned));
+    unassignedWrap.appendChild(createUnassignedCard(unassigned));
     cats.forEach(c => container.appendChild(createCategoryCard(c)));
   }
 


### PR DESCRIPTION
## Summary
- Restructure category management layout to keep "Unassigned Tags" visible and scroll categories horizontally
- Update drag-and-drop script to target new layout containers

## Testing
- `node --check frontend/js/category_drag.js`


------
https://chatgpt.com/codex/tasks/task_e_689b5f4f794c832e9a430edccd240a57