### PR TITLE
Improve backup/restore and upload logging

### DIFF
--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -31,7 +31,7 @@ try {
     $data = [];
     // Always include users and account details
     $data['users'] = $getAll('SELECT id, username, password FROM users ORDER BY id');
-    $data['accounts'] = $getAll('SELECT id, name, ledger_balance, ledger_balance_date FROM accounts ORDER BY id');
+    $data['accounts'] = $getAll('SELECT id, name, sort_code, account_number, ledger_balance, ledger_balance_date FROM accounts ORDER BY id');
     if (in_array('categories', $parts)) {
         $data['categories'] = $getAll('SELECT id, name, description FROM categories ORDER BY id');
     }

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -59,11 +59,13 @@ try {
     }
 
     if (isset($data['accounts'])) {
-        $stmtAcct = $db->prepare('INSERT INTO accounts (id, name, ledger_balance, ledger_balance_date) VALUES (:id, :name, :ledger_balance, :ledger_balance_date)');
+        $stmtAcct = $db->prepare('INSERT INTO accounts (id, name, sort_code, account_number, ledger_balance, ledger_balance_date) VALUES (:id, :name, :sort_code, :account_number, :ledger_balance, :ledger_balance_date)');
         foreach ($data['accounts'] as $row) {
             $stmtAcct->execute([
                 'id' => $row['id'],
                 'name' => $row['name'],
+                'sort_code' => $row['sort_code'] ?? null,
+                'account_number' => $row['account_number'] ?? null,
                 'ledger_balance' => $row['ledger_balance'],
                 'ledger_balance_date' => $row['ledger_balance_date'] ?? null
             ]);

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -20,8 +20,18 @@ try {
     $files = $_FILES['ofx_files'];
     $messages = [];
     for ($i = 0; $i < count($files['name']); $i++) {
-        if ($files['error'][$i] !== UPLOAD_ERR_OK) {
-            $msg = "No file uploaded for entry " . ($i + 1) . ".";
+        $error = $files['error'][$i];
+        if ($error !== UPLOAD_ERR_OK) {
+            $errMap = [
+                UPLOAD_ERR_INI_SIZE => 'The uploaded file exceeds the upload_max_filesize directive in php.ini.',
+                UPLOAD_ERR_FORM_SIZE => 'The uploaded file exceeds the MAX_FILE_SIZE directive specified in the HTML form.',
+                UPLOAD_ERR_PARTIAL => 'The uploaded file was only partially uploaded.',
+                UPLOAD_ERR_NO_FILE => 'No file was uploaded.',
+                UPLOAD_ERR_NO_TMP_DIR => 'Missing a temporary folder.',
+                UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk.',
+                UPLOAD_ERR_EXTENSION => 'A PHP extension stopped the file upload.'
+            ];
+            $msg = ($errMap[$error] ?? 'Unknown upload error') . ' File: ' . $files['name'][$i];
             $messages[] = $msg;
             Log::write($msg, 'ERROR');
             continue;


### PR DESCRIPTION
## Summary
- Include sort code and account number fields when backing up and restoring accounts
- Add detailed logging for failed OFX uploads

## Testing
- `php -l php_backend/public/backup.php`
- `php -l php_backend/public/restore.php`
- `php -l php_backend/public/upload_ofx.php`


------
https://chatgpt.com/codex/tasks/task_e_689f5d0939d4832ea0ce46c40b1dcee9