### PR TITLE
Expand page subtitles for clarity

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Account Dashboard</h1>
-            <p class="mb-4">Overview of account balances and activity.</p>
+            <p class="mb-4">See an overview of account balances and recent activity. Charts and tables reveal how money flows through each account.</p>
             <div class="bg-white p-6 rounded shadow">
                 <div id="accounts-table"></div>
                 <div id="accounts-chart" class="mt-4" style="height:400px"></div>

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">All Years Dashboard</h1>
-            <p class="mb-4">Compare financial totals across every recorded year.</p>
+            <p class="mb-4">Compare financial totals across every recorded year to reveal long-term trends and patterns in your finances.</p>
 
             <h2 class="text-xl font-semibold mt-6 mb-2">Tag Totals</h2>
             <div id="tags-table" class="mt-2"></div>

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -16,6 +16,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4">Backup &amp; Restore</h1>
+            <p class="mb-4">Create backups of your data or restore from an earlier snapshot. Use the tools below to download a copy of your information or load a previous backup.</p>
             <section class="bg-white p-6 rounded shadow space-y-4">
                 <h2 class="text-xl font-semibold">Download Backup</h2>
                 <p>Select which data to include in the backup JSON file.</p>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -18,6 +18,7 @@
     <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4">Budgets</h1>
+        <p class="mb-4">Set monthly spending limits for categories and monitor progress. Use this page to plan ahead and see where you may need to adjust your spending.</p>
         <section>
             <form id="budget-form" class="md:flex md:space-x-4 space-y-4 md:space-y-0">
                 <label class="block">Month<br><input type="month" id="month" class="border p-2 rounded" data-help="Month for the budget"></label>

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -16,7 +16,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Categories</h1>
-            <p class="mb-4">Create categories and assign tags to organise your transactions.</p>
+            <p class="mb-4">Create categories and assign tags to organise your transactions. A well-maintained list keeps reports clear and makes searching easier.</p>
             <form id="category-form" class="space-y-4">
                 <label class="block">Category Name<br><input type="text" id="category-name" class="border p-2 rounded w-full" data-help="Name for the category"></label>
                 <label class="block">Description<br><textarea id="category-description" class="border p-2 rounded w-full" data-help="Description for the category"></textarea></label>

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -14,6 +14,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-8">
             <h1 class="text-2xl font-semibold">Graphs</h1>
+            <p class="mb-4">Explore a collection of charts that illustrate your income and spending patterns. Choose a year to see how your finances evolve and compare categories or tags visually.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full"></select>
             </label>

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Group Dashboard</h1>
-            <p class="mb-4">Review group spending by month and year.</p>
+            <p class="mb-4">Review group spending by month and year to see how different areas of your budget change over time.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full" data-help="Select year"></select>
             </label>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Groups</h1>
-            <p class="mb-4">Create groups to collect related categories for reporting.</p>
+            <p class="mb-4">Create groups to collect related categories for reporting and analysis. Grouping similar categories helps you see broader spending patterns.</p>
             <form id="group-form" class="space-y-4">
                 <label class="block">Group Name<br><input type="text" id="group-name" class="border p-2 rounded w-full" data-help="Name for the group"></label>
                 <label class="block">Description<br><textarea id="group-description" class="border p-2 rounded w-full" data-help="Description for the group"></textarea></label>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,7 +21,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white/80 backdrop-blur border-r p-6 shadow"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-3xl font-semibold mb-4 text-indigo-700">Welcome to Finance Manager</h1>
-             <p class="text-gray-700">Select an option from the menu to get started.</p>
+            <p class="text-gray-700">Select an option from the menu to get started exploring your finances. Each section opens tools and dashboards that help you understand where your money goes.</p>
             <p id="version" class="text-gray-500">Version: loading...</p>
             <button id="update-btn" class="mt-2 bg-green-600 text-white px-4 py-2 rounded flex items-center"><i class="fas fa-sync-alt mr-2"></i>Update</button>
             <pre id="update-output" class="mt-2 text-sm text-gray-600 whitespace-pre-wrap"></pre>
