### PR TITLE
Add SQLite-based test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,16 @@ Reports can be saved in the browser for reuse and removed when no longer needed.
 The page sends requests to `php_backend/public/report.php` which returns matching
 transactions as JSON.
 
+## Running Tests
+
+The repository includes a small test script that exercises the user model using
+an in-memory SQLite database. It does not require a MySQL server, making it
+suitable for environments where a database is unavailable.
+
+Run the tests with:
+
+```bash
+php tests/run_tests.php
+```
+
 

--- a/php_backend/Database.php
+++ b/php_backend/Database.php
@@ -1,5 +1,5 @@
 <?php
-// Provides a shared PDO connection to the application's MySQL database.
+// Provides a shared PDO connection to the application's database.
 class Database {
     private static $instance = null;
 
@@ -8,11 +8,17 @@ class Database {
      */
     public static function getConnection(): PDO {
         if (self::$instance === null) {
-            $host = getenv('DB_HOST') ?: 'localhost';
-            $name = getenv('DB_NAME') ?: 'finance';
-            $user = getenv('DB_USER') ?: 'root';
-            $pass = getenv('DB_PASS') ?: '';
-            $dsn = "mysql:host=$host;dbname=$name;charset=utf8mb4";
+            $dsn = getenv('DB_DSN');
+            if ($dsn) {
+                $user = getenv('DB_USER') ?: null;
+                $pass = getenv('DB_PASS') ?: null;
+            } else {
+                $host = getenv('DB_HOST') ?: 'localhost';
+                $name = getenv('DB_NAME') ?: 'finance';
+                $user = getenv('DB_USER') ?: 'root';
+                $pass = getenv('DB_PASS') ?: '';
+                $dsn = "mysql:host=$host;dbname=$name;charset=utf8mb4";
+            }
             self::$instance = new PDO($dsn, $user, $pass);
             self::$instance->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         }

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -1,0 +1,53 @@
+<?php
+require_once __DIR__ . '/../php_backend/models/User.php';
+
+// Use an in-memory SQLite database for tests.
+putenv('DB_DSN=sqlite::memory:');
+$db = Database::getConnection();
+$db->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);');
+
+$results = [];
+
+function assertEqual($expected, $actual, string $message) {
+    global $results;
+    if ($expected === $actual) {
+        $results[] = "PASS: $message";
+    } else {
+        $results[] = "FAIL: $message (expected " . var_export($expected, true) . ", got " . var_export($actual, true) . ")";
+    }
+}
+
+// Database driver should be sqlite
+assertEqual('sqlite', $db->getAttribute(PDO::ATTR_DRIVER_NAME), 'Database driver is sqlite');
+
+// Test user creation and retrieval
+$userId = User::create('alice', 'secret');
+assertEqual(1, $userId, 'User ID starts at 1');
+
+$user = User::findByUsername('alice');
+assertEqual('alice', $user['username'] ?? null, 'User retrieved by username');
+
+// Test password verification
+$reason = null;
+$verifiedId = User::verify('alice', 'secret', $reason);
+assertEqual(1, $verifiedId, 'Password verification succeeds');
+
+$wrong = User::verify('alice', 'wrong', $reason);
+assertEqual(null, $wrong, 'Password verification fails for wrong password');
+
+// Test password update
+User::updatePassword(1, 'newpass');
+$updated = User::verify('alice', 'newpass', $reason);
+assertEqual(1, $updated, 'Updated password verifies');
+
+// Output results and set exit code
+$failed = false;
+foreach ($results as $line) {
+    echo $line, "\n";
+    if (strpos($line, 'FAIL') === 0) {
+        $failed = true;
+    }
+}
+if ($failed) {
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- Allow overriding PDO DSN via `DB_DSN` so tests can run without MySQL
- Add `tests/run_tests.php` exercising the user model with an in-memory SQLite database
- Document how to run the new test script

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0d3ff8d50832e9c0d71e1e022a388