### PR TITLE
Make descriptions on Missing Tags clickable

### DIFF
--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -38,7 +38,15 @@
                 layout: 'fitDataStretch',
                 initialSort: [{column:'count', dir:'desc'}],
                 columns: [
-                    { title: 'Description', field: 'description' },
+                    {
+                        title: 'Description',
+                        field: 'description',
+                        formatter: function(cell){
+                            const value = cell.getValue();
+                            const url = `search.html?value=${encodeURIComponent(value)}`;
+                            return `<a href="${url}" class="text-indigo-600 underline">${value}</a>`;
+                        }
+                    },
                     { title: 'Memo', field: 'memo' },
                     { title: 'Count', field: 'count', hozAlign: 'right', sorter: 'number' },
                     { title: 'Amount', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },


### PR DESCRIPTION
## Summary
- Link descriptions in the Missing Tags table to the search page to show matching transactions

## Testing
- `node --check /tmp/tmp_script.js`
- `npx -y htmlhint frontend/missing_tags.html` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_689f11baa9dc832ea42e66d472ff5aef