### PR TITLE
Harden OFX importer against malformed OFX files

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ curl -F "ofx_files[]=@first.ofx" -F "ofx_files[]=@second.ofx" https://localhost/
 You can try this using the included sample file `sample_data/test.ofx` which
 contains two transactions for a checking account.
 
+The importer normalises line endings, validates required tags and security
+settings, converts character encoding to UTF-8 (falling back to iconv when the
+mbstring extension is unavailable), truncates overly long field values and
+rejects transactions with invalid dates. These steps help prevent issues when
+working with OFX files from different financial institutions.
+
 ## Running a Local Server
 
 To use the upload page the frontend must be served over HTTPS so the PHP parser


### PR DESCRIPTION
## Summary
- sanitize incoming OFX data by normalising line endings, stripping control chars and converting to UTF-8
- validate root tags and security setting before import
- enforce transaction field limits, verify dates and capture optional reference/check numbers
- gracefully handle missing mbstring extension by falling back to iconv and substr

## Testing
- `php -l php_backend/public/upload_ofx.php`


------
https://chatgpt.com/codex/tasks/task_e_689f3861001c832e94ec17eac14b259a