### PR TITLE
Use gradient palette for single-series graphs

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -37,6 +37,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
     // Format balance cells with currency and positive/negative colouring
     function balanceFormatter(cell){
         const value = cell.getValue();
@@ -63,11 +64,12 @@
                 const dates = data.history.map(h => h.date);
                 const balances = data.history.map(h => parseFloat(h.balance));
                 Highcharts.chart('balance-chart', {
+                    colors: gradientColors,
                     title: { text: 'Balance Over Time' },
                     xAxis: { categories: dates },
                     yAxis: { title: { text: 'Balance (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
                     tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
-                    series: [{ name: 'Balance', data: balances }]
+                    series: [{ name: 'Balance', data: balances, colorByPoint: true }]
                 });
             });
 

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -31,6 +31,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
     // Format balance cells with currency and positive/negative colouring
     function balanceFormatter(cell){
         const value = cell.getValue();
@@ -60,12 +61,13 @@
             });
 
             Highcharts.chart('accounts-chart', {
+                colors: gradientColors,
                 chart: { type: 'column' },
                 title: { text: 'Account Balances' },
                 xAxis: { categories: data.map(a => a.name) },
                 yAxis: { title: { text: 'Balance (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
                 tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
-                series: [{ name: 'Balance', data: data.map(a => parseFloat(a.balance)) }]
+                series: [{ name: 'Balance', data: data.map(a => parseFloat(a.balance)), colorByPoint: true }]
             });
         });
     </script>

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -44,6 +44,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
     // Format totals with currency and colour
     function totalFormatter(cell){
         const value = cell.getValue();
@@ -96,12 +97,13 @@
     // Draw a column chart summarising totals
     function buildChart(id, title, data){
         Highcharts.chart(id, {
+            colors: gradientColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
             tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
-            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)) }]
+            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
 

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -32,6 +32,7 @@
     <script>
 
     // Retrieve data for the chosen year and draw charts with 3D bars where applicable
+    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
 
     function loadYear(year){
         Promise.all([
@@ -110,6 +111,7 @@
             const tagNames = yearly.tags.map(t => t.name);
             const tagTotals = yearly.tags.map(t => parseFloat(t.total));
             Highcharts.chart('tag-chart', {
+                colors: gradientColors,
                 chart: {
                     type: 'bar',
 
@@ -124,10 +126,11 @@
                 },
                 tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
                 plotOptions: { bar: { depth: 40 } },
-                series: [{ name: 'Total', data: tagTotals }]
+                series: [{ name: 'Total', data: tagTotals, colorByPoint: true }]
             });
 
             Highcharts.chart('scatter-chart', {
+                colors: gradientColors,
                 chart: {
 
                     type: 'scatter'
@@ -141,7 +144,7 @@
                 },
                 tooltip: { pointFormatter: function(){ return this.category + ': £' + Highcharts.numberFormat(this.y, 2); } },
 
-                series: [{ name: 'Spending', data: totals.map((v, i) => [i, v]) }]
+                series: [{ name: 'Spending', data: totals.map((v, i) => [i, v]), colorByPoint: true }]
 
             });
         }).catch(err => console.error('Graph data load failed', err));

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -42,6 +42,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
     // Format totals with currency and highlight positive/negative values
     function totalFormatter(cell){
         const value = cell.getValue();
@@ -120,12 +121,13 @@
     // Create a column chart for the supplied dataset
     function buildChart(id, title, data){
         Highcharts.chart(id, {
+            colors: gradientColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value,2); } } },
             tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y,2); } },
-            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)) }]
+            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
 

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -66,6 +66,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
     // Format totals with currency and sign-based colouring
     function totalFormatter(cell){
         const value = cell.getValue();
@@ -118,12 +119,13 @@
     // Draw a column chart visualising totals
     function buildChart(id, title, data){
         Highcharts.chart(id, {
+            colors: gradientColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
             tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
-            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)) }]
+            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
 

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -45,6 +45,7 @@
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
+    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
 
     // Load filter options for categories, tags and groups
     async function loadOptions() {
@@ -134,11 +135,12 @@
                     const categories = data.map(tx => tx.date);
                     const amounts = data.map(tx => parseFloat(tx.amount));
                     Highcharts.chart('chart', {
+                        colors: gradientColors,
                         chart: { type: 'column' },
                         title: { text: 'Transaction Amounts' },
                         xAxis: { categories: categories, title: { text: 'Date' } },
                         yAxis: { title: { text: 'Amount' } },
-                        series: [{ name: 'Amount', data: amounts }]
+                        series: [{ name: 'Amount', data: amounts, colorByPoint: true }]
                     });
                 } else {
                     gridEl.innerHTML = 'No transactions found.';

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -36,6 +36,7 @@
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/highcharts-3d.js"></script>
     <script>
+    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
     // Format a numeric value as pounds and pence
     function formatCurrency(value) {
         return '£' + parseFloat(value).toFixed(2);
@@ -140,6 +141,7 @@
                         }));
 
                         Highcharts.chart('results-chart', {
+                            colors: gradientColors,
                             chart: {
                                 type: 'column',
 

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -48,6 +48,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
+    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
     // Format totals with currency and colour coding
     function totalFormatter(cell){
         const value = cell.getValue();
@@ -100,12 +101,13 @@
     // Draw a column chart for the provided data set
     function buildChart(id, title, data){
         Highcharts.chart(id, {
+            colors: gradientColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
             tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
-            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)) }]
+            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
 


### PR DESCRIPTION
## Summary
- Apply indigo–viridian–emerald–mint gradient to single-series Highcharts graphs
- Color individual points in dashboards, reports, search results, and account views

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_689f5687f97c832eb0eb0fafd46b3e3e