### PR TITLE
Use 3D purple bar chart on search results

### DIFF
--- a/frontend/search.html
+++ b/frontend/search.html
@@ -26,7 +26,7 @@
             </form>
             <div id="results-grid" class="mt-4"></div>
             <p id="total" class="mt-4"></p>
-            <div id="monthly-chart" class="mt-6" style="height:400px"></div>
+            <div id="results-chart" class="mt-6" style="height:400px"></div>
         </main>
     </div>
     <script src="js/menu.js"></script>
@@ -34,6 +34,7 @@
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/highcharts-3d.js"></script>
     <script>
     // Format a numeric value as pounds and pence
     function formatCurrency(value) {
@@ -78,31 +79,65 @@
                 totalEl.textContent = 'Total: ' + formatCurrency(total);
                 totalEl.classList.add('text-right');
 
-                const chartEl = document.getElementById('monthly-chart');
+                const chartEl = document.getElementById('results-chart');
                 if (data.results && data.results.length) {
-                    const monthly = {};
-                    data.results.forEach(row => {
-                        if (row.transfer_id !== null) return;
-                        const date = row.date.substring(0, 7); // YYYY-MM
-                        const amount = parseFloat(row.amount);
-                        if (amount < 0) {
-                            monthly[date] = (monthly[date] || 0) + (-amount);
+                    const filtered = data.results.filter(r => r.transfer_id === null);
+                    if (filtered.length) {
+                        const dates = filtered.map(r => new Date(r.date));
+                        const min = new Date(Math.min.apply(null, dates));
+                        const max = new Date(Math.max.apply(null, dates));
+                        const diffDays = (max - min) / (1000 * 60 * 60 * 24);
+
+                        let buckets = {};
+                        let categories = [];
+                        let values = [];
+                        let chartTitle = '';
+
+                        if (diffDays <= 62) {
+                            filtered.forEach(r => {
+                                const day = r.date;
+                                const amt = -parseFloat(r.amount);
+                                if (amt > 0) buckets[day] = (buckets[day] || 0) + amt;
+                            });
+                            const days = Object.keys(buckets).sort();
+                            categories = days.map(d => new Date(d).toLocaleDateString());
+                            values = days.map(d => parseFloat(buckets[d].toFixed(2)));
+                            chartTitle = 'Daily Spend';
+                        } else {
+                            filtered.forEach(r => {
+                                const month = r.date.substring(0, 7);
+                                const amt = -parseFloat(r.amount);
+                                if (amt > 0) buckets[month] = (buckets[month] || 0) + amt;
+                            });
+                            const months = Object.keys(buckets).sort();
+                            categories = months.map(m => {
+                                const [y, mth] = m.split('-');
+                                return new Date(y, mth - 1).toLocaleString('default', { month: 'short', year: 'numeric' });
+                            });
+                            values = months.map(m => parseFloat(buckets[m].toFixed(2)));
+                            chartTitle = 'Monthly Spend';
                         }
-                    });
-                    const months = Object.keys(monthly).sort();
-                    const categories = months.map(m => {
-                        const [y, mth] = m.split('-');
-                        const d = new Date(y, mth - 1);
-                        return d.toLocaleString('default', { month: 'short', year: 'numeric' });
-                    });
-                    const series = months.map(m => parseFloat(monthly[m].toFixed(2)));
-                    Highcharts.chart('monthly-chart', {
-                        title: { text: 'Monthly Spend' },
-                        xAxis: { categories: categories },
-                        yAxis: { title: { text: 'Amount (£)' } },
-                        series: [{ name: 'Spend', data: series }],
-                        tooltip: { valuePrefix: '£', valueDecimals: 2 }
-                    });
+
+                        const points = values.map((v, i) => ({
+                            y: v,
+                            color: Highcharts.color('#6b21a8').brighten(i * 0.05).get()
+                        }));
+
+                        Highcharts.chart('results-chart', {
+                            chart: {
+                                type: 'column',
+                                options3d: { enabled: true, alpha: 0, beta: 0, depth: 50 }
+                            },
+                            title: { text: chartTitle },
+                            xAxis: { categories: categories },
+                            yAxis: { title: { text: 'Amount (£)' } },
+                            plotOptions: { column: { depth: 25 } },
+                            series: [{ name: 'Spend', data: points, colorByPoint: true }],
+                            tooltip: { valuePrefix: '£', valueDecimals: 2 }
+                        });
+                    } else {
+                        chartEl.innerHTML = '';
+                    }
                 } else {
                     chartEl.innerHTML = '';
                 }


### PR DESCRIPTION
## Summary
- Replace monthly line chart with 3D column chart showing spend in site purple.
- Scale chart automatically to daily or monthly totals based on result range.
- Render bars with front-facing 3D depth rather than tilting the entire plot.

## Testing
- `php -l php_backend/public/search_transactions.php`


------
https://chatgpt.com/codex/tasks/task_e_689b8032b83c832ea1c8d357b33f727a