### PR TITLE
fix: restore search results graph rendering

### DIFF
--- a/frontend/search.html
+++ b/frontend/search.html
@@ -132,11 +132,9 @@
                         }
 
 
-                        const baseColor = Highcharts.color('#4f46e5');
-                        const step = 0.25 / Math.max(values.length - 1, 1);
                         const points = values.map((v, i) => ({
                             y: v,
-                            color: baseColor.brighten(step * i).get()
+                            color: gradientColors[i % gradientColors.length]
 
                         }));
 


### PR DESCRIPTION
## Summary
- avoid use of Highcharts.color so search results chart renders without extra modules

## Testing
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `php php_backend/public/search_transactions.php value=test` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0818b5950832ebeeb0966327243a6