### PR TITLE
Add segment management page with drag-and-drop category assignment

### DIFF
--- a/frontend/js/segment_drag.js
+++ b/frontend/js/segment_drag.js
@@ -1,0 +1,181 @@
+// Handles segment and category drag-and-drop assignments
+(function(){
+  const dragInfo = { categoryId: null, oldSegment: null };
+
+  function handleDragStart(){
+    const parent = this.closest('[data-segment-id]');
+    dragInfo.categoryId = this.dataset.categoryId;
+    dragInfo.oldSegment = parent && parent.dataset.segmentId ? parent.dataset.segmentId : null;
+  }
+
+  async function handleDrop(e){
+    e.preventDefault();
+    const newSegment = this.dataset.segmentId || null;
+    if (!dragInfo.categoryId || newSegment === dragInfo.oldSegment) return;
+
+    if (dragInfo.oldSegment && newSegment) {
+      await fetch('../php_backend/public/segments.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'move_category', segment_id: newSegment, old_segment_id: dragInfo.oldSegment, category_id: dragInfo.categoryId })
+      });
+    } else if (dragInfo.oldSegment && !newSegment) {
+      await fetch('../php_backend/public/segments.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'remove_category', segment_id: dragInfo.oldSegment, category_id: dragInfo.categoryId })
+      });
+    } else if (!dragInfo.oldSegment && newSegment) {
+      await fetch('../php_backend/public/segments.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'add_category', segment_id: newSegment, category_id: dragInfo.categoryId })
+      });
+    }
+    loadSegments();
+  }
+
+  function createCategoryCard(cat){
+    const div = document.createElement('div');
+    div.textContent = cat.name;
+    div.className = 'bg-blue-200 text-blue-800 px-2 py-1 rounded cursor-move w-full text-center';
+    div.draggable = true;
+    div.dataset.categoryId = cat.id;
+    div.addEventListener('dragstart', handleDragStart);
+    return div;
+  }
+
+  function addDropHandlers(el){
+    el.addEventListener('dragover', e => e.preventDefault());
+    el.addEventListener('drop', handleDrop);
+  }
+
+  function createSegmentCard(seg){
+    const card = document.createElement('div');
+    card.className = 'bg-white p-4 rounded shadow w-64 flex-shrink-0';
+    card.dataset.segmentId = seg.id;
+
+    const header = document.createElement('div');
+    header.className = 'flex justify-between items-center mb-2';
+    const title = document.createElement('h2');
+    title.className = 'font-semibold';
+    title.textContent = seg.name;
+    header.appendChild(title);
+
+    const actions = document.createElement('div');
+    actions.className = 'flex gap-2';
+
+    const editBtn = document.createElement('button');
+    editBtn.className = 'text-indigo-600';
+    editBtn.innerHTML = '<i class="fas fa-edit"></i>';
+    editBtn.addEventListener('click', async () => {
+      const name = prompt('Segment Name', seg.name);
+      if (name === null) return;
+      const description = prompt('Description', seg.description || '');
+      if (description === null) return;
+      await fetch('../php_backend/public/segments.php', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: seg.id, name, description })
+      });
+      loadSegments();
+      if (typeof showMessage !== 'undefined') {
+        showMessage('Segment updated');
+      }
+    });
+    actions.appendChild(editBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'text-red-600';
+    delBtn.innerHTML = '<i class="fas fa-trash"></i>';
+    delBtn.addEventListener('click', async () => {
+      if (!confirm('Delete this segment?')) return;
+      await fetch('../php_backend/public/segments.php', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: seg.id })
+      });
+      loadSegments();
+    });
+    actions.appendChild(delBtn);
+
+    header.appendChild(actions);
+    card.appendChild(header);
+
+    if (seg.description) {
+      const desc = document.createElement('p');
+      desc.className = 'text-sm text-gray-600 mb-2';
+      desc.textContent = seg.description;
+      card.appendChild(desc);
+    }
+
+    const catWrap = document.createElement('div');
+    catWrap.className = 'min-h-[3rem] flex flex-col gap-2';
+    catWrap.dataset.segmentId = seg.id;
+    (seg.categories || []).forEach(c => catWrap.appendChild(createCategoryCard(c)));
+    card.appendChild(catWrap);
+
+    addDropHandlers(catWrap);
+    return card;
+  }
+
+  function createUnassignedCard(categories){
+    const card = document.createElement('div');
+    card.className = 'bg-white p-4 rounded shadow w-64 flex-shrink-0';
+    const title = document.createElement('h2');
+    title.className = 'font-semibold mb-2';
+    title.textContent = 'Unassigned Categories';
+    card.appendChild(title);
+    const wrap = document.createElement('div');
+    wrap.className = 'min-h-[3rem] flex flex-col gap-2';
+    categories.forEach(c => wrap.appendChild(createCategoryCard(c)));
+    card.appendChild(wrap);
+    addDropHandlers(wrap);
+    return card;
+  }
+
+  async function loadSegments(){
+    const [segRes, catRes] = await Promise.all([
+      fetch('../php_backend/public/segments.php'),
+      fetch('../php_backend/public/categories.php')
+    ]);
+    const segments = await segRes.json();
+    const categories = await catRes.json();
+
+    const assigned = new Set();
+    segments.forEach(s => (s.categories || []).forEach(c => assigned.add(c.id)));
+    const unassigned = categories.filter(c => !assigned.has(c.id));
+
+    const unassignedWrap = document.getElementById('unassigned');
+    const container = document.getElementById('segment-container');
+    unassignedWrap.innerHTML = '';
+    container.innerHTML = '';
+    unassignedWrap.appendChild(createUnassignedCard(unassigned));
+    segments.forEach(s => container.appendChild(createSegmentCard(s)));
+  }
+
+  function init(){
+    const form = document.getElementById('segment-form');
+    if (form) {
+      form.addEventListener('submit', async e => {
+        e.preventDefault();
+        const name = document.getElementById('segment-name').value;
+        const description = document.getElementById('segment-description').value;
+        await fetch('../php_backend/public/segments.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, description })
+        });
+        document.getElementById('segment-name').value = '';
+        document.getElementById('segment-description').value = '';
+        loadSegments();
+        if (typeof showMessage !== 'undefined') {
+          showMessage('Segment created');
+        }
+      });
+    }
+    loadSegments();
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!-- Page for creating segments and assigning categories -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Manage Segments</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+</head>
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
+            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Segments</h1>
+            <p class="mb-4">Create segments to group categories for broader analysis. Drag categories between segments to adjust their grouping.</p>
+            <form id="segment-form" class="space-y-4">
+                <label class="block">Segment Name<br><input type="text" id="segment-name" class="border p-2 rounded w-full" data-help="Name for the segment"></label>
+                <label class="block">Description<br><textarea id="segment-description" class="border p-2 rounded w-full" data-help="Description for the segment"></textarea></label>
+                <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Segment</button>
+            </form>
+            <div id="segment-layout" class="mt-6 flex items-start gap-4">
+                <div id="unassigned" class="flex-shrink-0"></div>
+                <div id="segment-container" class="flex-1 flex gap-4 overflow-x-auto items-start"></div>
+            </div>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="js/segment_drag.js"></script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `segments.html` for creating segments and organizing categories via drag-and-drop.
- Introduce `segment_drag.js` to fetch segments/categories and update assignments through API calls.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a201a38a34832e897e71a59c805b44