### PR TITLE
Improve search results chart titles and time scales

### DIFF
--- a/frontend/search.html
+++ b/frontend/search.html
@@ -91,19 +91,21 @@
                         let buckets = {};
                         let categories = [];
                         let values = [];
-                        let chartTitle = '';
+                        let chartTitle = term ? `Spending for "${term}"` : 'Search Results Spending';
+                        if (amount) chartTitle += ` of £${parseFloat(amount).toFixed(2)}`;
+                        let chartSubtitle = '';
 
-                        if (diffDays <= 62) {
+                        if (diffDays > 1095) {
                             filtered.forEach(r => {
-                                const day = r.date;
+                                const year = r.date.substring(0, 4);
                                 const amt = -parseFloat(r.amount);
-                                if (amt > 0) buckets[day] = (buckets[day] || 0) + amt;
+                                if (amt > 0) buckets[year] = (buckets[year] || 0) + amt;
                             });
-                            const days = Object.keys(buckets).sort();
-                            categories = days.map(d => new Date(d).toLocaleDateString());
-                            values = days.map(d => parseFloat(buckets[d].toFixed(2)));
-                            chartTitle = 'Daily Spend';
-                        } else {
+                            const years = Object.keys(buckets).sort();
+                            categories = years;
+                            values = years.map(y => parseFloat(buckets[y].toFixed(2)));
+                            chartSubtitle = 'Yearly totals';
+                        } else if (diffDays > 62) {
                             filtered.forEach(r => {
                                 const month = r.date.substring(0, 7);
                                 const amt = -parseFloat(r.amount);
@@ -115,7 +117,17 @@
                                 return new Date(y, mth - 1).toLocaleString('default', { month: 'short', year: 'numeric' });
                             });
                             values = months.map(m => parseFloat(buckets[m].toFixed(2)));
-                            chartTitle = 'Monthly Spend';
+                            chartSubtitle = 'Monthly totals';
+                        } else {
+                            filtered.forEach(r => {
+                                const day = r.date;
+                                const amt = -parseFloat(r.amount);
+                                if (amt > 0) buckets[day] = (buckets[day] || 0) + amt;
+                            });
+                            const days = Object.keys(buckets).sort();
+                            categories = days.map(d => new Date(d).toLocaleDateString());
+                            values = days.map(d => parseFloat(buckets[d].toFixed(2)));
+                            chartSubtitle = 'Daily totals';
                         }
 
 
@@ -135,6 +147,7 @@
 
                             },
                             title: { text: chartTitle },
+                            subtitle: { text: chartSubtitle },
                             xAxis: { categories: categories },
                             yAxis: { title: { text: 'Amount (£)' } },
                             plotOptions: { column: { depth: 25 } },


### PR DESCRIPTION
## Summary
- make search results chart title reflect current query
- group data by year/month/day depending on range and show timescale subtitle

## Testing
- `php -l php_backend/public/search_transactions.php`


------
https://chatgpt.com/codex/tasks/task_e_689f5396bdbc832e95b29113ed952921