### PR TITLE
style: use hover color for missing tags links

### DIFF
--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -44,7 +44,7 @@
                         formatter: function(cell){
                             const value = cell.getValue();
                             const url = `search.html?value=${encodeURIComponent(value)}`;
-                            return `<a href="${url}" class="text-indigo-600 underline">${value}</a>`;
+                            return `<a href="${url}" class="text-indigo-600 no-underline hover:text-indigo-800">${value}</a>`;
                         }
                     },
                     { title: 'Memo', field: 'memo' },


### PR DESCRIPTION
## Summary
- Make missing tags description links change color on hover instead of being underlined

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1bfe1b4bc832eb1d6415d4839b2af