### PR TITLE
Enable inline account name editing in dashboard

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -55,10 +55,26 @@
                 data,
                 layout: 'fitDataStretch',
                 rowClick: (e, row) => {
-                    window.location = `account.html?id=${row.getData().id}`;
+                    const cell = row.getCellFromEvent(e);
+                    if (!cell || cell.getField() !== 'name') {
+                        window.location = `account.html?id=${row.getData().id}`;
+                    }
                 },
                 columns: [
-                    { title: 'Name', field: 'name' },
+                    { title: 'Name', field: 'name', editor: 'input', cellEdited: async (cell) => {
+                        const oldValue = cell.getOldValue();
+                        const newValue = cell.getValue();
+                        const id = cell.getRow().getData().id;
+                        const resp = await fetch('../php_backend/public/update_account.php', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ account_id: id, name: newValue })
+                        });
+                        if (!resp.ok) {
+                            alert('Failed to update name');
+                            cell.setValue(oldValue, true);
+                        }
+                    } },
                     { title: 'Sort Code', field: 'sort_code' },
                     { title: 'Account/Card Number', field: 'account_number' },
                     { title: 'Credit Card', field: 'is_credit_card', hozAlign: 'center', formatter: creditCardFormatter, headerSort: false },

--- a/php_backend/models/Account.php
+++ b/php_backend/models/Account.php
@@ -38,5 +38,14 @@ class Account {
         $stmt = $db->prepare('UPDATE accounts SET ledger_balance = :bal, ledger_balance_date = :dt WHERE id = :id');
         $stmt->execute(['bal' => $balance, 'dt' => $date, 'id' => $accountId]);
     }
+
+    /**
+     * Rename an existing account.
+     */
+    public static function rename(int $accountId, string $name): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE accounts SET name = :name WHERE id = :id');
+        $stmt->execute(['name' => $name, 'id' => $accountId]);
+    }
 }
 ?>

--- a/php_backend/public/update_account.php
+++ b/php_backend/public/update_account.php
@@ -1,0 +1,32 @@
+<?php
+// API endpoint to update the name of an account.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Account.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$accountId = $data['account_id'] ?? null;
+$name = $data['name'] ?? null;
+
+if (!$accountId || !$name) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid parameters']);
+    exit;
+}
+
+try {
+    Account::rename((int)$accountId, $name);
+    echo json_encode(['status' => 'ok']);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Update account error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>


### PR DESCRIPTION
## Summary
- Allow account names to be edited directly from the dashboard table
- Add backend endpoint to persist account name changes
- Extend Account model with rename method

## Testing
- `php -l php_backend/public/update_account.php`
- `php -l php_backend/models/Account.php`
- `node --check /tmp/account_dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68a196632570832ebd969dac4f4b2689