### PR TITLE
Use monospaced font for financial records

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,11 +9,11 @@
     <meta http-equiv="Expires" content="0">
     <title>Finance Manager</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;500&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
-        body { font-family: 'Roboto', sans-serif; font-weight: 300; }
+        body { font-family: 'Roboto Mono', monospace; font-weight: 300; }
     </style>
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -54,15 +54,15 @@ document.addEventListener('DOMContentLoaded', () => {
       document.head.appendChild(link);
     }
 
-    // Load Roboto font for a lighter appearance
-    if (!document.getElementById('roboto-font')) {
+    // Load monospaced font suitable for financial records
+    if (!document.getElementById('roboto-mono-font')) {
       const fontLink = document.createElement('link');
-      fontLink.id = 'roboto-font';
+      fontLink.id = 'roboto-mono-font';
       fontLink.rel = 'stylesheet';
-      fontLink.href = 'https://fonts.googleapis.com/css2?family=Roboto:wght@300;500&display=swap';
+      fontLink.href = 'https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300;500&display=swap';
       document.head.appendChild(fontLink);
     }
-    document.body.style.fontFamily = 'Roboto, sans-serif';
+    document.body.style.fontFamily = 'Roboto Mono, monospace';
     document.body.style.fontWeight = '300';
 
     fetch('menu.html')


### PR DESCRIPTION
## Summary
- replace Roboto with Roboto Mono across the frontend
- load monospaced font in menu script and apply site-wide

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1a08633ec832e82662c0523f32f4f