@@ -29,15 +29,15 @@
             <section class="mt-8 grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="bg-white p-6 rounded shadow flex flex-col items-center text-center">
                     <i class="fas fa-chart-line text-indigo-600 text-4xl mb-2"></i>
-                    <p class="text-gray-700">Visualise your spending trends.</p>
+                    <p class="text-gray-700">Visualise your spending trends with clear charts that highlight where your money goes.</p>
                 </div>
                 <div class="bg-white p-6 rounded shadow flex flex-col items-center text-center">
                     <i class="fas fa-piggy-bank text-indigo-600 text-4xl mb-2"></i>
-                    <p class="text-gray-700">Track savings effortlessly.</p>
+                    <p class="text-gray-700">Track savings effortlessly to see how your balance grows over time.</p>
                 </div>
                 <div class="bg-white p-6 rounded shadow flex flex-col items-center text-center">
                     <i class="fas fa-money-bill-wave text-indigo-600 text-4xl mb-2"></i>
-                    <p class="text-gray-700">Manage budgets with ease.</p>
+                    <p class="text-gray-700">Manage budgets with ease by setting targets and watching your progress.</p>
                 </div>
             </section>
 

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Application Logs</h1>
-            <p class="mb-4">Review recent log entries to monitor system activity.</p>
+            <p class="mb-4">Review recent log entries to monitor system activity. Filtering by time or keyword helps you trace what happened during a specific event.</p>
             <div id="logs-grid" class="mt-4"></div>
         </main>
     </div>

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -17,7 +17,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Missing Tags</h1>
-            <p class="mb-4">Identify transactions that have not yet been tagged.</p>
+            <p class="mb-4">Identify transactions that have not yet been tagged so you can assign categories before they slip through your reports.</p>
             <div id="untagged-table"></div>
         </main>
     </div>

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Monthly Dashboard</h1>
-            <p class="mb-4">View income and outgoings for a chosen month.</p>
+            <p class="mb-4">View income and outgoings for a chosen month. Compare different months to spot trends and track progress toward your goals.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full" data-help="Select year"></select>
             </label>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -19,7 +19,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Monthly Statement</h1>
-            <p class="mb-4">Select a month to view a detailed list of transactions.</p>
+            <p class="mb-4">Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.</p>
             <div class="bg-white p-6 rounded shadow">
                 <form id="statement-form" class="flex items-end space-x-4">
                     <div>

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -15,7 +15,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Run Processes</h1>
-            <p class="mb-4">Run background tasks like auto-tagging and category assignment.</p>
+            <p class="mb-4">Run background tasks like auto-tagging and category assignment. These automated processes tidy your data so reports stay accurate without manual effort.</p>
             <div class="space-x-4">
                 <button id="tagging-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Run Tagging</button>
                 <button id="categories-btn" class="bg-blue-600 text-white px-4 py-2 rounded">Apply Categories</button>

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Recurring Spend Detection</h1>
-            <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses.</p>
+            <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses. The results highlight ongoing commitments so you know where money leaves your account regularly.</p>
             <button id="run-analysis" class="bg-blue-600 text-white px-4 py-2 rounded mb-4"><i class="fa-solid fa-play mr-2"></i>Run Analysis</button>
             <div id="results-grid"></div>
             <p id="total" class="mt-4 text-right"></p>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Transaction Reports</h1>
