### PR TITLE
Add transaction ignore functionality and management page

### DIFF
--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Ignored Transactions</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+</head>
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
+            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Ignored Transactions</h1>
+            <p class="mb-4">Transactions tagged with <strong>IGNORE</strong> are hidden from dashboards and reports. Use this page to review and restore them.</p>
+            <div id="ignored-table"></div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
+    <script>
+    let table;
+    async function loadIgnored(){
+        const res = await fetch('../php_backend/public/ignored_transactions.php');
+        const data = await res.json();
+        if (table){
+            table.setData(data);
+        } else {
+            table = tailwindTabulator('#ignored-table', {
+                data: data,
+                layout: 'fitDataStretch',
+                columns: [
+                    {title: 'Date', field: 'date'},
+                    {title: 'Account', field: 'account_name'},
+                    {title: 'Description', field: 'description'},
+                    {title: 'Amount', field: 'amount', formatter: 'money', formatterParams: {symbol: '£', precision: 2}, hozAlign: 'right'},
+                    {title: 'Action', formatter: () => '<button class="bg-indigo-600 text-white px-2 py-1 rounded">Unignore</button>', width: 110, hozAlign: 'center', cellClick: async (e, cell) => {
+                        const id = cell.getRow().getData().id;
+                        await fetch('../php_backend/public/unignore_transaction.php', {
+                            method: 'POST',
+                            headers: {'Content-Type':'application/json'},
+                            body: JSON.stringify({transaction_id: id})
+                        });
+                        showMessage('Transaction restored');
+                        loadIgnored();
+                    }}
+                ]
+            });
+        }
+    }
+    loadIgnored();
+    </script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -16,6 +16,7 @@
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="report.html"><i class="fa-solid fa-table text-indigo-600 mr-1"></i> Transaction Reports</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="search.html"><i class="fa-solid fa-magnifying-glass text-indigo-600 mr-1"></i> Search Transactions</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="transfers.html"><i class="fa-solid fa-right-left text-indigo-600 mr-1"></i> Transfers</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ignored.html"><i class="fa-solid fa-eye-slash text-indigo-600 mr-1"></i> Ignored Transactions</a></li>
     </ul>
   </div>
 

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -77,6 +77,28 @@ class Tag {
     }
 
     /**
+     * Look up a tag's id by its exact name.
+     */
+    public static function getIdByName(string $name): ?int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT `id` FROM `tags` WHERE `name` = :name LIMIT 1');
+        $stmt->execute(['name' => $name]);
+        $id = $stmt->fetchColumn();
+        return $id !== false ? (int)$id : null;
+    }
+
+    /**
+     * Return the id for the IGNORE tag, creating it if missing.
+     */
+    public static function getIgnoreId(): int {
+        $id = self::getIdByName('IGNORE');
+        if ($id === null) {
+            $id = self::create('IGNORE', 'IGNORE', 'Ignored transactions');
+        }
+        return $id;
+    }
+
+    /**
      * Set a tag's keyword if it is currently blank.
      */
     public static function setKeywordIfMissing(int $tagId, string $keyword): void {

--- a/php_backend/public/account_balance.php
+++ b/php_backend/public/account_balance.php
@@ -2,6 +2,7 @@
 // Returns running balance history for a single account starting from latest bank balance.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Account.php';
+require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../Database.php';
 
 header('Content-Type: application/json');
@@ -23,8 +24,9 @@ try {
     if ($account['ledger_balance_date']) {
         $history[] = ['date' => $account['ledger_balance_date'], 'balance' => $balance];
     }
-    $stmt = $db->prepare('SELECT date, amount FROM transactions WHERE account_id = :id ORDER BY date DESC, id DESC');
-    $stmt->execute(['id' => $id]);
+    $ignore = Tag::getIgnoreId();
+    $stmt = $db->prepare('SELECT date, amount FROM transactions WHERE account_id = :id AND (tag_id IS NULL OR tag_id != :ignore) ORDER BY date DESC, id DESC');
+    $stmt->execute(['id' => $id, 'ignore' => $ignore]);
     while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
         $balance -= (float)$row['amount'];
         $history[] = ['date' => $row['date'], 'balance' => $balance];

--- a/php_backend/public/export_ofx.php
+++ b/php_backend/public/export_ofx.php
@@ -2,6 +2,7 @@
 // Exports all transactions as a single OFX file
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
+require_once __DIR__ . '/../models/Tag.php';
 
 header('Content-Type: application/x-ofx');
 $host = $_SERVER['HTTP_HOST'] ?? 'backup';
@@ -11,7 +12,9 @@ header('Content-Disposition: attachment; filename="' . $filename . '"');
 
 try {
     $db = Database::getConnection();
-    $stmt = $db->query('SELECT id, date, amount, description, memo, ofx_id FROM transactions ORDER BY date');
+    $ignore = Tag::getIgnoreId();
+    $stmt = $db->prepare('SELECT id, date, amount, description, memo, ofx_id FROM transactions WHERE tag_id IS NULL OR tag_id != :ignore ORDER BY date');
+    $stmt->execute(['ignore' => $ignore]);
     $txns = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     // Retrieve basic account details for the OFX header. If there are

--- a/php_backend/public/ignored_transactions.php
+++ b/php_backend/public/ignored_transactions.php
@@ -1,0 +1,22 @@
+<?php
+// List transactions tagged as IGNORE so they can be managed separately.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../Database.php';
+require_once __DIR__ . '/../models/Tag.php';
+
+header('Content-Type: application/json');
+
+try {
+    $ignore = Tag::getIgnoreId();
+    $db = Database::getConnection();
+    $sql = 'SELECT t.id, t.date, t.amount, t.description, a.name AS account_name '
+         . 'FROM transactions t JOIN accounts a ON t.account_id = a.id '
+         . 'WHERE t.tag_id = :ignore ORDER BY t.date DESC, t.id DESC';
+    $stmt = $db->prepare($sql);
+    $stmt->execute(['ignore' => $ignore]);
+    echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}
+?>

--- a/php_backend/public/unignore_transaction.php
+++ b/php_backend/public/unignore_transaction.php
@@ -1,0 +1,31 @@
+<?php
+// Remove the IGNORE tag from a transaction so it appears in reports again.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$transactionId = $data['transaction_id'] ?? null;
+if (!$transactionId) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid parameters']);
+    exit;
+}
+
+try {
+    Transaction::setTag((int)$transactionId, null);
+    echo json_encode(['status' => 'ok']);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Unignore transaction error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>


### PR DESCRIPTION
## Summary
- Introduce IGNORE tag support and helper methods.
- Exclude ignored transactions across queries and budget calculations.
- Add management page to view and restore ignored transactions.

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/models/Budget.php`
- `php -l php_backend/public/account_balance.php`
- `php -l php_backend/public/dedupe_transactions.php`
- `php -l php_backend/public/export_ofx.php`
- `php -l php_backend/public/ignored_transactions.php`
- `php -l php_backend/public/unignore_transaction.php`
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1bf406e60832ea0071deb56e0166d