### PR TITLE
Handle generic ACCTFROM blocks when importing OFX

### DIFF
--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -94,6 +94,18 @@ try {
             if (preg_match('/<ACCTNAME>([^<]+)/i', $block, $nm)) {
                 $accountName = trim($nm[1]);
             }
+        } elseif (preg_match('/<ACCTFROM>(.*?)<\/ACCTFROM>/is', $ofxData, $m)) {
+            // Some credit card OFX files use ACCTFROM without the CC prefix
+            $block = $m[1];
+            if (preg_match('/<BANKID>([^<]+)/i', $block, $sm)) {
+                $sortCode = trim($sm[1]);
+            }
+            if (preg_match('/<ACCTID>([^<]+)/i', $block, $am)) {
+                $accountNumber = trim($am[1]);
+            }
+            if (preg_match('/<ACCTNAME>([^<]+)/i', $block, $nm)) {
+                $accountName = trim($nm[1]);
+            }
         }
 
         if ($accountNumber === null) {


### PR DESCRIPTION
## Summary
- support OFX files that specify account details using `<ACCTFROM>` so credit card accounts and transactions import correctly

## Testing
- `php -l php_backend/public/upload_ofx.php`

------
https://chatgpt.com/codex/tasks/task_e_68a07380bdb0832ea862c408bc033228