### PR TITLE
Show release number in top bar

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -132,6 +132,19 @@ document.addEventListener('DOMContentLoaded', () => {
           })
           .catch(err => console.error('Latest statement load failed', err));
       }
+
+      const releaseEl = document.getElementById('release-number');
+      if (releaseEl) {
+        fetch('../php_backend/public/version.php')
+          .then(r => r.json())
+          .then(v => {
+            const version = v.version || 'unknown';
+            releaseEl.textContent = `v${version}`;
+          })
+          .catch(() => {
+            releaseEl.textContent = 'v?';
+          });
+      }
     })
     .catch(err => console.error('Top bar load failed', err));
 

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -4,7 +4,10 @@
     <div class="flex items-center space-x-4">
       <img src="../favicon.svg" alt="Finance Manager Logo" class="h-8 w-8">
       <button id="menu-toggle" class="md:hidden bg-indigo-700 p-2 rounded"><i class="fa-solid fa-bars"></i></button>
-      <div class="font-bold text-lg">Personal Finance Manager</div>
+      <div class="font-bold text-lg flex items-center">
+        <span>Personal Finance Manager</span>
+        <span id="release-number" class="ml-2 bg-indigo-700 text-white text-[0.675rem] px-2 py-0.5 rounded">v0.0.0</span>
+      </div>
     </div>
     <div id="topbar-right" class="flex items-center space-x-4 transition-transform duration-300">
       <form id="topbar-search" action="search.html" method="get" class="flex">


### PR DESCRIPTION
## Summary
- display current release number next to site name in the top bar
- fetch release info from the backend and show it in a compact button

## Testing
- `node --check frontend/js/menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68a19cc67304832ea51c1b82472f4bea