### PR TITLE
Ensure page help initializes when loaded dynamically

### DIFF
--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -1,6 +1,6 @@
 // Provides a help overlay describing the purpose of the current page.
 // Loads Font Awesome for the help icon if it is not already available.
-document.addEventListener('DOMContentLoaded', () => {
+const init = () => {
   const page = location.pathname.split('/').pop();
   const helpTexts = {
 
@@ -66,5 +66,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.body.appendChild(btn);
   document.body.appendChild(overlay);
-});
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
 


### PR DESCRIPTION
## Summary
- Initialize page help overlay immediately if the DOM is already loaded so help buttons appear on every page.

## Testing
- `node --check frontend/js/page_help.js`

------
https://chatgpt.com/codex/tasks/task_e_689c7fc0daec832e92104a4299b5fcf9