### PR TITLE
Add global opacity

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -10,6 +10,8 @@ window.fetch = (input, init = {}) => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+  // Apply 20% opacity to all page elements
+  document.documentElement.style.opacity = '0.2';
   // Apply consistent hover styling across the site
   const hoverStyle = document.createElement('style');
   hoverStyle.textContent = `


### PR DESCRIPTION
## Summary
- Apply 20% opacity across site by setting document root's style during menu initialization

## Testing
- `node --check frontend/js/menu.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a19be55490832e8f3fa00ab1fde7ec