### PR TITLE
Replace bubble chart with donut chart on monthly statement

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -74,12 +74,9 @@
             <div class="bg-white p-6 rounded shadow mt-4">
                 <div id="transactions-grid"></div>
             </div>
-            <div class="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="mt-4">
                 <div class="bg-white p-6 rounded shadow">
-                    <div id="sankey-chart" style="height:400px;"></div>
-                </div>
-                <div class="bg-white p-6 rounded shadow">
-                    <div id="category-bubbles" style="height:400px;"></div>
+                    <div id="category-donut" style="height:500px;"></div>
                 </div>
             </div>
         </main>
@@ -89,9 +86,7 @@
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
-    <script src="https://code.highcharts.com/highcharts-more.js"></script>
-    <script src="https://code.highcharts.com/modules/sankey.js"></script>
-    <script src="https://code.highcharts.com/modules/packed-bubble.js"></script>
+    
 <script>
 const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
@@ -220,7 +215,6 @@ function loadTransactions() {
         // normalise group ids for Tabulator
         data.forEach(t => { t.group_id = t.group_id ? String(t.group_id) : ''; });
         let income = 0, outgoings = 0, numIncome = 0, numExpense = 0;
-        const incomes = {};
         const spendings = {};
         const prevSpendings = {};
         const categoryTotals = {};
@@ -233,7 +227,6 @@ function loadTransactions() {
             if (amt > 0) {
                 income += amt;
                 numIncome++;
-                incomes[cat] = (incomes[cat] || 0) + amt;
             } else if (amt < 0) {
                 const exp = -amt;
                 outgoings += exp;
@@ -365,61 +358,44 @@ function loadTransactions() {
             ]
         });
 
-        buildSankeyChart(incomes, spendings);
-        buildBubbleChart(spendings, prevSpendings);
+        buildDonutChart(spendings, prevSpendings);
     });
 }
 
-function buildSankeyChart(incomes, spendings){
-    const totalIncome = Object.values(incomes).reduce((a,b) => a + b, 0);
-    const links = [];
-    Object.entries(incomes).forEach(([source, amount]) => {
-        const share = amount / totalIncome;
-        Object.entries(spendings).forEach(([cat, total]) => {
-            links.push([source, cat, +(total * share).toFixed(2)]);
-        });
-    });
-    Highcharts.chart('sankey-chart', {
-        title: { text: 'Income to Spending Flow' },
-        tooltip: {
-            pointFormatter: function(){
-                return '£' + Highcharts.numberFormat(this.weight, 2);
-            }
-        },
-        series: [{
-            keys: ['from', 'to', 'weight'],
-            data: links,
-            type: 'sankey',
-            name: 'Flow'
-        }]
-    });
-}
-
-function buildBubbleChart(spendings, prevSpendings){
+function buildDonutChart(spendings, prevSpendings){
     const data = Object.entries(spendings).map(([cat, total]) => {
         const prev = prevSpendings[cat] || 0;
         const change = total - prev;
         const color = change > 0 ? '#dc2626' : (change < 0 ? '#16a34a' : '#9ca3af');
-        return { name: cat, value: parseFloat(total.toFixed(2)), color, change };
+        return { name: cat, y: parseFloat(total.toFixed(2)), color, change };
     });
-    Highcharts.chart('category-bubbles', {
-        chart: { type: 'packedbubble' },
+    Highcharts.chart('category-donut', {
+        chart: { type: 'pie', height: 500 },
         title: { text: 'Spending by Category' },
+        legend: {
+            enabled: true,
+            useHTML: true,
+            labelFormatter: function(){
+                return '<span class="px-2 py-1 rounded bg-indigo-100 text-indigo-700 text-xs">'+this.name+'</span>';
+            }
+        },
+        plotOptions: {
+            pie: {
+                innerSize: '60%',
+                dataLabels: {
+                    enabled: true,
+                    useHTML: true,
+                    format: '<span class="px-2 py-1 rounded bg-indigo-100 text-indigo-700 text-xs">{point.name}</span>',
+                    style: { textOutline: 'none' }
+                }
+            }
+        },
         tooltip: {
             useHTML: true,
             pointFormatter: function(){
                 const change = this.change;
                 const sign = change >= 0 ? '+' : '-';
-                return `<b>${this.name}</b><br/>Spend: £${Highcharts.numberFormat(this.value, 2)}<br/>Change: ${sign}£${Highcharts.numberFormat(Math.abs(change), 2)}`;
-            }
-        },
-        plotOptions: {
-            packedbubble: {
-                dataLabels: {
-                    enabled: true,
-                    format: '{point.name}',
-                    style: { color: 'black', textOutline: 'none', fontWeight: 'normal' }
-                }
+                return `<b>${this.name}</b><br/>Spend: £${Highcharts.numberFormat(this.y, 2)}<br/>Change: ${sign}£${Highcharts.numberFormat(Math.abs(change), 2)}`;
             }
         },
         series: [{ data }]


### PR DESCRIPTION
## Summary
- swap packed bubble visualization for an expanded donut chart on the monthly statement page
- remove the Sankey flow chart
- color slices by monthly change and display category tags in labels and legend

## Testing
- `php -l frontend/monthly_statement.html`


------
https://chatgpt.com/codex/tasks/task_e_689cc5253cc0832ea86709e4fd580675