### PR TITLE
Show transfer status and tag/category icons on transaction page

### DIFF
--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -8,6 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Transaction Details</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
 <body class="bg-gray-50 font-sans">
     <div class="flex min-h-screen">
@@ -36,6 +37,17 @@
                 return;
             }
 
+            const card = document.createElement('div');
+            card.className = 'relative bg-white p-6 rounded shadow';
+
+            const icons = document.createElement('div');
+            icons.className = 'absolute top-2 right-2 flex space-x-2 text-4xl';
+            icons.innerHTML = `
+                ${tx.tag_id ? '<i class="fa-solid fa-tag text-green-600" title="Tagged"></i>' : '<i class="fa-solid fa-tag text-red-500" title="No tag"></i>'}
+                ${tx.category_id ? '<i class="fa-solid fa-folder-open text-green-600" title="Categorised"></i>' : '<i class="fa-solid fa-folder text-red-500" title="No category"></i>'}
+            `;
+            card.appendChild(icons);
+
             const form = document.createElement('form');
             form.className = 'space-y-4';
             form.innerHTML = `
@@ -44,12 +56,14 @@
                 <p><strong>Memo:</strong> ${tx.memo || ''}</p>
                 <p><strong>Amount:</strong> £${parseFloat(tx.amount).toFixed(2)}</p>
                 <p><strong>OFX Type:</strong> ${tx.ofx_type || ''}</p>
+                <p><strong>Transfer:</strong> ${tx.transfer_id ? '<span class="text-blue-600"><i class="fa-solid fa-right-left mr-1"></i>Yes – ignored in KPI, income and expense totals</span>' : 'No'}</p>
                 ${tx.category_name ? '<p><strong>Category:</strong> ' + tx.category_name + '</p>' : ''}
                 <label class="block">Tag: <input type="text" id="tag" class="border p-2 rounded w-full" data-help="Enter a new tag name to auto-tag similar transactions"></label>
                 <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Assign a group"></select></label>
                 <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Save</button>
             `;
-            container.appendChild(form);
+            card.appendChild(form);
+            container.appendChild(card);
             const tagInput = form.querySelector('#tag');
             const groupSel = form.querySelector('#group');
             const blankGrp = document.createElement('option');


### PR DESCRIPTION
## Summary
- Display transfer status on the transaction detail page, highlighting when a transaction is excluded from KPI, income and expense totals.
- Add large Font Awesome icons in the card header showing whether a transaction has a tag or category assigned.

## Testing
- `php -l php_backend/public/transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_689cab5c01a4832e82a666d1cd691f6b