### PR TITLE
Improve logging and add log pruning

### DIFF
--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -19,6 +19,13 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Application Logs</h1>
             <p class="mb-4">Review recent log entries to monitor system activity. Filtering by time or keyword helps you trace what happened during a specific event.</p>
+            <div class="mb-4 flex items-center space-x-2">
+                <label class="text-sm">Days to keep/show:
+                    <input type="number" id="log-days" value="30" class="border p-1 w-20 rounded ml-1" data-help="Number of days of log entries to display and retain when pruning">
+                </label>
+                <button id="refresh-logs" class="bg-indigo-600 text-white px-3 py-1 rounded">Refresh</button>
+                <button id="prune-logs" class="bg-red-500 text-white px-3 py-1 rounded">Prune</button>
+            </div>
             <div id="logs-grid" class="mt-4"></div>
         </main>
     </div>
@@ -27,20 +34,35 @@
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
-    fetch('../php_backend/public/logs.php')
-        .then(resp => resp.json())
-        .then(data => {
-            tailwindTabulator('#logs-grid', {
-                data: data,
-                layout: 'fitDataStretch',
-                columns: [
-                    { title: 'Time', field: 'created_at' },
-                    { title: 'Level', field: 'level' },
-                    { title: 'Message', field: 'message' }
-                ]
+    const gridEl = '#logs-grid';
+
+    function loadLogs() {
+        const days = document.getElementById('log-days').value;
+        fetch(`../php_backend/public/logs.php?days=${days}`)
+            .then(resp => resp.json())
+            .then(data => {
+                tailwindTabulator(gridEl, {
+                    data: data,
+                    layout: 'fitDataStretch',
+                    columns: [
+                        { title: 'Time', field: 'created_at' },
+                        { title: 'Level', field: 'level' },
+                        { title: 'Message', field: 'message' }
+                    ]
+                });
             });
-        });
+    }
+
+    document.getElementById('refresh-logs').addEventListener('click', loadLogs);
+    document.getElementById('prune-logs').addEventListener('click', () => {
+        const days = document.getElementById('log-days').value;
+        fetch(`../php_backend/public/logs.php?prune_days=${days}`)
+            .then(() => loadLogs());
+    });
+
+    loadLogs();
     </script>
+    <script src="js/input_help.js"></script>
     <script src="js/overlay.js"></script>
 </body>
 </html>

--- a/index.php
+++ b/index.php
@@ -15,6 +15,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if ($userId !== null) {
         $_SESSION['user_id'] = $userId;
+        Log::write("User '$username' logged in");
         header('Location: frontend/index.html');
         exit;
     } else {

--- a/logout.php
+++ b/logout.php
@@ -3,6 +3,12 @@
 ini_set('session.cookie_secure', '1');
 session_start();
 require_once __DIR__ . '/php_backend/nocache.php';
+require_once __DIR__ . '/php_backend/models/Log.php';
+
+if (isset($_SESSION['user_id'])) {
+    Log::write('User ' . $_SESSION['user_id'] . ' logged out');
+}
+
 session_destroy();
 header('Location: index.php');
 exit;

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -4,6 +4,7 @@
 // information is always included so a full backup can be restored.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
+require_once __DIR__ . '/../models/Log.php';
 
 // Send a gzipped JSON file
 header('Content-Type: application/gzip');
@@ -51,7 +52,9 @@ try {
     // Compress the JSON payload
     $json = json_encode($data);
     echo gzencode($json);
+    Log::write('Backup generated with parts: ' . implode(',', $parts));
 } catch (Exception $e) {
+    Log::write('Backup error: ' . $e->getMessage(), 'ERROR');
     http_response_code(500);
     echo gzencode(json_encode(['error' => $e->getMessage()]));
 }

--- a/php_backend/public/logs.php
+++ b/php_backend/public/logs.php
@@ -6,8 +6,16 @@ require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');
 
 $limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 100;
+$days = isset($_GET['days']) ? (int)$_GET['days'] : null;
+
+if (isset($_GET['prune_days'])) {
+    $prune = (int)$_GET['prune_days'];
+    Log::prune($prune);
+    Log::write('Pruned logs older than ' . $prune . ' days');
+}
+
 try {
-    echo json_encode(Log::all($limit));
+    echo json_encode(Log::all($limit, $days));
 } catch (Exception $e) {
     http_response_code(500);
     echo json_encode(['error' => $e->getMessage()]);

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -4,6 +4,7 @@
 
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
+require_once __DIR__ . '/../models/Log.php';
 
 try {
     if (!isset($_FILES['backup_file']) || $_FILES['backup_file']['error'] !== UPLOAD_ERR_OK) {
@@ -116,9 +117,10 @@ try {
             $stmtCT->execute(['category_id' => $row['category_id'], 'tag_id' => $row['tag_id']]);
         }
     }
-
+    Log::write('Restore completed for parts: ' . implode(',', array_keys($data)));
     echo 'Restore complete.';
 } catch (Exception $e) {
+    Log::write('Restore error: ' . $e->getMessage(), 'ERROR');
     http_response_code(500);
     echo 'Error: ' . $e->getMessage();
 }


### PR DESCRIPTION
## Summary
- Log successful logins, user logouts, backup creation and restore operations
- Add Log::prune for deleting old entries and extend logs API and UI to filter/prune by days

## Testing
- `php -l index.php`
- `php -l logout.php`
- `php -l php_backend/public/backup.php`
- `php -l php_backend/public/restore.php`
- `php -l php_backend/models/Log.php`
- `php -l php_backend/public/logs.php`
- `php php_backend/public/logs.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f37bd3c34832e8b81e54a0369da5a