### PR TITLE
Ensure git pull runs from the web root

### DIFF
--- a/php_backend/public/git_pull.php
+++ b/php_backend/public/git_pull.php
@@ -2,7 +2,9 @@
 // Runs 'git pull' to update the application to the latest version.
 require_once __DIR__ . '/../nocache.php';
 header('Content-Type: application/json');
-$rootDir = dirname(__DIR__, 2);
+// Determine the repository root. Prefer the web server's document root
+// so the script operates within the deployed application directory.
+$rootDir = realpath($_SERVER['DOCUMENT_ROOT'] ?? '') ?: dirname(__DIR__, 2);
 $output = [];
 $returnVar = 0;
 


### PR DESCRIPTION
## Summary
- derive repository path from the web server's document root
- allow update button to run `git pull` in the deployed directory

## Testing
- `php -l php_backend/public/git_pull.php`


------
https://chatgpt.com/codex/tasks/task_e_689ca4c044dc832ea7d6975fde78223c