### PR TITLE
Refine message overlay to top bar toast

### DIFF
--- a/frontend/js/overlay.js
+++ b/frontend/js/overlay.js
@@ -1,12 +1,10 @@
 // Provides a simple overlay for displaying temporary messages.
 (function(){
-    // Build the overlay element and insert it into the DOM
+    // Build a small notification element anchored to the top bar
     function createOverlay(){
         const overlay = document.createElement('div');
         overlay.id = 'overlay';
-        overlay.className = 'fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden';
-        overlay.innerHTML = '<div class="p-6 rounded shadow text-white"></div>';
-        overlay.addEventListener('click', () => overlay.classList.add('hidden'));
+        overlay.className = 'fixed top-2 right-4 z-50 px-4 py-2 rounded shadow text-white hidden';
         document.body.appendChild(overlay);
         return overlay;
     }
@@ -15,24 +13,16 @@
         window.__overlay = createOverlay();
     });
 
-
     let hideTimer;
 
-    // Display a temporary message in the overlay
+    // Display a temporary message in the top bar
     window.showMessage = function(msg, type = 'success'){
         const overlay = window.__overlay || document.getElementById('overlay') || createOverlay();
-        const box = overlay.querySelector('div');
-        box.textContent = msg;
-        box.className = 'p-6 rounded shadow text-white';
-        if(type === 'error') {
-            box.classList.add('bg-red-600');
-        } else {
-            box.classList.add('bg-green-600');
-        }
-        overlay.classList.remove('hidden');
+        overlay.textContent = msg;
+        overlay.classList.remove('hidden', 'bg-green-600', 'bg-red-600');
+        overlay.classList.add(type === 'error' ? 'bg-red-600' : 'bg-green-600');
 
         clearTimeout(hideTimer);
         hideTimer = setTimeout(() => overlay.classList.add('hidden'), 2000);
-
     };
 })();


### PR DESCRIPTION
## Summary
- Display temporary messages as a small toast on the top bar instead of full-screen overlay

## Testing
- `node --check frontend/js/overlay.js`


------
https://chatgpt.com/codex/tasks/task_e_689ca94fe090832e950606089c25007b