-            <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria.</p>
+            <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>
             <form id="report-form" class="bg-white p-4 rounded shadow grid grid-cols-1 md:grid-cols-3 gap-4">
                 <label class="block">Category: <select id="category" class="border p-2 rounded w-full" data-help="Filter by category"></select></label>
                 <label class="block">Tag: <select id="tag" class="border p-2 rounded w-full" data-help="Filter by tag"></select></label>

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Search Transactions</h1>
-            <p class="mb-4">Find specific transactions using keywords and view the results below.</p>
+            <p class="mb-4">Find specific transactions using keywords and view the results below. Quick searches help you jump straight to the entries you need.</p>
             <form id="search-form" class="space-y-4">
                 <input type="text" id="term" placeholder="Search value" class="border p-2 rounded w-full" data-help="Value to search across transactions">
                 <input type="number" step="0.01" id="amount" placeholder="Amount (£)" class="border p-2 rounded w-full" data-help="Exact amount to match">

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Manage Tags</h1>
-            <p class="mb-4">Create new tags and manage existing ones for categorising transactions.</p>
+            <p class="mb-4">Create new tags and manage existing ones for categorising transactions. Tags act like labels that make reports and searches more meaningful.</p>
             <form id="tag-form" class="space-y-4">
                 <label class="block">Tag Name<br><input type="text" id="tag-name" class="border p-2 rounded w-full" data-help="Name for the tag"></label>
                 <label class="block">Keyword (for auto tagging)<br><input type="text" id="tag-keyword" class="border p-2 rounded w-full" data-help="Keyword used to auto-tag transactions"></label>

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -14,7 +14,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Transaction Details</h1>
-            <p class="mb-4">Review or edit the information for a single transaction.</p>
+            <p class="mb-4">Review or edit the information for a single transaction. Changes here immediately update dashboards, reports and budgets.</p>
             <div id="transaction-details" class="mt-4"></div>
         </main>
     </div>

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -26,6 +26,7 @@
                     </span>
 
                 </h1>
+                <p class="mb-4">Manage possible transfers between accounts and mark them so they don't count toward income or outgoings.</p>
                 <div id="transfers-table"></div>
             </section>
             <section>

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -15,7 +15,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Upload OFX Files</h1>
-            <p class="mb-4">Upload one or more OFX statements from your bank to import transactions.</p>
+        <p class="mb-4">Upload one or more OFX statements from your bank to import transactions into the system. The file contents will be processed and your data added to the database for review.</p>
             <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                 <input type="file" name="ofx_files[]" accept=".ofx" multiple required class="block w-full" data-help="Select one or more OFX files to upload">
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Upload</button>

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -18,7 +18,7 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4">Yearly Dashboard</h1>
-            <p class="mb-4">Analyse totals for a single year through charts and tables.</p>
+            <p class="mb-4">Analyse totals for a single year through charts and tables to understand how income and spending evolved month by month.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full" data-help="Select year to display"></select>
             </label>

--- a/index.php
+++ b/index.php
@@ -41,7 +41,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <div class="w-full max-w-sm bg-white p-6 rounded shadow">
         <img src="frontend/wallet.svg" alt="Finance Manager Logo" class="w-24 mx-auto mb-4">
         <h1 class="text-2xl font-semibold mb-4 text-center">Login</h1>
-        <p class="mb-4 text-center">Use your account credentials to sign in and access the finance manager.</p>
+        <p class="mb-4 text-center">Use your account credentials to sign in and access the finance manager. Enter your username and password in the boxes below and press the login button to continue.</p>
         <?php if ($error): ?>
             <p class="mb-4 text-red-500 text-center"><?= htmlspecialchars($error) ?></p>
         <?php endif; ?>

--- a/users.php
+++ b/users.php
@@ -53,7 +53,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow">
         <img src="frontend/wallet.svg" alt="Finance Manager Logo" class="w-24 mx-auto mb-4">
         <h1 class="text-2xl font-semibold mb-4">User Management</h1>
-        <p class="mb-4">Add new users or update your password from this page.</p>
+        <p class="mb-4">Add new users or update your own password from this page. Use the forms below to manage access so everyone who needs the system can sign in securely.</p>
         <p class="mb-4"><a href="logout.php" class="text-blue-600 hover:underline">Logout</a> | <a href="frontend/index.html" class="text-blue-600 hover:underline">Home</a></p>
         <?php if ($message): ?>
             <p class="mb-4 text-green-600"><?= htmlspecialchars($message) ?></p>


### PR DESCRIPTION
## Summary
- Broadened subtitles across login and dashboard pages to explain each page's purpose in more detail.
- Added missing subtitles where none existed so every view provides immediate context.

## Testing
- `php -l index.php users.php`


------
https://chatgpt.com/codex/tasks/task_e_689ca4e7ea94832e9d20f7d67658c113