### PR TITLE
Add tools to prevent and remove duplicate transactions

### DIFF
--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<!-- Page for reviewing and removing duplicate transactions -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Duplicate Transactions</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+</head>
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
+            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Duplicate Transactions</h1>
+            <p class="mb-4">Remove unwanted duplicate entries to keep your records accurate.</p>
+            <div class="mb-4 space-x-2">
+                <button id="refresh" class="bg-indigo-600 text-white px-3 py-1 rounded">Refresh</button>
+                <button id="dedupe-all" class="bg-red-600 text-white px-3 py-1 rounded">Dedupe All</button>
+            </div>
+            <div id="dupe-table"></div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
+    <script>
+    let table = null;
+    async function loadDupes(){
+        const resp = await fetch('../php_backend/public/dedupe_transactions.php');
+        const data = await resp.json();
+        if(table){
+            table.setData(data);
+            return;
+        }
+        table = tailwindTabulator(document.getElementById('dupe-table'), {
+            data: data,
+            layout: 'fitDataStretch',
+            columns: [
+                { title: 'Account', field: 'account' },
+                { title: 'Date', field: 'date' },
+                { title: 'Description', field: 'description' },
+                { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
+                { title: 'Count', field: 'count', hozAlign: 'right' },
+                { title: 'Remove', formatter: function(){ return '<button class="bg-red-600 text-white px-2 py-1 rounded text-sm"><i class="fa-solid fa-trash"></i></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); dedupe(r.ids); } }
+            ]
+        });
+    }
+
+    async function dedupe(ids){
+        const resp = await fetch('../php_backend/public/dedupe_transactions.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ids: ids })
+        });
+        const res = await resp.json();
+        if(res.status === 'ok'){
+            loadDupes();
+        } else {
+            alert(res.error || 'Dedupe failed');
+        }
+    }
+
+    document.getElementById('refresh').addEventListener('click', loadDupes);
+    document.getElementById('dedupe-all').addEventListener('click', async () => {
+        if(!table) return;
+        const rows = table.getData();
+        for(const r of rows){
+            await dedupe(r.ids);
+        }
+    });
+
+    loadDupes();
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -60,6 +60,7 @@
     <ul class="space-y-1">
         <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="processes.html"><i class="fa-solid fa-gear mr-1"></i> Run Processes</a></li>
         <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="logs.html"><i class="fa-solid fa-clipboard-list mr-1"></i> View Logs</a></li>
+        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="dedupe.html"><i class="fa-solid fa-clone mr-1"></i> Remove Duplicates</a></li>
         <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="backup.html"><i class="fa-solid fa-database mr-1"></i> Backup &amp; Restore</a></li>
         <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="../users.php"><i class="fa-solid fa-user mr-1"></i> Manage Users</a></li>
         <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="../logout.php"><i class="fa-solid fa-right-from-bracket mr-1"></i> Logout</a></li>

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -87,6 +87,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     ofx_id VARCHAR(255) UNIQUE,
     ofx_type VARCHAR(50) DEFAULT NULL,
     bank_ofx_id VARCHAR(255) DEFAULT NULL,
+    UNIQUE KEY unique_txn (account_id, date, amount, description(150), memo(150)),
     FOREIGN KEY (account_id) REFERENCES accounts(id),
     FOREIGN KEY (category_id) REFERENCES categories(id),
     FOREIGN KEY (tag_id) REFERENCES tags(id),
@@ -143,6 +144,12 @@ if ($result->rowCount() === 0) {
 $result = $db->query("SHOW COLUMNS FROM `transactions` LIKE 'bank_ofx_id'");
 if ($result->rowCount() === 0) {
     $db->exec("ALTER TABLE `transactions` ADD COLUMN `bank_ofx_id` VARCHAR(255) DEFAULT NULL");
+}
+
+// Ensure unique constraint on core transaction fields to prevent duplicates
+$result = $db->query("SHOW INDEX FROM `transactions` WHERE Key_name = 'unique_txn'");
+if ($result->rowCount() === 0) {
+    $db->exec("ALTER TABLE `transactions` ADD UNIQUE KEY `unique_txn` (`account_id`,`date`,`amount`,`description`(150),`memo`(150))");
 }
 
 // Ensure ledger balance columns exist in accounts

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -47,6 +47,19 @@ class Transaction {
             }
         }
 
+        // Fallback duplicate check on core fields when no OFX identifiers are available
+        $coreCheck = $db->prepare('SELECT id FROM `transactions` WHERE `account_id` = :account AND `date` = :date AND `amount` = :amount AND `description` = :description AND ((`memo` IS NULL AND :memo IS NULL) OR `memo` = :memo) LIMIT 1');
+        $coreCheck->execute([
+            'account' => $account,
+            'date' => $date,
+            'amount' => $amount,
+            'description' => $description,
+            'memo' => $memo
+        ]);
+        if ($row = $coreCheck->fetch(PDO::FETCH_ASSOC)) {
+            return (int)$row['id'];
+        }
+
 
         $stmt = $db->prepare('INSERT INTO transactions (`account_id`, `date`, `amount`, `description`, `memo`, `category_id`, `tag_id`, `group_id`, `ofx_id`, `ofx_type`, `bank_ofx_id`) VALUES (:account, :date, :amount, :description, :memo, :category, :tag, :group, :ofx_id, :ofx_type, :bank_ofx_id)');
         $stmt->execute([

--- a/php_backend/public/dedupe_transactions.php
+++ b/php_backend/public/dedupe_transactions.php
@@ -1,0 +1,55 @@
+<?php
+// Lists duplicate transactions and removes extras when requested.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../Database.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+try {
+    $db = Database::getConnection();
+
+    if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+        $sql = 'SELECT GROUP_CONCAT(t.id) AS ids, COUNT(*) AS count, a.name AS account, '
+             . 't.date, t.amount, t.description '
+             . 'FROM transactions t JOIN accounts a ON t.account_id = a.id '
+             . 'GROUP BY t.account_id, t.date, t.amount, t.description, t.memo '
+             . 'HAVING COUNT(*) > 1';
+        $rows = $db->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($rows as &$row) {
+            $row['ids'] = array_map('intval', explode(',', $row['ids']));
+            $row['count'] = (int)$row['count'];
+            $row['amount'] = (float)$row['amount'];
+        }
+        echo json_encode($rows);
+        exit;
+    }
+
+    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+        $data = json_decode(file_get_contents('php://input'), true);
+        $ids = $data['ids'] ?? [];
+        if (!is_array($ids) || count($ids) < 2) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Invalid ids']);
+            exit;
+        }
+        $keep = min($ids);
+        $toDelete = array_values(array_diff($ids, [$keep]));
+        if (!$toDelete) {
+            echo json_encode(['status' => 'ok', 'deleted' => 0]);
+            exit;
+        }
+        $placeholders = implode(',', array_fill(0, count($toDelete), '?'));
+        $stmt = $db->prepare("DELETE FROM transactions WHERE id IN ($placeholders)");
+        $stmt->execute($toDelete);
+        Log::write('Deduped transactions, kept ' . $keep . ' removed ' . implode(',', $toDelete));
+        echo json_encode(['status' => 'ok', 'deleted' => $stmt->rowCount()]);
+        exit;
+    }
+
+    http_response_code(405);
+} catch (Exception $e) {
+    Log::write('Dedupe error: ' . $e->getMessage(), 'ERROR');
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -141,7 +141,7 @@ try {
     }
 
     if (isset($data['transactions'])) {
-        $stmtTx = $db->prepare('INSERT INTO transactions (id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id, bank_ofx_id) VALUES (:id, :account_id, :date, :amount, :description, :memo, :category_id, :tag_id, :group_id, :transfer_id, :ofx_id, :bank_ofx_id)');
+        $stmtTx = $db->prepare('INSERT IGNORE INTO transactions (id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id, bank_ofx_id) VALUES (:id, :account_id, :date, :amount, :description, :memo, :category_id, :tag_id, :group_id, :transfer_id, :ofx_id, :bank_ofx_id)');
         foreach ($data['transactions'] as $row) {
             $stmtTx->execute([
                 'id' => $row['id'],


### PR DESCRIPTION
## Summary
- Guard transaction creation with core field duplicate check
- Enforce unique transaction index and ignore duplicates on restore
- Provide admin page and API to review and purge duplicate transactions

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/create_tables.php`
- `php -l php_backend/public/restore.php`
- `php -l php_backend/public/dedupe_transactions.php`
- `php php_backend/create_tables.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a082f3db18832e9e92090094c8878a