### PR TITLE
Include selected sections in backup filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Back up and restore your data through the web interface. From the navigation
 menu open **Backup & Restore** under *Administration*. User accounts and
 account information are always included in backups. You can additionally choose
 which other parts of the database to download—transactions, categories, tags,
-
 groups, or budgets. The downloaded file contains gzipped JSON and is named after
-your site's hostname and the current date (for example,
-`example.com-2024-05-15.json.gz`). To restore a backup, choose the compressed
-file on the same page and click **Restore**; any included sections are imported.
+your site's hostname, the current date, and the selected sections (for example,
+`example.com-2024-05-15-transactions-categories.json.gz`). To restore a backup,
+choose the compressed file on the same page and click **Restore**; any included
+sections are imported.
 
 The same page also lets you export all transactions to a single OFX file for
 use in other financial tools.

--- a/frontend/js/backup.js
+++ b/frontend/js/backup.js
@@ -7,11 +7,13 @@ function initBackup() {
     if (dlBtn) {
         dlBtn.addEventListener('click', () => {
             const parts = Array.from(document.querySelectorAll('input[name="parts"]:checked')).map(cb => cb.value);
+            const allParts = ['categories','tags','groups','transactions','budgets'];
+            const selected = parts.length ? parts : allParts;
             const qs = parts.length ? `?parts=${parts.join(',')}` : '';
             fetch(`../php_backend/public/backup.php${qs}`)
                 .then(resp => {
                     const disposition = resp.headers.get('Content-Disposition') || '';
-                    let filename = `${window.location.hostname}-${new Date().toISOString().slice(0, 10)}.json.gz`;
+                    let filename = `${window.location.hostname}-${new Date().toISOString().slice(0, 10)}-${selected.join('-')}.json.gz`;
                     const match = disposition.match(/filename="?([^";]+)"?/i);
                     if (match) {
                         filename = match[1];

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -6,11 +6,18 @@ require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Log.php';
 
-// Send a gzipped JSON file
+// Determine which parts are being backed up so the filename can reflect them
+$allParts = ['categories','tags','groups','transactions','budgets'];
+$parts = isset($_GET['parts']) && $_GET['parts'] !== ''
+    ? array_intersect($allParts, explode(',', $_GET['parts']))
+    : $allParts;
+$partSlug = preg_replace('/[^A-Za-z0-9_-]/', '_', implode('-', $parts));
+
+// Send a gzipped JSON file with a descriptive filename
 header('Content-Type: application/gzip');
 $host = $_SERVER['HTTP_HOST'] ?? 'backup';
 $host = preg_replace('/[^A-Za-z0-9_-]/', '_', $host);
-$filename = $host . '-' . date('Y-m-d') . '.json.gz';
+$filename = $host . '-' . date('Y-m-d') . '-' . $partSlug . '.json.gz';
 header('Content-Disposition: attachment; filename="' . $filename . '"');
 
 try {
@@ -20,11 +27,6 @@ try {
         $stmt = $db->query($sql);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     };
-
-    $allParts = ['categories','tags','groups','transactions','budgets'];
-    $parts = isset($_GET['parts']) && $_GET['parts'] !== ''
-        ? array_intersect($allParts, explode(',', $_GET['parts']))
-        : $allParts;
 
     $data = [];
     // Always include users and account details


### PR DESCRIPTION
## Summary
- include selected database sections in backup filenames for clarity
- update backup downloader to fall back to the same descriptive naming
- document new naming scheme in README

## Testing
- `php -l php_backend/public/backup.php`
- `node --check frontend/js/backup.js`


------
https://chatgpt.com/codex/tasks/task_e_689f3a3c4e84832e8f043a579aad2324