### PR TITLE
Add keyboard navigation hints across site

### DIFF
--- a/frontend/js/keyboard_hints.js
+++ b/frontend/js/keyboard_hints.js
@@ -1,0 +1,8 @@
+// Displays a brief keyboard navigation tip on each page.
+document.addEventListener('DOMContentLoaded', () => {
+  const hint = document.createElement('div');
+  hint.textContent = 'Tip: Use Tab to move around, Shift+Tab to move back, Enter to activate and ? for help.';
+  hint.className = 'fixed bottom-4 left-4 bg-indigo-600 text-white text-sm px-3 py-2 rounded shadow';
+  document.body.appendChild(hint);
+  setTimeout(() => hint.remove(), 8000);
+});

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -156,4 +156,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const helpScript = document.createElement('script');
   helpScript.src = 'js/page_help.js';
   document.body.appendChild(helpScript);
+
+  const hintScript = document.createElement('script');
+  hintScript.src = 'js/keyboard_hints.js';
+  document.body.appendChild(hintScript);
 });

--- a/index.php
+++ b/index.php
@@ -63,6 +63,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </form>
     </div>
     <script src="frontend/js/input_help.js"></script>
+    <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
 </body>
 </html>

--- a/users.php
+++ b/users.php
@@ -82,6 +82,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </form>
     </div>
     <script src="frontend/js/input_help.js"></script>
+    <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce keyboard navigation hints module to display short tip
- inject hints script across frontend via menu.js and include on login and user pages

## Testing
- `php -l index.php`
- `php -l users.php`
- `node --check frontend/js/keyboard_hints.js`
- `node --check frontend/js/menu.js`


------
https://chatgpt.com/codex/tasks/task_e_689f0793c894832e9ff94ebbf99e0e73