### PR TITLE
Add OFX export option alongside JSON backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ and the current date (for example, `example.com-2024-05-15.json`). To restore a
 backup, choose the JSON file on the same page and click **Restore**; any
 included sections are imported.
 
+The same page also lets you export all transactions to a single OFX file for
+use in other financial tools.
+
 ## Frontend
 
 

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -27,7 +27,9 @@
                     <label class="block"><input type="checkbox" name="parts" value="groups" class="mr-2">Groups</label>
                     <label class="block"><input type="checkbox" name="parts" value="budgets" class="mr-2">Budgets</label>
                 </div>
-                <button id="download-backup" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-download mr-2"></i>Download</button>
+                <button id="download-backup" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-download mr-2"></i>Download JSON</button>
+                <p class="mt-4">Export all transactions to a single OFX file.</p>
+                <button id="download-ofx" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-file-export mr-2"></i>Download OFX</button>
             </section>
             <section class="bg-white p-6 rounded shadow space-y-4">
                 <h2 class="text-xl font-semibold">Restore Backup</h2>

--- a/frontend/js/backup.js
+++ b/frontend/js/backup.js
@@ -2,6 +2,7 @@
 // Set up handlers for downloading and restoring backups
 function initBackup() {
     const dlBtn = document.getElementById('download-backup');
+    const ofxBtn = document.getElementById('download-ofx');
     const form = document.getElementById('restore-form');
     if (dlBtn) {
         dlBtn.addEventListener('click', () => {
@@ -28,6 +29,35 @@ function initBackup() {
                     URL.revokeObjectURL(url);
                     if (typeof showMessage !== 'undefined') {
                         showMessage('Backup downloaded');
+                    }
+                })
+                .catch(() => showMessage && showMessage('Download failed', 'error'));
+        });
+    }
+
+    if (ofxBtn) {
+        ofxBtn.addEventListener('click', () => {
+            fetch('../php_backend/public/export_ofx.php')
+                .then(resp => {
+                    const disposition = resp.headers.get('Content-Disposition') || '';
+                    let filename = `${window.location.hostname}-${new Date().toISOString().slice(0, 10)}.ofx`;
+                    const match = disposition.match(/filename="?([^";]+)"?/i);
+                    if (match) {
+                        filename = match[1];
+                    }
+                    return resp.blob().then(blob => ({ blob, filename }));
+                })
+                .then(({ blob, filename }) => {
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = filename;
+                    document.body.appendChild(a);
+                    a.click();
+                    document.body.removeChild(a);
+                    URL.revokeObjectURL(url);
+                    if (typeof showMessage !== 'undefined') {
+                        showMessage('OFX exported');
                     }
                 })
                 .catch(() => showMessage && showMessage('Download failed', 'error'));

--- a/php_backend/public/export_ofx.php
+++ b/php_backend/public/export_ofx.php
@@ -1,0 +1,60 @@
+<?php
+// Exports all transactions as a single OFX file
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../Database.php';
+
+header('Content-Type: application/x-ofx');
+$host = $_SERVER['HTTP_HOST'] ?? 'backup';
+$host = preg_replace('/[^A-Za-z0-9_-]/', '_', $host);
+$filename = $host . '-' . date('Y-m-d') . '.ofx';
+header('Content-Disposition: attachment; filename="' . $filename . '"');
+
+try {
+    $db = Database::getConnection();
+    $stmt = $db->query('SELECT id, date, amount, description, memo, ofx_id FROM transactions ORDER BY date');
+    $txns = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo "OFXHEADER:100\n";
+    echo "DATA:OFXSGML\n";
+    echo "VERSION:102\n";
+    echo "SECURITY:NONE\n";
+    echo "ENCODING:USASCII\n";
+    echo "CHARSET:1252\n";
+    echo "COMPRESSION:NONE\n";
+    echo "OLDFILEUID:NONE\n";
+    echo "NEWFILEUID:NONE\n\n";
+
+    echo "<OFX>\n";
+    echo "  <BANKMSGSRSV1>\n";
+    echo "    <STMTTRNRS>\n";
+    echo "      <TRNUID>1</TRNUID>\n";
+    echo "      <STATUS><CODE>0</CODE><SEVERITY>INFO</SEVERITY></STATUS>\n";
+    echo "      <STMTRS>\n";
+    echo "        <CURDEF>GBP</CURDEF>\n";
+    echo "        <BANKTRANLIST>\n";
+
+    foreach ($txns as $tx) {
+        $date = date('Ymd', strtotime($tx['date']));
+        $amount = $tx['amount'];
+        $id = $tx['ofx_id'] ?: $tx['id'];
+        $name = htmlspecialchars($tx['description'] ?? '');
+        $memo = htmlspecialchars($tx['memo'] ?? '');
+        echo "          <STMTTRN>\n";
+        echo "            <TRNTYPE>OTHER</TRNTYPE>\n";
+        echo "            <DTPOSTED>{$date}</DTPOSTED>\n";
+        echo "            <TRNAMT>{$amount}</TRNAMT>\n";
+        echo "            <FITID>{$id}</FITID>\n";
+        echo "            <NAME>{$name}</NAME>\n";
+        echo "            <MEMO>{$memo}</MEMO>\n";
+        echo "          </STMTTRN>\n";
+    }
+
+    echo "        </BANKTRANLIST>\n";
+    echo "      </STMTRS>\n";
+    echo "    </STMTTRNRS>\n";
+    echo "  </BANKMSGSRSV1>\n";
+    echo "</OFX>\n";
+} catch (Exception $e) {
+    http_response_code(500);
+    echo $e->getMessage();
+}


### PR DESCRIPTION
## Summary
- Support exporting all transactions to a single OFX file
- Add OFX download button to backup page
- Document and wire up OFX export in frontend

## Testing
- `php php_backend/public/backup.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `php php_backend/public/export_ofx.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `php php_backend/public/restore.php` *(fails: No backup file uploaded)*

------
https://chatgpt.com/codex/tasks/task_e_689f0a38909c832ebbbc8b7e0252506d