### PR TITLE
Use icons for edit and delete actions

### DIFF
--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -54,7 +54,8 @@ async function loadGroups() {
                 const g = cell.getRow().getData();
                 const container = document.createElement('div');
                 const edit = document.createElement('button');
-                edit.textContent = 'Edit';
+                edit.innerHTML = '<i class="fa-solid fa-pen"></i>';
+                edit.setAttribute('aria-label','Edit');
                 edit.className = 'bg-blue-600 text-white px-2 py-1 rounded mr-2';
                 edit.addEventListener('click', async () => {
                     const name = prompt('Group Name', g.name);
@@ -70,7 +71,8 @@ async function loadGroups() {
                     showMessage('Group updated');
                 });
                 const del = document.createElement('button');
-                del.textContent = 'Delete';
+                del.innerHTML = '<i class="fa-solid fa-trash"></i>';
+                del.setAttribute('aria-label','Delete');
                 del.className = 'bg-red-600 text-white px-2 py-1 rounded';
                 del.addEventListener('click', async () => {
                     if (!confirm('Delete this group?')) return;

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -33,7 +33,7 @@
             </form>
             <div class="mt-4 flex items-center space-x-2">
                 <label class="block flex-1">Saved Reports: <select id="saved-reports" class="border p-2 rounded w-full" data-help="Load a saved report"></select></label>
-                <button type="button" id="delete-report" class="bg-red-600 text-white px-4 py-2 rounded">Delete</button>
+                <button type="button" id="delete-report" class="bg-red-600 text-white px-3 py-2 rounded" aria-label="Delete saved report"><i class="fa-solid fa-trash"></i></button>
             </div>
             <div id="results-grid" class="mt-4"></div>
             <div id="chart" class="mt-6" style="height:400px;"></div>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -56,7 +56,8 @@ async function loadTags(){
                 const t = cell.getRow().getData();
                 const container = document.createElement('div');
                 const edit = document.createElement('button');
-                edit.textContent = 'Edit';
+                edit.innerHTML = '<i class="fa-solid fa-pen"></i>';
+                edit.setAttribute('aria-label','Edit');
                 edit.className = 'bg-blue-600 text-white px-2 py-1 rounded mr-2';
                 edit.addEventListener('click', async () => {
                     const name = prompt('Tag Name', t.name);
@@ -74,7 +75,8 @@ async function loadTags(){
                     showMessage('Tag updated');
                 });
                 const del = document.createElement('button');
-                del.textContent = 'Delete';
+                del.innerHTML = '<i class="fa-solid fa-trash"></i>';
+                del.setAttribute('aria-label','Delete');
                 del.className = 'bg-red-600 text-white px-2 py-1 rounded';
                 del.addEventListener('click', async () => {
                     if (!confirm('Delete this tag?')) return;


### PR DESCRIPTION
## Summary
- swap edit and delete action buttons to Font Awesome icons on tag and group management pages
- replace saved report delete text button with a trash icon

## Testing
- `php -l frontend/tags.html`
- `php -l frontend/groups.html`
- `php -l frontend/report.html`


------
https://chatgpt.com/codex/tasks/task_e_689b81064be4832e93819d7a722de597