### PR TITLE
Prevent caching of JavaScript assets

### DIFF
--- a/frontend/.htaccess
+++ b/frontend/.htaccess
@@ -1,0 +1,7 @@
+<IfModule mod_headers.c>
+  <FilesMatch "\.js$">
+    Header set Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
+    Header set Pragma "no-cache"
+    Header set Expires "Wed, 11 Jan 1984 05:00:00 GMT"
+  </FilesMatch>
+</IfModule>


### PR DESCRIPTION
## Summary
- add `.htaccess` in `frontend` to instruct browsers not to cache JavaScript files

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_689c76fd53d0832e857e73e289f02fd6