### PR TITLE
Fix git pull endpoint to locate repo root and handle remotes

### DIFF
--- a/php_backend/public/git_pull.php
+++ b/php_backend/public/git_pull.php
@@ -2,9 +2,33 @@
 // Runs 'git pull' to update the application to the latest version.
 require_once __DIR__ . '/../nocache.php';
 header('Content-Type: application/json');
-// Determine the repository root. Prefer the web server's document root
-// so the script operates within the deployed application directory.
-$rootDir = realpath($_SERVER['DOCUMENT_ROOT'] ?? '') ?: dirname(__DIR__, 2);
+// Determine the repository root. Start from the web server's document root if
+// available, but walk up the directory tree until a `.git` folder is found so
+// Git commands always run from the actual repository root.
+$rootDir = realpath($_SERVER['DOCUMENT_ROOT'] ?? __DIR__);
+if ($rootDir === false) {
+    $rootDir = dirname(__DIR__, 2);
+}
+
+// Traverse upwards to locate the git repository
+$repoDir = $rootDir;
+while ($repoDir !== '/' && !is_dir($repoDir . '/.git')) {
+    $parent = dirname($repoDir);
+    if ($parent === $repoDir) {
+        break;
+    }
+    $repoDir = $parent;
+}
+
+if (!is_dir($repoDir . '/.git')) {
+    echo json_encode([
+        'success' => false,
+        'output' => 'Git repository not found'
+    ]);
+    exit;
+}
+
+$rootDir = $repoDir;
 
 
 // Git expects a HOME environment variable even when no global configuration is
@@ -24,7 +48,15 @@ $gitCmd = 'git -C ' . escapeshellarg($rootDir) . ' -c safe.directory=' . escapes
 $remoteList = [];
 $remoteStatus = 0;
 exec($gitCmd . ' remote 2>&1', $remoteList, $remoteStatus);
-if ($remoteStatus !== 0 || trim(implode("\n", $remoteList)) === '') {
+$remoteOutput = trim(implode("\n", $remoteList));
+if ($remoteStatus !== 0) {
+    echo json_encode([
+        'success' => false,
+        'output' => $remoteOutput
+    ]);
+    exit;
+}
+if ($remoteOutput === '') {
     echo json_encode([
         'success' => false,
         'output' => 'No git remote configured'


### PR DESCRIPTION
## Summary
- search upwards for the repository root before running git commands
- return git errors and properly detect missing remotes before pulling

## Testing
- `php -l php_backend/public/git_pull.php`
- `php php_backend/public/git_pull.php` (with and without a remote)


------
https://chatgpt.com/codex/tasks/task_e_68a1bfaa767c832e974334a9157ba9ed