### PR TITLE
feat: show credit card flag and add clickable balances

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -41,6 +41,10 @@
         return '£' + parseFloat(value).toFixed(2);
     }
 
+    function creditCardFormatter(cell){
+        return cell.getValue() ? '<i class="fa-solid fa-credit-card text-indigo-600"></i>' : '';
+    }
+
     fetch('../php_backend/public/account_dashboard.php')
         .then(resp => resp.json())
         .then(data => {
@@ -54,6 +58,7 @@
                     { title: 'Name', field: 'name' },
                     { title: 'Sort Code', field: 'sort_code' },
                     { title: 'Account/Card Number', field: 'account_number' },
+                    { title: 'Credit Card', field: 'is_credit_card', hozAlign: 'center', formatter: creditCardFormatter, headerSort: false },
                     { title: 'Transactions', field: 'transactions', hozAlign: 'right' },
                     { title: 'Balance', field: 'balance', hozAlign: 'right', formatter: balanceFormatter },
                     { title: 'Last Transaction', field: 'last_transaction' }
@@ -64,10 +69,22 @@
                 colors: gradientColors,
                 chart: { type: 'column' },
                 title: { text: 'Account Balances' },
-                xAxis: { categories: data.map(a => a.name) },
+                xAxis: { type: 'category' },
                 yAxis: { title: { text: 'Balance (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
                 tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
-                series: [{ name: 'Balance', data: data.map(a => parseFloat(a.balance)), colorByPoint: true }]
+                series: [{
+                    name: 'Balance',
+                    data: data.map(a => ({ y: parseFloat(a.balance), name: a.name, id: a.id })),
+                    colorByPoint: true,
+                    cursor: 'pointer',
+                    point: {
+                        events: {
+                            click: function(){
+                                window.location = `account.html?id=${this.options.id}`;
+                            }
+                        }
+                    }
+                }]
             });
         });
     </script>

--- a/php_backend/models/Account.php
+++ b/php_backend/models/Account.php
@@ -20,7 +20,8 @@ class Account {
         $db = Database::getConnection();
         $sql = 'SELECT a.`id`, a.`name`, a.`sort_code`, a.`account_number`, COUNT(t.`id`) AS `transactions`, '
              . 'COALESCE(a.`ledger_balance`, 0) AS `balance`, '
-             . 'MAX(t.`date`) AS `last_transaction` '
+             . 'MAX(t.`date`) AS `last_transaction`, '
+             . 'CASE WHEN a.`sort_code` IS NULL OR a.`sort_code` = "" THEN 1 ELSE 0 END AS `is_credit_card` '
              . 'FROM `accounts` a '
              . 'LEFT JOIN `transactions` t ON t.`account_id` = a.`id` '
              . 'GROUP BY a.`id`, a.`name`, a.`sort_code`, a.`account_number`, a.`ledger_balance` '


### PR DESCRIPTION
## Summary
- show credit card flag in account dashboard using backend flag and Font Awesome icon
- allow users to click account balance columns for quick navigation

## Testing
- `php -l php_backend/models/Account.php`
- `php -l php_backend/public/account_dashboard.php`


------
https://chatgpt.com/codex/tasks/task_e_689f5fa524d0832e8285b1c04d41d4ec