### PR TITLE
Improve backup/restore and upload logging

### DIFF
--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -31,7 +31,7 @@ try {
     $data = [];
     // Always include users and account details
     $data['users'] = $getAll('SELECT id, username, password FROM users ORDER BY id');
-    $data['accounts'] = $getAll('SELECT id, name, ledger_balance, ledger_balance_date FROM accounts ORDER BY id');
+    $data['accounts'] = $getAll('SELECT id, name, sort_code, account_number, ledger_balance, ledger_balance_date FROM accounts ORDER BY id');
     if (in_array('categories', $parts)) {
         $data['categories'] = $getAll('SELECT id, name, description FROM categories ORDER BY id');
     }
@@ -53,8 +53,10 @@ try {
 
     // Compress the JSON payload
     $json = json_encode($data);
-    echo gzencode($json);
+    $gz = gzencode($json);
+    // Log before sending output to avoid corrupting the gzip stream
     Log::write('Backup generated with parts: ' . implode(',', $parts));
+    echo $gz;
 } catch (Exception $e) {
     Log::write('Backup error: ' . $e->getMessage(), 'ERROR');
     http_response_code(500);

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -20,8 +20,18 @@ try {
     $files = $_FILES['ofx_files'];
     $messages = [];
     for ($i = 0; $i < count($files['name']); $i++) {
-        if ($files['error'][$i] !== UPLOAD_ERR_OK) {
-            $msg = "No file uploaded for entry " . ($i + 1) . ".";
+        $error = $files['error'][$i];
+        if ($error !== UPLOAD_ERR_OK) {
+            $errMap = [
+                UPLOAD_ERR_INI_SIZE => 'The uploaded file exceeds the upload_max_filesize directive in php.ini.',
+                UPLOAD_ERR_FORM_SIZE => 'The uploaded file exceeds the MAX_FILE_SIZE directive specified in the HTML form.',
+                UPLOAD_ERR_PARTIAL => 'The uploaded file was only partially uploaded.',
+                UPLOAD_ERR_NO_FILE => 'No file was uploaded.',
+                UPLOAD_ERR_NO_TMP_DIR => 'Missing a temporary folder.',
+                UPLOAD_ERR_CANT_WRITE => 'Failed to write file to disk.',
+                UPLOAD_ERR_EXTENSION => 'A PHP extension stopped the file upload.'
+            ];
+            $msg = ($errMap[$error] ?? 'Unknown upload error') . ' File: ' . $files['name'][$i];
             $messages[] = $msg;
             Log::write($msg, 'ERROR');
             continue;


### PR DESCRIPTION
## Summary
- Include sort code and account number fields when backing up and restoring accounts
- Add detailed logging for failed OFX uploads
- Safely restore gzipped backups using gzip signature detection and clearer JSON error reporting

## Testing
- `php -l php_backend/public/backup.php`
- `php -l php_backend/public/restore.php`
- `php -l php_backend/public/upload_ofx.php`


------
https://chatgpt.com/codex/tasks/task_e_689f5d0939d4832ea0ce46c40b1dcee9