### PR TITLE
Hide tag input when transaction already tagged

### DIFF
--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -90,6 +90,9 @@
             card.appendChild(form);
             container.appendChild(card);
             const tagInput = form.querySelector('#tag');
+            if (tx.tag_name) {
+                tagInput.parentElement.classList.add('hidden');
+            }
             const groupSel = form.querySelector('#group');
             const blankGrp = document.createElement('option');
             blankGrp.value = '';


### PR DESCRIPTION
## Summary
- hide the Tag field on the transaction details form when the transaction already has a tag

## Testing
- `php -v`


------
https://chatgpt.com/codex/tasks/task_e_68a199b57450832eb6036d90e35d94d7