### PR TITLE
Generate synthetic OFX transaction IDs

### DIFF
--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -86,6 +86,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     transfer_id INT DEFAULT NULL,
     ofx_id VARCHAR(255) UNIQUE,
     ofx_type VARCHAR(50) DEFAULT NULL,
+    bank_ofx_id VARCHAR(255) DEFAULT NULL,
     FOREIGN KEY (account_id) REFERENCES accounts(id),
     FOREIGN KEY (category_id) REFERENCES categories(id),
     FOREIGN KEY (tag_id) REFERENCES tags(id),
@@ -136,6 +137,12 @@ if ($result->rowCount() === 0) {
 $result = $db->query("SHOW COLUMNS FROM `transactions` LIKE 'ofx_type'");
 if ($result->rowCount() === 0) {
     $db->exec("ALTER TABLE `transactions` ADD COLUMN `ofx_type` VARCHAR(50) DEFAULT NULL");
+}
+
+// Ensure bank_ofx_id column exists in transactions
+$result = $db->query("SHOW COLUMNS FROM `transactions` LIKE 'bank_ofx_id'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `transactions` ADD COLUMN `bank_ofx_id` VARCHAR(255) DEFAULT NULL");
 }
 
 // Ensure ledger balance columns exist in accounts

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -7,7 +7,7 @@ class Transaction {
     /**
      * Insert a new transaction and attempt to auto-tag and link transfers.
      */
-    public static function create(int $account, string $date, float $amount, string $description, ?string $memo = null, ?int $category = null, ?int $tag = null, ?int $group = null, ?string $ofx_id = null, ?string $ofx_type = null): int {
+    public static function create(int $account, string $date, float $amount, string $description, ?string $memo = null, ?int $category = null, ?int $tag = null, ?int $group = null, ?string $ofx_id = null, ?string $ofx_type = null, ?string $bank_ofx_id = null): int {
         if ($tag === null) {
             $tag = Tag::findMatch($description);
         }
@@ -23,7 +23,7 @@ class Transaction {
             }
         }
 
-        $stmt = $db->prepare('INSERT INTO transactions (`account_id`, `date`, `amount`, `description`, `memo`, `category_id`, `tag_id`, `group_id`, `ofx_id`, `ofx_type`) VALUES (:account, :date, :amount, :description, :memo, :category, :tag, :group, :ofx_id, :ofx_type)');
+        $stmt = $db->prepare('INSERT INTO transactions (`account_id`, `date`, `amount`, `description`, `memo`, `category_id`, `tag_id`, `group_id`, `ofx_id`, `ofx_type`, `bank_ofx_id`) VALUES (:account, :date, :amount, :description, :memo, :category, :tag, :group, :ofx_id, :ofx_type, :bank_ofx_id)');
         $stmt->execute([
             'account' => $account,
             'date' => $date,
@@ -34,7 +34,8 @@ class Transaction {
             'tag' => $tag,
             'group' => $group,
             'ofx_id' => $ofx_id,
-            'ofx_type' => $ofx_type
+            'ofx_type' => $ofx_type,
+            'bank_ofx_id' => $bank_ofx_id
         ]);
         $id = (int)$db->lastInsertId();
 

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -45,7 +45,7 @@ try {
         $data['groups'] = $getAll('SELECT id, name, description FROM transaction_groups ORDER BY id');
     }
     if (in_array('transactions', $parts)) {
-        $data['transactions'] = $getAll('SELECT id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id FROM transactions ORDER BY id');
+        $data['transactions'] = $getAll('SELECT id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id, bank_ofx_id FROM transactions ORDER BY id');
     }
     if (in_array('budgets', $parts)) {
         $data['budgets'] = $getAll('SELECT category_id, month, year, amount FROM budgets ORDER BY category_id, year, month');

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -104,7 +104,7 @@ try {
     }
 
     if (isset($data['transactions'])) {
-        $stmtTx = $db->prepare('INSERT INTO transactions (id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id) VALUES (:id, :account_id, :date, :amount, :description, :memo, :category_id, :tag_id, :group_id, :transfer_id, :ofx_id)');
+        $stmtTx = $db->prepare('INSERT INTO transactions (id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id, bank_ofx_id) VALUES (:id, :account_id, :date, :amount, :description, :memo, :category_id, :tag_id, :group_id, :transfer_id, :ofx_id, :bank_ofx_id)');
         foreach ($data['transactions'] as $row) {
             $stmtTx->execute([
                 'id' => $row['id'],
@@ -117,7 +117,8 @@ try {
                 'tag_id' => $row['tag_id'],
                 'group_id' => $row['group_id'],
                 'transfer_id' => $row['transfer_id'],
-                'ofx_id' => $row['ofx_id']
+                'ofx_id' => $row['ofx_id'],
+                'bank_ofx_id' => $row['bank_ofx_id'] ?? null
             ]);
         }
     }

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -167,9 +167,9 @@ try {
                 $memo .= ($memo === '' ? '' : ' ') . 'Chk:' . $chk;
             }
 
-            $ofxId = null;
+            $bankId = null;
             if (preg_match('/<FITID>([^<]+)/i', $block, $om)) {
-                $ofxId = trim($om[1]);
+                $bankId = trim($om[1]);
             }
 
             // Enforce database field limits to avoid import failures
@@ -177,11 +177,14 @@ try {
             $substr = function_exists('mb_substr') ? 'mb_substr' : 'substr';
             $desc = $substr($desc, 0, 255);
             $memo = $memo === '' ? null : $substr($memo, 0, 255);
-            $ofxId = $ofxId === null ? null : $substr($ofxId, 0, 255);
+            $bankId = $bankId === null ? null : $substr($bankId, 0, 255);
             $type = $type === null ? null : $substr($type, 0, 50);
 
+            // Generate synthetic ID to replace unreliable bank FITIDs
+            $amountStr = number_format($amount, 2, '.', '');
+            $syntheticId = sha1($accountId . $date . $amountStr . $desc . ($memo ?? ''));
 
-            Transaction::create($accountId, $date, $amount, $desc, $memo, null, null, null, $ofxId, $type);
+            Transaction::create($accountId, $date, $amount, $desc, $memo, null, null, null, $syntheticId, $type, $bankId);
             $inserted++;
         }
 


### PR DESCRIPTION
## Summary
- Generate SHA1-based synthetic IDs for OFX imports and store original FITID separately
- Track bank-provided FITIDs with new `bank_ofx_id` column and include in backup/restore

## Testing
- `php -l php_backend/create_tables.php`
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/upload_ofx.php`
- `php -l php_backend/public/backup.php`
- `php -l php_backend/public/restore.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f456dcb64832ebdb448ac7be08937