### PR TITLE
Harden OFX importer against malformed OFX files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ curl -F "ofx_files[]=@first.ofx" -F "ofx_files[]=@second.ofx" https://localhost/
 You can try this using the included sample file `sample_data/test.ofx` which
 contains two transactions for a checking account.
 
+The importer normalises line endings, validates required tags and security
+settings, converts character encoding to UTF-8, truncates overly long field
+values and rejects transactions with invalid dates. These steps help prevent
+issues when working with OFX files from different financial institutions.
+
 ## Running a Local Server
 
 To use the upload page the frontend must be served over HTTPS so the PHP parser

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -35,6 +35,35 @@ try {
             continue;
         }
 
+        // Normalise line endings and strip unprintable characters that may
+        // cause issues for some financial software when parsing carriage
+        // returns.
+        $ofxData = str_replace(["\r\n", "\r"], "\n", $ofxData);
+        $ofxData = preg_replace('/[\x00-\x09\x0B\x0C\x0E-\x1F\x7F]/', '', $ofxData);
+
+        // Convert to UTF-8 if the file uses a different character set.
+        $encoding = mb_detect_encoding($ofxData, 'UTF-8, ISO-8859-1, Windows-1252', true);
+        if ($encoding && $encoding !== 'UTF-8') {
+            $ofxData = mb_convert_encoding($ofxData, 'UTF-8', $encoding);
+        }
+
+        // Validate basic OFX structure and supported security settings.
+        if (stripos($ofxData, '<OFX>') === false || stripos($ofxData, '</OFX>') === false) {
+            $msg = 'Missing OFX root tags in ' . $files['name'][$i] . '.';
+            $messages[] = $msg;
+            Log::write($msg, 'ERROR');
+            continue;
+        }
+        if (preg_match('/SECURITY:([^\n]+)/i', $ofxData, $secMatch)) {
+            $security = strtoupper(trim($secMatch[1]));
+            if ($security !== 'NONE') {
+                $msg = "Unsupported SECURITY setting '$security' in " . $files['name'][$i] . '.';
+                $messages[] = $msg;
+                Log::write($msg, 'ERROR');
+                continue;
+            }
+        }
+
         // Extract account identifiers
         $sortCode = null;
         $accountNumber = null;
@@ -90,37 +119,68 @@ try {
         }
 
         preg_match_all('/<STMTTRN>(.*?)<\/STMTTRN>/is', $ofxData, $matches);
+        if (empty($matches[1])) {
+            $msg = 'No transactions found in ' . $files['name'][$i] . '.';
+            $messages[] = $msg;
+            Log::write($msg, 'ERROR');
+            continue;
+        }
+
         $inserted = 0;
         foreach ($matches[1] as $block) {
-            if (preg_match('/<DTPOSTED>([^\r\n<]+)/i', $block, $m)) {
+            if (preg_match('/<DTPOSTED>([^<]+)/i', $block, $m)) {
                 $dateStr = substr(trim($m[1]), 0, 8); // YYYYMMDD
-                $date = date('Y-m-d', strtotime($dateStr));
+                $dt = DateTime::createFromFormat('Ymd', $dateStr);
+                if (!$dt || $dt->format('Ymd') !== $dateStr) {
+                    Log::write('Invalid date ' . $dateStr . ' in ' . $files['name'][$i], 'ERROR');
+                    continue; // skip invalid entry
+                }
+                $date = $dt->format('Y-m-d');
             } else {
+                Log::write('Missing DTPOSTED in transaction block', 'ERROR');
                 continue; // skip invalid entry
             }
-            if (!preg_match('/<TRNAMT>([^\r\n<]+)/i', $block, $am)) {
+            if (!preg_match('/<TRNAMT>([^<]+)/i', $block, $am)) {
+                Log::write('Missing TRNAMT in transaction block', 'ERROR');
                 continue;
             }
             $amount = (float)trim($am[1]);
             $desc = '';
             $memo = '';
             $type = null;
-            if (preg_match('/<NAME>([^\r\n<]+)/i', $block, $dm)) {
+            if (preg_match('/<NAME>([^<]+)/i', $block, $dm)) {
                 $desc = trim($dm[1]);
             }
-            if (preg_match('/<MEMO>([^\r\n<]+)/i', $block, $mm)) {
+            if (preg_match('/<MEMO>([^<]+)/i', $block, $mm)) {
                 $memo = trim($mm[1]);
                 if ($desc === '') {
                     $desc = $memo;
                 }
             }
-            if (preg_match('/<TRNTYPE>([^\r\n<]+)/i', $block, $tm)) {
+            if (preg_match('/<TRNTYPE>([^<]+)/i', $block, $tm)) {
                 $type = strtoupper(trim($tm[1]));
             }
+            // Optional reference and cheque numbers with character limits
+            if (preg_match('/<REFNUM>([^<]+)/i', $block, $rm)) {
+                $ref = substr(trim($rm[1]), 0, 32);
+                $memo .= ($memo === '' ? '' : ' ') . 'Ref:' . $ref;
+            }
+            if (preg_match('/<CHECKNUM>([^<]+)/i', $block, $cm)) {
+                $chk = substr(trim($cm[1]), 0, 20);
+                $memo .= ($memo === '' ? '' : ' ') . 'Chk:' . $chk;
+            }
+
             $ofxId = null;
-            if (preg_match('/<FITID>([^\r\n<]+)/i', $block, $om)) {
+            if (preg_match('/<FITID>([^<]+)/i', $block, $om)) {
                 $ofxId = trim($om[1]);
             }
+
+            // Enforce database field limits to avoid import failures
+            $desc = mb_substr($desc, 0, 255);
+            $memo = $memo === '' ? null : mb_substr($memo, 0, 255);
+            $ofxId = $ofxId === null ? null : mb_substr($ofxId, 0, 255);
+            $type = $type === null ? null : mb_substr($type, 0, 50);
+
             Transaction::create($accountId, $date, $amount, $desc, $memo, null, null, null, $ofxId, $type);
             $inserted++;
         }


### PR DESCRIPTION
## Summary
- sanitize incoming OFX data by normalising line endings, stripping control chars and converting to UTF-8
- validate root tags and security setting before import
- enforce transaction field limits, verify dates and capture optional reference/check numbers

## Testing
- `php -l php_backend/public/upload_ofx.php`


------
https://chatgpt.com/codex/tasks/task_e_689f3861001c832e94ec17eac14b259a