### PR TITLE
Remove success popups from category management page

### DIFF
--- a/frontend/js/category_drag.js
+++ b/frontend/js/category_drag.js
@@ -24,21 +24,18 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'add_tag', category_id: newCategory, tag_id: dragInfo.tagId })
       });
-      showMessage('Tag moved');
     } else if (dragInfo.oldCategory && !newCategory) {
       await fetch('../php_backend/public/categories.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'remove_tag', category_id: dragInfo.oldCategory, tag_id: dragInfo.tagId })
       });
-      showMessage('Tag removed');
     } else if (!dragInfo.oldCategory && newCategory) {
       await fetch('../php_backend/public/categories.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ action: 'add_tag', category_id: newCategory, tag_id: dragInfo.tagId })
       });
-      showMessage('Tag assigned');
     }
     loadCategories();
   }
@@ -81,7 +78,6 @@
         body: JSON.stringify({ id: cat.id })
       });
       loadCategories();
-      showMessage('Category deleted');
     });
     header.appendChild(delBtn);
     card.appendChild(header);
@@ -148,7 +144,6 @@
         document.getElementById('category-name').value = '';
         document.getElementById('category-description').value = '';
         loadCategories();
-        showMessage('Category created');
       });
     }
     loadCategories();


### PR DESCRIPTION
## Summary
- Avoid showMessage overlays when moving tags or managing categories

## Testing
- `node --check frontend/js/category_drag.js`


------
https://chatgpt.com/codex/tasks/task_e_689b625fe794832e9d55c225688d9072