### PR TITLE
Show missing tag count in menu

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -86,6 +86,20 @@ document.addEventListener('DOMContentLoaded', () => {
             heading.before(crumb);
           }
         }
+        // Display counter for untagged transactions in menu
+        fetch('../php_backend/public/untagged_transactions.php')
+          .then(r => r.json())
+          .then(rows => {
+            const total = rows.reduce((sum, row) => sum + Number(row.count || 0), 0);
+            if (total > 10) {
+              const counter = menu.querySelector('#missing-tags-count');
+              if (counter) {
+                counter.textContent = total;
+                counter.classList.remove('hidden');
+              }
+            }
+          })
+          .catch(err => console.error('Untagged count load failed', err));
       })
       .catch(err => console.error('Menu load failed', err));
   }

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -49,7 +49,12 @@
     <h3 class="text-lg font-semibold text-indigo-600 mb-2">Data Organisation</h3>
     <ul class="space-y-1">
         <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="tags.html"><i class="fa-solid fa-tags mr-1"></i> Manage Tags</a></li>
-        <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="missing_tags.html"><i class="fa-solid fa-circle-question mr-1"></i> Missing Tags</a></li>
+        <li>
+          <a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="missing_tags.html">
+            <span class="flex items-center"><i class="fa-solid fa-circle-question mr-1"></i> Missing Tags</span>
+            <span id="missing-tags-count" class="ml-auto bg-red-600 text-white text-xs font-bold rounded-full px-2 hidden"></span>
+          </a>
+        </li>
         <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="categories.html"><i class="fa-solid fa-folder-open mr-1"></i> Manage Categories</a></li>
         <li><a class="flex items-center text-indigo-600 hover:text-indigo-800 hover:bg-indigo-50 px-2 py-1 rounded" href="groups.html"><i class="fa-solid fa-users mr-1"></i> Manage Groups</a></li>
     </ul>


### PR DESCRIPTION
## Summary
- add a badge placeholder for the Missing Tags menu entry
- dynamically fetch untagged transaction count and show badge when above 10

## Testing
- `node --check frontend/js/menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68a19bc45c4c832eb8a91c0a6efe9034