### PR TITLE
Add update button to run git pull from home page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -20,8 +20,10 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white/80 backdrop-blur border-r p-6 shadow"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-3xl font-semibold mb-4 text-indigo-700">Welcome to Finance Manager</h1>
-            <p class="text-gray-700">Select an option from the menu to get started.</p>
+             <p class="text-gray-700">Select an option from the menu to get started.</p>
             <p id="version" class="text-gray-500">Version: loading...</p>
+            <button id="update-btn" class="mt-2 bg-green-600 text-white px-4 py-2 rounded flex items-center"><i class="fas fa-sync-alt mr-2"></i>Update</button>
+            <pre id="update-output" class="mt-2 text-sm text-gray-600 whitespace-pre-wrap"></pre>
 
             <section class="mt-8 bg-white p-8 rounded-lg shadow-lg">
                 <h2 class="text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
@@ -54,7 +56,8 @@
 
     <script src="js/menu.js"></script>
     <script src="js/version.js"></script>
+    <script src="js/update.js"></script>
 
     <script src="js/overlay.js"></script>
-</body>
+  </body>
 </html>

--- a/frontend/js/update.js
+++ b/frontend/js/update.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('update-btn');
+  const output = document.getElementById('update-output');
+  if (!btn || !output) return;
+
+  btn.addEventListener('click', () => {
+    btn.disabled = true;
+    output.textContent = 'Updating...';
+    fetch('../php_backend/public/git_pull.php')
+      .then(r => r.json())
+      .then(data => {
+        output.textContent = data.output || '';
+        btn.disabled = false;
+        if (data.success) {
+          fetch('../php_backend/public/version.php')
+            .then(resp => resp.json())
+            .then(v => {
+              const target = document.getElementById('version');
+              if (target) {
+                const version = v.version || 'unknown';
+                target.textContent = `Version: ${version}`;
+              }
+            });
+        }
+      })
+      .catch(() => {
+        output.textContent = 'Update failed';
+        btn.disabled = false;
+      });
+  });
+});

--- a/php_backend/public/git_pull.php
+++ b/php_backend/public/git_pull.php
@@ -1,0 +1,12 @@
+<?php
+// Runs 'git pull' to update the application to the latest version.
+require_once __DIR__ . '/../nocache.php';
+header('Content-Type: application/json');
+$rootDir = dirname(__DIR__, 2);
+$output = [];
+$returnVar = 0;
+exec('cd ' . escapeshellarg($rootDir) . ' && git pull 2>&1', $output, $returnVar);
+echo json_encode([
+    'success' => $returnVar === 0,
+    'output' => trim(implode("\n", $output))
+]);


### PR DESCRIPTION
## Summary
- add Update button on landing page to run git pull
- expose backend endpoint that executes git pull and returns output
- refresh displayed version after updating

## Testing
- `php -l php_backend/public/git_pull.php`
- `node --check frontend/js/update.js`
- `REQUEST_METHOD=GET php -d display_errors=0 php_backend/public/git_pull.php`


------
https://chatgpt.com/codex/tasks/task_e_689c6927cf08832eb52b0cdb015864cc