### PR TITLE
Link tag, category and group names to search

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -54,7 +54,7 @@
     }
 
     // Render a table with yearly totals across multiple years
-    function buildTable(id, data, years){
+    function buildTable(id, data, years, colorClasses){
         const el = document.getElementById(id);
         el.innerHTML = '';
 
@@ -69,7 +69,19 @@
         }));
 
         const columns = [
-            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
+            {
+                title: 'Name',
+                field: 'name',
+                bottomCalc: () => 'Total',
+                formatter: function(cell){
+                    const value = cell.getValue();
+                    const badge = createBadge(value, colorClasses);
+                    const link = document.createElement('a');
+                    link.href = `search.html?value=${encodeURIComponent(value)}`;
+                    link.appendChild(badge);
+                    return link;
+                }
+            },
             ...yearCols,
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
@@ -151,12 +163,12 @@
         fetch('../php_backend/public/all_years_dashboard.php')
             .then(resp => resp.json())
             .then(data => {
-                buildTable('tags-table', data.tags, data.years);
+                buildTable('tags-table', data.tags, data.years, 'bg-blue-200 text-blue-800');
                 buildChart('tags-chart', 'Tag Totals', data.tags);
-                buildTable('categories-table', data.categories, data.years);
+                buildTable('categories-table', data.categories, data.years, 'bg-green-200 text-green-800');
                 buildChart('categories-chart', 'Category Totals', data.categories);
                 buildDonutCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
-                buildTable('groups-table', data.groups, data.years);
+                buildTable('groups-table', data.groups, data.years, 'bg-purple-200 text-purple-800');
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });
     });

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -65,7 +65,19 @@
             bottomCalcFormatter: totalFormatter
         }));
         const columns = [
-            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
+            {
+                title: 'Name',
+                field: 'name',
+                bottomCalc: () => 'Total',
+                formatter: function(cell){
+                    const value = cell.getValue();
+                    const badge = createBadge(value, 'bg-purple-200 text-purple-800');
+                    const link = document.createElement('a');
+                    link.href = `search.html?value=${encodeURIComponent(value)}`;
+                    link.appendChild(badge);
+                    return link;
+                }
+            },
             ...monthCols,
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
@@ -86,7 +98,19 @@
             bottomCalcFormatter: totalFormatter
         }));
         const columns = [
-            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
+            {
+                title: 'Name',
+                field: 'name',
+                bottomCalc: () => 'Total',
+                formatter: function(cell){
+                    const value = cell.getValue();
+                    const badge = createBadge(value, 'bg-purple-200 text-purple-800');
+                    const link = document.createElement('a');
+                    link.href = `search.html?value=${encodeURIComponent(value)}`;
+                    link.appendChild(badge);
+                    return link;
+                }
+            },
             ...yearCols,
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -32,10 +32,20 @@ function badgeFormatter(colorClasses) {
         if (!value) return '';
         if (Array.isArray(value)) {
             const container = document.createElement('div');
-            value.forEach(v => container.appendChild(createBadge(v, colorClasses)));
+            value.forEach(v => {
+                const badge = createBadge(v, colorClasses);
+                const link = document.createElement('a');
+                link.href = `search.html?value=${encodeURIComponent(v)}`;
+                link.appendChild(badge);
+                container.appendChild(link);
+            });
             return container;
         }
-        return createBadge(value, colorClasses);
+        const badge = createBadge(value, colorClasses);
+        const link = document.createElement('a');
+        link.href = `search.html?value=${encodeURIComponent(value)}`;
+        link.appendChild(badge);
+        return link;
     };
 }
 

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -76,7 +76,7 @@
     }
 
     // Render a table showing daily totals for the month
-    function buildTable(id, data, days){
+    function buildTable(id, data, days, colorClasses){
         const el = document.getElementById(id);
         el.innerHTML = '';
 
@@ -91,7 +91,19 @@
         }));
 
         const columns = [
-            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
+            {
+                title: 'Name',
+                field: 'name',
+                bottomCalc: () => 'Total',
+                formatter: function(cell){
+                    const value = cell.getValue();
+                    const badge = createBadge(value, colorClasses);
+                    const link = document.createElement('a');
+                    link.href = `search.html?value=${encodeURIComponent(value)}`;
+                    link.appendChild(badge);
+                    return link;
+                }
+            },
             ...dayCols,
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
@@ -183,12 +195,12 @@
 
                 const days = new Date(year, month, 0).getDate();
 
-                buildTable('tags-table', data.tags, days);
+                buildTable('tags-table', data.tags, days, 'bg-blue-200 text-blue-800');
                 buildChart('tags-chart', 'Tag Totals', data.tags);
-                buildTable('categories-table', data.categories, days);
+                buildTable('categories-table', data.categories, days, 'bg-green-200 text-green-800');
                 buildChart('categories-chart', 'Category Totals', data.categories);
                 buildDonutCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
-                buildTable('groups-table', data.groups, days);
+                buildTable('groups-table', data.groups, days, 'bg-purple-200 text-purple-800');
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });
     }

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -335,7 +335,11 @@ function loadTransactions() {
                         const id = cell.getValue();
                         const name = groupValues[id] || '';
                         if (!name) return '';
-                        return createBadge(name, 'bg-purple-200 text-purple-800');
+                        const badge = createBadge(name, 'bg-purple-200 text-purple-800');
+                        const link = document.createElement('a');
+                        link.href = `search.html?value=${encodeURIComponent(name)}`;
+                        link.appendChild(badge);
+                        return link;
                     },
                     editor: 'list',
                     editorParams: { values: groupValues },

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -58,7 +58,7 @@
     }
 
     // Render a Tabulator table showing monthly breakdowns
-    function buildTable(id, data){
+    function buildTable(id, data, colorClasses){
         const el = document.getElementById(id);
         el.innerHTML = '';
 
@@ -73,7 +73,19 @@
         }));
 
         const columns = [
-            { title: 'Name', field: 'name', bottomCalc: () => 'Total' },
+            {
+                title: 'Name',
+                field: 'name',
+                bottomCalc: () => 'Total',
+                formatter: function(cell){
+                    const value = cell.getValue();
+                    const badge = createBadge(value, colorClasses);
+                    const link = document.createElement('a');
+                    link.href = `search.html?value=${encodeURIComponent(value)}`;
+                    link.appendChild(badge);
+                    return link;
+                }
+            },
             ...monthCols,
             { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: totalFormatter }
         ];
@@ -156,12 +168,12 @@
         fetch('../php_backend/public/yearly_dashboard.php?year=' + year)
             .then(resp => resp.json())
             .then(data => {
-                buildTable('tags-table', data.tags);
+                buildTable('tags-table', data.tags, 'bg-blue-200 text-blue-800');
                 buildChart('tags-chart', 'Tag Totals ' + year, data.tags);
-                buildTable('categories-table', data.categories);
+                buildTable('categories-table', data.categories, 'bg-green-200 text-green-800');
                 buildChart('categories-chart', 'Category Totals ' + year, data.categories);
                 buildDonutCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
-                buildTable('groups-table', data.groups);
+                buildTable('groups-table', data.groups, 'bg-purple-200 text-purple-800');
                 buildChart('groups-chart', 'Group Totals ' + year, data.groups);
             });
     }


### PR DESCRIPTION
## Summary
- Wrap badgeFormatter output in links to search for the selected tag, category or group.
- Make group entries in the monthly statement and all dashboard tables clickable.

## Testing
- `node --check frontend/js/tabulator-tailwind.js`


------
https://chatgpt.com/codex/tasks/task_e_689b7d61fbac832e9ebcda5ab52b4236