### PR TITLE
Sync account balances with bank and add balance history

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Account Balance</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
+            <h1 id="account-name" class="text-2xl font-semibold mb-4 text-indigo-700">Account Balance</h1>
+            <p class="mb-4">View the balance over time based on the latest bank statement.</p>
+            <div class="bg-white p-6 rounded shadow">
+                <div id="balance-chart" style="height:400px"></div>
+            </div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script>
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    if (id) {
+        fetch(`../php_backend/public/account_balance.php?id=${id}`)
+            .then(r => r.json())
+            .then(data => {
+                if (data.error) {
+                    document.getElementById('balance-chart').textContent = 'Account not found.';
+                    return;
+                }
+                document.getElementById('account-name').textContent = data.name;
+                const dates = data.history.map(h => h.date);
+                const balances = data.history.map(h => parseFloat(h.balance));
+                Highcharts.chart('balance-chart', {
+                    title: { text: 'Balance Over Time' },
+                    xAxis: { categories: dates },
+                    yAxis: { title: { text: 'Balance (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
+                    tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                    series: [{ name: 'Balance', data: balances }]
+                });
+            });
+    } else {
+        document.getElementById('balance-chart').textContent = 'No account specified.';
+    }
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -46,6 +46,9 @@
             tailwindTabulator(document.getElementById('accounts-table'), {
                 data,
                 layout: 'fitDataStretch',
+                rowClick: (e, row) => {
+                    window.location = `account.html?id=${row.getData().id}`;
+                },
                 columns: [
                     { title: 'Name', field: 'name' },
                     { title: 'Transactions', field: 'transactions', hozAlign: 'right' },

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -29,7 +29,9 @@ CREATE TABLE IF NOT EXISTS users (
 
 CREATE TABLE IF NOT EXISTS accounts (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    name VARCHAR(100) NOT NULL
+    name VARCHAR(100) NOT NULL,
+    ledger_balance DECIMAL(10,2) DEFAULT 0,
+    ledger_balance_date DATE DEFAULT NULL
 );
 
 CREATE TABLE IF NOT EXISTS categories (
@@ -132,6 +134,17 @@ if ($result->rowCount() === 0) {
 $result = $db->query("SHOW COLUMNS FROM `transactions` LIKE 'ofx_type'");
 if ($result->rowCount() === 0) {
     $db->exec("ALTER TABLE `transactions` ADD COLUMN `ofx_type` VARCHAR(50) DEFAULT NULL");
+}
+
+// Ensure ledger balance columns exist in accounts
+$result = $db->query("SHOW COLUMNS FROM `accounts` LIKE 'ledger_balance'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `accounts` ADD COLUMN `ledger_balance` DECIMAL(10,2) DEFAULT 0");
+}
+
+$result = $db->query("SHOW COLUMNS FROM `accounts` LIKE 'ledger_balance_date'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `accounts` ADD COLUMN `ledger_balance_date` DATE DEFAULT NULL");
 }
 
 echo "Database tables created.\n";

--- a/php_backend/public/account_balance.php
+++ b/php_backend/public/account_balance.php
@@ -1,0 +1,38 @@
+<?php
+// Returns running balance history for a single account starting from latest bank balance.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Account.php';
+require_once __DIR__ . '/../Database.php';
+
+header('Content-Type: application/json');
+
+try {
+    if (!isset($_GET['id'])) {
+        throw new Exception('Account id required');
+    }
+    $id = (int)$_GET['id'];
+    $db = Database::getConnection();
+    $stmt = $db->prepare('SELECT name, ledger_balance, ledger_balance_date FROM accounts WHERE id = :id');
+    $stmt->execute(['id' => $id]);
+    $account = $stmt->fetch(PDO::FETCH_ASSOC);
+    if (!$account) {
+        throw new Exception('Account not found');
+    }
+    $balance = (float)$account['ledger_balance'];
+    $history = [];
+    if ($account['ledger_balance_date']) {
+        $history[] = ['date' => $account['ledger_balance_date'], 'balance' => $balance];
+    }
+    $stmt = $db->prepare('SELECT date, amount FROM transactions WHERE account_id = :id ORDER BY date DESC, id DESC');
+    $stmt->execute(['id' => $id]);
+    while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+        $balance -= (float)$row['amount'];
+        $history[] = ['date' => $row['date'], 'balance' => $balance];
+    }
+    $history = array_reverse($history);
+    echo json_encode(['name' => $account['name'], 'history' => $history]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -45,6 +45,14 @@ try {
             $accountId = Account::create($accountName);
         }
 
+        // Update stored ledger balance if available
+        if (preg_match('/<LEDGERBAL>.*?<BALAMT>([^<]+).*?<DTASOF>([^<]+)/is', $ofxData, $balMatch)) {
+            $bal = (float)trim($balMatch[1]);
+            $balDateStr = substr(trim($balMatch[2]), 0, 8);
+            $balDate = date('Y-m-d', strtotime($balDateStr));
+            Account::updateLedgerBalance($accountId, $bal, $balDate);
+        }
+
         preg_match_all('/<STMTTRN>(.*?)<\/STMTTRN>/is', $ofxData, $matches);
         $inserted = 0;
         foreach ($matches[1] as $block) {


### PR DESCRIPTION
## Summary
- Store and update bank-reported ledger balances when importing OFX files
- Serve account summaries using stored bank balances
- Add account balance history API and frontend page showing running balance over time

## Testing
- `php -l php_backend/create_tables.php`
- `php -l php_backend/models/Account.php`
- `php -l php_backend/public/upload_ofx.php`
- `php -l php_backend/public/account_balance.php`


------
https://chatgpt.com/codex/tasks/task_e_689f01425cd0832ea68920af3e667543