### PR TITLE
Preserve custom account names on OFX import

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ curl -F "ofx_files[]=@first.ofx" -F "ofx_files[]=@second.ofx" https://localhost/
 You can try this using the included sample file `sample_data/test.ofx` which
 contains two transactions for a checking account.
 
+Account names you've customised in the UI are preserved. Uploading new OFX files will not overwrite renamed accounts.
+
 
 The importer normalises line endings, strips control characters and converts
 character encoding to UTF-8, falling back to iconv when the mbstring extension

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -121,10 +121,7 @@ try {
         $account = $stmt->fetch(PDO::FETCH_ASSOC);
         if ($account) {
             $accountId = (int)$account['id'];
-            if ($accountName && $account['name'] !== $accountName) {
-                $upd = $db->prepare('UPDATE accounts SET name = :name WHERE id = :id');
-                $upd->execute(['name' => $accountName, 'id' => $accountId]);
-            }
+            // Preserve existing account names – do not overwrite with OFX-provided names
         } else {
             $accountId = Account::create($accountName, $sortCode, $accountNumber);
         }


### PR DESCRIPTION
## Summary
- Avoid overwriting existing account names when importing OFX files so user renames persist.
- Document that customised account names are preserved during subsequent OFX uploads.

## Testing
- `php tests/run_tests.php`
- Manual SQLite simulation of OFX import confirmed account name remains "Custom Name" after second import.

------
https://chatgpt.com/codex/tasks/task_e_68a1a3a750f0832e89d4ad768145f01f