### PR TITLE
Ensure git pull runs from the web root

### DIFF
--- a/php_backend/public/git_pull.php
+++ b/php_backend/public/git_pull.php
@@ -2,16 +2,26 @@
 // Runs 'git pull' to update the application to the latest version.
 require_once __DIR__ . '/../nocache.php';
 header('Content-Type: application/json');
-$rootDir = dirname(__DIR__, 2);
+// Determine the repository root. Prefer the web server's document root
+// so the script operates within the deployed application directory.
+$rootDir = realpath($_SERVER['DOCUMENT_ROOT'] ?? '') ?: dirname(__DIR__, 2);
+
+// Git expects a HOME environment variable even when no global configuration is
+// required. Point it at the repository root to satisfy this requirement.
+putenv('HOME=' . $rootDir);
+$_SERVER['HOME'] = $rootDir;
+
 $output = [];
 $returnVar = 0;
 
-// Allow git to operate even if repository ownership differs from the running user.
-exec('git config --global --add safe.directory ' . escapeshellarg($rootDir));
+// Prepare a git command that treats the repository directory as safe without
+// relying on global configuration that requires the HOME environment variable.
+$gitCmd = 'git -C ' . escapeshellarg($rootDir) . ' -c safe.directory=' . escapeshellarg($rootDir);
+
 // Ensure a remote is configured before attempting to pull.
 $remoteList = [];
 $remoteStatus = 0;
-exec('cd ' . escapeshellarg($rootDir) . ' && git remote 2>&1', $remoteList, $remoteStatus);
+exec($gitCmd . ' remote 2>&1', $remoteList, $remoteStatus);
 if ($remoteStatus !== 0 || trim(implode("\n", $remoteList)) === '') {
     echo json_encode([
         'success' => false,
@@ -19,7 +29,7 @@ if ($remoteStatus !== 0 || trim(implode("\n", $remoteList)) === '') {
     ]);
     exit;
 }
-exec('cd ' . escapeshellarg($rootDir) . ' && git pull 2>&1', $output, $returnVar);
+exec($gitCmd . ' pull 2>&1', $output, $returnVar);
 
 echo json_encode([
     'success' => $returnVar === 0,


### PR DESCRIPTION
## Summary
- derive repository path from the web server's document root
- execute git commands with per-command `safe.directory` to avoid HOME requirement
- set HOME environment variable to repo root so git commands run without fatal error

## Testing
- `php -l php_backend/public/git_pull.php`


------
https://chatgpt.com/codex/tasks/task_e_689ca4c044dc832ea7d6975fde78223c