### PR TITLE
Fix git pull endpoint to locate repo root and handle remotes

### DIFF
--- a/php_backend/public/git_pull.php
+++ b/php_backend/public/git_pull.php
@@ -1,39 +1,89 @@
 <?php
 // Runs 'git pull' to update the application to the latest version.
 require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');
-// Determine the repository root. Prefer the web server's document root
-// so the script operates within the deployed application directory.
-$rootDir = realpath($_SERVER['DOCUMENT_ROOT'] ?? '') ?: dirname(__DIR__, 2);
+// Determine the repository root. Start from the web server's document root if
+// available, but walk up the directory tree until a `.git` folder is found so
+// Git commands always run from the actual repository root.
+$rootDir = realpath($_SERVER['DOCUMENT_ROOT'] ?? __DIR__);
+if ($rootDir === false) {
+    $rootDir = dirname(__DIR__, 2);
+}
+
+// Traverse upwards to locate the git repository
+$repoDir = $rootDir;
+while ($repoDir !== '/' && !is_dir($repoDir . '/.git')) {
+    $parent = dirname($repoDir);
+    if ($parent === $repoDir) {
+        break;
+    }
+    $repoDir = $parent;
+}
+
+if (!is_dir($repoDir . '/.git')) {
+    Log::write('Git repository not found starting at ' . $rootDir, 'ERROR');
+    echo json_encode([
+        'success' => false,
+        'output' => 'Git repository not found',
+        'cwd' => $rootDir,
+    ]);
+    exit;
+}
+
+$rootDir = $repoDir;
 
 
 // Git expects a HOME environment variable even when no global configuration is
-// required. Point it at the repository root to satisfy this requirement.
-putenv('HOME=' . $rootDir);
-$_SERVER['HOME'] = $rootDir;
+// required. Point it at a temporary directory so `git config --global` has a
+// safe place to write to and doesn't pollute the repository.
+$homeDir = sys_get_temp_dir();
+putenv('HOME=' . $homeDir);
+$_SERVER['HOME'] = $homeDir;
 
+// Mark the repository as a safe directory if it has not already been whitelisted
+// to avoid "dubious ownership" errors when running commands.
+$safeCheck = [];
+$safeStatus = 0;
+exec('git config --global --get safe.directory ' . escapeshellarg($rootDir) . ' 2>&1', $safeCheck, $safeStatus);
+if ($safeStatus !== 0) {
+    exec('git config --global --add safe.directory ' . escapeshellarg($rootDir) . ' 2>&1');
+}
 
 $output = [];
 $returnVar = 0;
 
-// Prepare a git command that treats the repository directory as safe without
-// relying on global configuration that requires the HOME environment variable.
-$gitCmd = 'git -C ' . escapeshellarg($rootDir) . ' -c safe.directory=' . escapeshellarg($rootDir);
+// Prepare a git command rooted at the repository.
+$gitCmd = 'git -C ' . escapeshellarg($rootDir);
 
 // Ensure a remote is configured before attempting to pull.
 $remoteList = [];
 $remoteStatus = 0;
 exec($gitCmd . ' remote 2>&1', $remoteList, $remoteStatus);
-if ($remoteStatus !== 0 || trim(implode("\n", $remoteList)) === '') {
+$remoteOutput = trim(implode("\n", $remoteList));
+if ($remoteStatus !== 0) {
+    Log::write('Git remote check failed in ' . $rootDir . ': ' . $remoteOutput, 'ERROR');
     echo json_encode([
         'success' => false,
-        'output' => 'No git remote configured'
+        'output' => $remoteOutput,
+        'cwd' => $rootDir,
+    ]);
+    exit;
+}
+if ($remoteOutput === '') {
+    Log::write('No git remote configured in ' . $rootDir, 'ERROR');
+    echo json_encode([
+        'success' => false,
+        'output' => 'No git remote configured',
+        'cwd' => $rootDir,
     ]);
     exit;
 }
 exec($gitCmd . ' pull 2>&1', $output, $returnVar);
+Log::write('git pull run in ' . $rootDir . ': ' . trim(implode("\n", $output)), $returnVar === 0 ? 'INFO' : 'ERROR');
 
 echo json_encode([
     'success' => $returnVar === 0,
-    'output' => trim(implode("\n", $output))
+    'output' => trim(implode("\n", $output)),
+    'cwd' => $rootDir,
 ]);


### PR DESCRIPTION
## Summary
- search upwards for the repository root before running git commands
- whitelist the repository as safe to avoid "dubious ownership" errors
- return git errors and properly detect missing remotes before pulling
- log pull attempts and include the working directory in the JSON output

## Testing
- `php -l php_backend/public/git_pull.php`
- `REQUEST_METHOD=GET php php_backend/public/git_pull.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1bfaa767c832e974334a9157ba9ed