### PR TITLE
Add budget deletion feature

### DIFF
--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -73,7 +73,18 @@ async function loadBudgets(){
                 {title:'Category',field:'category'},
                 {title:'Budget',field:'amount',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
                 {title:'Spent',field:'spent',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
-                {title:'Left',field:'left',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'}
+                {title:'Left',field:'left',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
+                {formatter:()=>'<i class="fa-solid fa-trash text-red-600"></i>',width:40,hozAlign:'center',cellClick:async(e,cell)=>{
+                    if(!confirm('Delete this budget?')) return;
+                    const id=cell.getRow().getData().id;
+                    await fetch('../php_backend/public/budgets.php',{
+                        method:'DELETE',
+                        headers:{'Content-Type':'application/json'},
+                        body:JSON.stringify({id})
+                    });
+                    loadBudgets();
+                    showMessage('Budget deleted');
+                }}
             ]
         });
     }

--- a/php_backend/models/Budget.php
+++ b/php_backend/models/Budget.php
@@ -19,6 +19,15 @@ class Budget {
     }
 
     /**
+     * Delete a budget by its ID.
+     */
+    public static function delete(int $id): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('DELETE FROM budgets WHERE id = :id');
+        $stmt->execute(['id' => $id]);
+    }
+
+    /**
      * Retrieve budgets and spending for a given month and year.
      * Returns category name, budget amount, spent, and remaining.
      */

--- a/php_backend/public/budgets.php
+++ b/php_backend/public/budgets.php
@@ -43,5 +43,25 @@ if ($method === 'POST') {
     return;
 }
 
+if ($method === 'DELETE') {
+    $data = json_decode(file_get_contents('php://input'), true) ?? [];
+    $id = (int)($data['id'] ?? 0);
+    if ($id <= 0) {
+        http_response_code(400);
+        echo json_encode(['error' => 'ID required']);
+        return;
+    }
+    try {
+        Budget::delete($id);
+        Log::write("Deleted budget $id");
+        echo json_encode(['status' => 'ok']);
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Budget delete error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode(['error' => 'Server error']);
+    }
+    return;
+}
+
 http_response_code(405);
 ?>


### PR DESCRIPTION
## Summary
- support deleting budgets via new DELETE endpoint
- add trash icon column to budgets table for removal

## Testing
- `php -l php_backend/models/Budget.php`
- `php -l php_backend/public/budgets.php`


------
https://chatgpt.com/codex/tasks/task_e_689b7298e8cc832e97031a483c743233