### PR TITLE
Add finance-themed graphics to landing page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,6 +11,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;500&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="wallet.svg">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
         body { font-family: 'Roboto', sans-serif; font-weight: 300; }
     </style>
@@ -24,6 +25,25 @@
             <p id="version" class="text-gray-500">Version: loading...</p>
             <button id="update-btn" class="mt-2 bg-green-600 text-white px-4 py-2 rounded flex items-center"><i class="fas fa-sync-alt mr-2"></i>Update</button>
             <pre id="update-output" class="mt-2 text-sm text-gray-600 whitespace-pre-wrap"></pre>
+
+            <section class="mt-8 grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div class="bg-white p-6 rounded shadow flex flex-col items-center text-center">
+                    <i class="fas fa-chart-line text-indigo-600 text-4xl mb-2"></i>
+                    <p class="text-gray-700">Visualise your spending trends.</p>
+                </div>
+                <div class="bg-white p-6 rounded shadow flex flex-col items-center text-center">
+                    <i class="fas fa-piggy-bank text-indigo-600 text-4xl mb-2"></i>
+                    <p class="text-gray-700">Track savings effortlessly.</p>
+                </div>
+                <div class="bg-white p-6 rounded shadow flex flex-col items-center text-center">
+                    <i class="fas fa-money-bill-wave text-indigo-600 text-4xl mb-2"></i>
+                    <p class="text-gray-700">Manage budgets with ease.</p>
+                </div>
+            </section>
+
+            <section class="mt-8 bg-white p-6 rounded shadow">
+                <div id="home-chart" style="height:300px"></div>
+            </section>
 
             <section class="mt-8 bg-white p-8 rounded-lg shadow-lg">
                 <h2 class="text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
@@ -57,7 +77,23 @@
     <script src="js/menu.js"></script>
     <script src="js/version.js"></script>
     <script src="js/update.js"></script>
-
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', function(){
+            Highcharts.chart('home-chart', {
+                title: { text: 'Sample Spending' },
+                xAxis: { categories: ['Mon','Tue','Wed','Thu','Fri'] },
+                yAxis: {
+                    title: { text: 'Amount (£)' },
+                    labels: { formatter: function(){ return '£' + this.value; } }
+                },
+                series: [{ name: 'Spending', data: [5, 3, 4, 7, 2] }],
+                tooltip: {
+                    pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); }
+                }
+            });
+        });
+    </script>
     <script src="js/overlay.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Font Awesome and Highcharts on the home page
- Highlight key features with finance-themed icons
- Display a sample spending chart using Highcharts

## Testing
- `php -l frontend/index.html`


------
https://chatgpt.com/codex/tasks/task_e_689c761b6760832e8b06dff48c8f2ef9