### PR TITLE
Show transfer status on transaction page

### DIFF
--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -44,6 +44,7 @@
                 <p><strong>Memo:</strong> ${tx.memo || ''}</p>
                 <p><strong>Amount:</strong> £${parseFloat(tx.amount).toFixed(2)}</p>
                 <p><strong>OFX Type:</strong> ${tx.ofx_type || ''}</p>
+                <p><strong>Transfer:</strong> ${tx.transfer_id ? '<span class="text-blue-600"><i class="fa-solid fa-right-left mr-1"></i>Yes – ignored in KPI, income and expense totals</span>' : 'No'}</p>
                 ${tx.category_name ? '<p><strong>Category:</strong> ' + tx.category_name + '</p>' : ''}
                 <label class="block">Tag: <input type="text" id="tag" class="border p-2 rounded w-full" data-help="Enter a new tag name to auto-tag similar transactions"></label>
                 <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Assign a group"></select></label>


### PR DESCRIPTION
## Summary
- Display transfer status on the transaction detail page, highlighting when a transaction is excluded from KPI, income and expense totals.

## Testing
- `php -l php_backend/public/transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_689cab5c01a4832e82a666d1cd691f6b