### PR TITLE
Use waterfall chart for account totals

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -30,6 +30,7 @@
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="https://code.highcharts.com/modules/waterfall.js"></script>
     <script>
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
     // Format balance cells with currency and positive/negative colouring
@@ -65,22 +66,46 @@
                 ]
             });
 
+            const seriesData = data.map(a => ({
+                y: parseFloat(a.balance),
+                name: a.name,
+                id: a.id
+            }));
+
+            seriesData.push({
+                name: 'Total',
+                isSum: true
+            });
+
             Highcharts.chart('accounts-chart', {
                 colors: gradientColors,
-                chart: { type: 'column' },
+                chart: { type: 'waterfall' },
                 title: { text: 'Account Balances' },
                 xAxis: { type: 'category' },
-                yAxis: { title: { text: 'Balance (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                yAxis: {
+                    title: { text: 'Balance (£)' },
+                    labels: {
+                        formatter: function(){
+                            return '£' + Highcharts.numberFormat(this.value, 2);
+                        }
+                    }
+                },
+                tooltip: {
+                    pointFormatter: function(){
+                        return '£' + Highcharts.numberFormat(this.y, 2);
+                    }
+                },
                 series: [{
                     name: 'Balance',
-                    data: data.map(a => ({ y: parseFloat(a.balance), name: a.name, id: a.id })),
+                    data: seriesData,
                     colorByPoint: true,
                     cursor: 'pointer',
                     point: {
                         events: {
                             click: function(){
-                                window.location = `account.html?id=${this.options.id}`;
+                                if(this.options.id){
+                                    window.location = `account.html?id=${this.options.id}`;
+                                }
                             }
                         }
                     }

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -1,21 +1,6 @@
-// Ensure the ResizeColumns module is available for Tabulator. Loading it via
-// a synchronous XHR causes cross-origin errors when the page is served from a
-// different domain, so instead inject the script tag which allows the browser
-// to fetch it without CORS issues.
-if (typeof Tabulator !== 'undefined' && !(Tabulator.prototype.modules && Tabulator.prototype.modules.resizeColumns)) {
-    var script = document.createElement('script');
-    script.src = 'https://unpkg.com/tabulator-tables@6.3.0/dist/js/modules/resizeColumns.js';
-    script.async = false;
-    document.head.appendChild(script);
-}
-
-// Ensure the global Search module is available so tables can use simple search
-if (typeof Tabulator !== 'undefined' && !(Tabulator.prototype.modules && Tabulator.prototype.modules.search)) {
-    var searchScript = document.createElement('script');
-    searchScript.src = 'https://unpkg.com/tabulator-tables@6.3.0/dist/js/modules/search.js';
-    searchScript.async = false;
-    document.head.appendChild(searchScript);
-}
+// Tabulator modules are loaded via the main bundle. Avoid dynamically
+// injecting module scripts from external CDNs so the app works in offline
+// or restricted environments without console errors.
 
 // Create a coloured badge element used in table cells
 function createBadge(text, colorClasses) {


### PR DESCRIPTION
## Summary
- explicitly include Highcharts waterfall module so account totals chart renders
- drop dynamic Tabulator module loaders that caused 404 errors

## Testing
- `php -l frontend/account_dashboard.html`
- `node --check frontend/js/tabulator-tailwind.js`


------
https://chatgpt.com/codex/tasks/task_e_689f69c7405c832e929e1f05e70e006f