### PR TITLE
Add breadcrumb headers for page navigation

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -52,6 +52,21 @@ document.addEventListener('DOMContentLoaded', () => {
         menu.querySelectorAll('a').forEach(a =>
           a.addEventListener('click', () => menu.classList.add('hidden'))
         );
+
+        // Build breadcrumb text above the page title
+        const current = location.pathname.split('/').pop();
+        const link = menu.querySelector(`a[href="${current}"]`);
+        if (link) {
+          const section = link.closest('div')?.querySelector('h3')?.textContent?.trim();
+          const page = link.textContent.trim();
+          const heading = document.querySelector('main h1');
+          if (section && page && heading) {
+            const crumb = document.createElement('div');
+            crumb.textContent = `${section} / ${page}`.toUpperCase();
+            crumb.className = 'uppercase text-indigo-900 text-[0.6rem] mb-1';
+            heading.before(crumb);
+          }
+        }
       })
       .catch(err => console.error('Menu load failed', err));
   }

--- a/index.php
+++ b/index.php
@@ -40,6 +40,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <body class="min-h-screen flex items-center justify-center bg-gray-50 font-sans">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow">
         <img src="frontend/wallet.svg" alt="Finance Manager Logo" class="w-24 mx-auto mb-4">
+        <div class="uppercase text-indigo-900 text-[0.6rem] mb-1 text-center">AUTHENTICATION / LOGIN</div>
         <h1 class="text-2xl font-semibold mb-4 text-center">Login</h1>
         <p class="mb-4 text-center">Use your account credentials to sign in and access the finance manager. Enter your username and password in the boxes below and press the login button to continue.</p>
         <?php if ($error): ?>

--- a/users.php
+++ b/users.php
@@ -52,6 +52,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <body class="min-h-screen bg-gray-50 font-sans p-6">
     <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow">
         <img src="frontend/wallet.svg" alt="Finance Manager Logo" class="w-24 mx-auto mb-4">
+        <div class="uppercase text-indigo-900 text-[0.6rem] mb-1">ADMIN TOOLS / MANAGE USERS</div>
         <h1 class="text-2xl font-semibold mb-4">User Management</h1>
         <p class="mb-4">Add new users or update your own password from this page. Use the forms below to manage access so everyone who needs the system can sign in securely.</p>
         <p class="mb-4"><a href="logout.php" class="text-blue-600 hover:underline">Logout</a> | <a href="frontend/index.html" class="text-blue-600 hover:underline">Home</a></p>


### PR DESCRIPTION
## Summary
- inject breadcrumb text above main headings using menu.js
- show AUTHENTICATION / LOGIN on the login page
- show ADMIN TOOLS / MANAGE USERS on the user management page

## Testing
- `node --check frontend/js/menu.js`
- `php -l index.php`
- `php -l users.php`


------
https://chatgpt.com/codex/tasks/task_e_689cae978574832ebd2e207d95a9fc63