### PR TITLE
Tighten sidebar spacing and unify heading color

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -1,69 +1,69 @@
 <!-- Navigation menu shared across pages -->
 <img src="wallet.svg" alt="Finance Manager Logo" class="w-24 mb-4 mx-auto">
-<h2 class="text-xl font-semibold mb-4">Menu</h2>
-<div class="space-y-4">
+<h2 class="text-xl font-semibold text-indigo-600 mb-4">Menu</h2>
+<div class="space-y-2">
   <div>
-    <h3 class="text-lg font-semibold mb-2">General Overview</h3>
+    <h3 class="text-lg font-semibold text-indigo-600 mb-2">General Overview</h3>
     <ul class="space-y-1">
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="index.html"><i class="fa-solid fa-house mr-1"></i> Home</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="upload.html"><i class="fa-solid fa-upload mr-1"></i> Upload OFX Files</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="index.html"><i class="fa-solid fa-house mr-1"></i> Home</a></li>
+      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="upload.html"><i class="fa-solid fa-upload mr-1"></i> Upload OFX Files</a></li>
     </ul>
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Transaction Hub</h3>
+    <h3 class="text-lg font-semibold text-indigo-600 mb-2">Transaction Hub</h3>
     <ul class="space-y-1">
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-1 rounded" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-1"></i> Monthly Statement</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-1 rounded" href="report.html"><i class="fa-solid fa-table mr-1"></i> Transaction Reports</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="search.html"><i class="fa-solid fa-magnifying-glass mr-1"></i> Search Transactions</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="transfers.html"><i class="fa-solid fa-right-left mr-1"></i> Transfers</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar mr-1"></i> Monthly Statement</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="report.html"><i class="fa-solid fa-table mr-1"></i> Transaction Reports</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="search.html"><i class="fa-solid fa-magnifying-glass mr-1"></i> Search Transactions</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="transfers.html"><i class="fa-solid fa-right-left mr-1"></i> Transfers</a></li>
     </ul>
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Data Dashboards</h3>
+    <h3 class="text-lg font-semibold text-indigo-600 mb-2">Data Dashboards</h3>
     <ul class="space-y-1">
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line mr-1"></i> Yearly Dashboard</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar mr-1"></i> All Years Dashboard</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-1"></i> Monthly Dashboard</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="group_dashboard.html"><i class="fa-solid fa-users mr-1"></i> Group Dashboard</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="account_dashboard.html"><i class="fa-solid fa-wallet mr-1"></i> Account Dashboard</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="recurring_spend.html"><i class="fa-solid fa-repeat mr-1"></i> Recurring Spend</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line mr-1"></i> Yearly Dashboard</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar mr-1"></i> All Years Dashboard</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column mr-1"></i> Monthly Dashboard</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="group_dashboard.html"><i class="fa-solid fa-users mr-1"></i> Group Dashboard</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="account_dashboard.html"><i class="fa-solid fa-wallet mr-1"></i> Account Dashboard</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="recurring_spend.html"><i class="fa-solid fa-repeat mr-1"></i> Recurring Spend</a></li>
     </ul>
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Data Graphs</h3>
+    <h3 class="text-lg font-semibold text-indigo-600 mb-2">Data Graphs</h3>
     <ul class="space-y-1">
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="graphs.html"><i class="fa-solid fa-chart-pie mr-1"></i> Graphs</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="graphs.html"><i class="fa-solid fa-chart-pie mr-1"></i> Graphs</a></li>
     </ul>
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Budget Plans</h3>
+    <h3 class="text-lg font-semibold text-indigo-600 mb-2">Budget Plans</h3>
     <ul class="space-y-1">
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="budgets.html"><i class="fa-solid fa-wallet mr-1"></i> Budgets</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="budgets.html"><i class="fa-solid fa-wallet mr-1"></i> Budgets</a></li>
     </ul>
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Data Organisation</h3>
+    <h3 class="text-lg font-semibold text-indigo-600 mb-2">Data Organisation</h3>
     <ul class="space-y-1">
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="tags.html"><i class="fa-solid fa-tags mr-1"></i> Manage Tags</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="missing_tags.html"><i class="fa-solid fa-circle-question mr-1"></i> Missing Tags</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="categories.html"><i class="fa-solid fa-folder-open mr-1"></i> Manage Categories</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="groups.html"><i class="fa-solid fa-users mr-1"></i> Manage Groups</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="tags.html"><i class="fa-solid fa-tags mr-1"></i> Manage Tags</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="missing_tags.html"><i class="fa-solid fa-circle-question mr-1"></i> Missing Tags</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="categories.html"><i class="fa-solid fa-folder-open mr-1"></i> Manage Categories</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="groups.html"><i class="fa-solid fa-users mr-1"></i> Manage Groups</a></li>
     </ul>
   </div>
 
   <div>
-    <h3 class="text-lg font-semibold mb-2">Admin Tools</h3>
+    <h3 class="text-lg font-semibold text-indigo-600 mb-2">Admin Tools</h3>
     <ul class="space-y-1">
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="processes.html"><i class="fa-solid fa-gear mr-1"></i> Run Processes</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="logs.html"><i class="fa-solid fa-clipboard-list mr-1"></i> View Logs</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="backup.html"><i class="fa-solid fa-database mr-1"></i> Backup &amp; Restore</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="../users.php"><i class="fa-solid fa-user mr-1"></i> Manage Users</a></li>
-      <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 p-2 rounded" href="../logout.php"><i class="fa-solid fa-right-from-bracket mr-1"></i> Logout</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="processes.html"><i class="fa-solid fa-gear mr-1"></i> Run Processes</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="logs.html"><i class="fa-solid fa-clipboard-list mr-1"></i> View Logs</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="backup.html"><i class="fa-solid fa-database mr-1"></i> Backup &amp; Restore</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="../users.php"><i class="fa-solid fa-user mr-1"></i> Manage Users</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="../logout.php"><i class="fa-solid fa-right-from-bracket mr-1"></i> Logout</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Decrease vertical spacing between sidebar sections for a more compact menu
- Standardize link padding to keep sidebar items evenly spaced
- Color menu headings purple to match site theme

## Testing
- Manually inspected `frontend/menu.html` to verify spacing and color updates

------
https://chatgpt.com/codex/tasks/task_e_689b6b2efcd4832ebbcc11e3c5397afc