### PR TITLE
Add segment totals and filtering

### DIFF
--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -106,9 +106,10 @@ class Transaction {
         $db = Database::getConnection();
         $ignore = Tag::getIgnoreId();
         $sql = 'SELECT t.`date`, t.`amount`, t.`description`, '
-             . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
+             . 'c.`name` AS category_name, s.`name` AS segment_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
+             . 'LEFT JOIN `segments` s ON c.`segment_id` = s.`id` '
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` '
              . 'WHERE t.`category_id` = :category AND t.`transfer_id` IS NULL'
@@ -125,9 +126,10 @@ class Transaction {
         $db = Database::getConnection();
         $ignore = Tag::getIgnoreId();
         $sql = 'SELECT t.`date`, t.`amount`, t.`description`, '
-             . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
+             . 'c.`name` AS category_name, s.`name` AS segment_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
+             . 'LEFT JOIN `segments` s ON c.`segment_id` = s.`id` '
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` '
              . 'WHERE t.`tag_id` = :tag AND t.`transfer_id` IS NULL'
@@ -144,9 +146,10 @@ class Transaction {
         $db = Database::getConnection();
         $ignore = Tag::getIgnoreId();
         $sql = 'SELECT t.`date`, t.`amount`, t.`description`, '
-             . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
+             . 'c.`name` AS category_name, s.`name` AS segment_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
+             . 'LEFT JOIN `segments` s ON c.`segment_id` = s.`id` '
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` '
              . 'WHERE t.`group_id` = :grp AND t.`transfer_id` IS NULL'
@@ -157,19 +160,20 @@ class Transaction {
     }
 
     /**
-     * Filter transactions by optional category, tag, group, text and date range.
+     * Filter transactions by optional category, tag, group, segment, text and date range.
      */
-    public static function filter(?int $category = null, ?int $tag = null, ?int $group = null, ?string $text = null, ?string $start = null, ?string $end = null): array {
-        if ($category === null && $tag === null && $group === null && $text === null && $start === null && $end === null) {
+    public static function filter(?int $category = null, ?int $tag = null, ?int $group = null, ?int $segment = null, ?string $text = null, ?string $start = null, ?string $end = null): array {
+        if ($category === null && $tag === null && $group === null && $segment === null && $text === null && $start === null && $end === null) {
             return [];
         }
 
         $db = Database::getConnection();
         $ignore = Tag::getIgnoreId();
         $sql = 'SELECT t.`date`, t.`amount`, t.`description`, '
-             . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
+             . 'c.`name` AS category_name, s.`name` AS segment_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
+             . 'LEFT JOIN `segments` s ON c.`segment_id` = s.`id` '
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` '
              . 'WHERE t.`transfer_id` IS NULL'
@@ -187,6 +191,10 @@ class Transaction {
         if ($group !== null) {
             $sql .= ' AND t.`group_id` = :grp';
             $params['grp'] = $group;
+        }
+        if ($segment !== null) {
+            $sql .= ' AND c.`segment_id` = :segment';
+            $params['segment'] = $segment;
         }
         if ($text !== null && $text !== '') {
             $sql .= ' AND (t.`description` LIKE :txt OR t.`memo` LIKE :txt)';
@@ -217,9 +225,10 @@ class Transaction {
         $ignore = Tag::getIgnoreId();
         $sql = 'SELECT t.`id`, t.`account_id`, t.`date`, t.`amount`, t.`description`, t.`memo`, '
              . 't.`category_id`, t.`tag_id`, t.`group_id`, t.`transfer_id`, '
-             . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
+             . 'c.`name` AS category_name, s.`name` AS segment_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
+             . 'LEFT JOIN `segments` s ON c.`segment_id` = s.`id` '
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` '
              . 'WHERE MONTH(t.`date`) = :month AND YEAR(t.`date`) = :year '
@@ -241,9 +250,10 @@ class Transaction {
         $db = Database::getConnection();
         $ignore = Tag::getIgnoreId();
         $sql = 'SELECT t.`id`, t.`date`, t.`amount`, t.`description`, t.`memo`, '
-             . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
+             . 'c.`name` AS category_name, s.`name` AS segment_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
+             . 'LEFT JOIN `segments` s ON c.`segment_id` = s.`id` '
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` '
              . 'WHERE t.`account_id` = :acc '
@@ -263,10 +273,11 @@ class Transaction {
              . 't.`category_id`, t.`tag_id`, t.`group_id`, t.`transfer_id`, t.`ofx_type`, '
              . 't.`ofx_id`, t.`bank_ofx_id`, '
              . 'a.`name` AS account_name, a.`sort_code`, a.`account_number`, '
-             . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
+             . 'c.`name` AS category_name, s.`name` AS segment_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `accounts` a ON t.`account_id` = a.`id` '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
+             . 'LEFT JOIN `segments` s ON c.`segment_id` = s.`id` '
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` '
              . 'WHERE t.`id` = :id LIMIT 1';
@@ -463,6 +474,34 @@ class Transaction {
     }
 
     /**
+     * Retrieve total amounts by segment for a given month.
+     * Returns segment name with positive and negative totals ordered by total descending.
+     */
+    public static function getSegmentTotalsByMonth(int $month, int $year): array {
+        $db = Database::getConnection();
+
+        $dayCases = [];
+        for ($d = 1; $d <= 31; $d++) {
+            $dayCases[] = "SUM(CASE WHEN DAY(t.`date`) = $d THEN t.`amount` ELSE 0 END) AS `$d`";
+        }
+
+        $ignore = Tag::getIgnoreId();
+        $sql = 'SELECT COALESCE(s.`name`, \'Not Segmented\') AS `name`, '
+             . implode(', ', $dayCases)
+             . ', SUM(t.`amount`) AS `total`'
+             . ' FROM `transactions` t'
+             . ' LEFT JOIN `categories` c ON t.`category_id` = c.`id`'
+             . ' LEFT JOIN `segments` s ON c.`segment_id` = s.`id`'
+             . ' WHERE MONTH(t.`date`) = :month AND YEAR(t.`date`) = :year AND t.`transfer_id` IS NULL AND (t.`tag_id` IS NULL OR t.`tag_id` != :ignore)'
+             . ' GROUP BY `name`'
+             . ' ORDER BY `total` DESC';
+
+        $stmt = $db->prepare($sql);
+        $stmt->execute(['month' => $month, 'year' => $year, 'ignore' => $ignore]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
 
      * Retrieve total amounts by tag for a given year.
      * Returns tag name with totals including both positive and negative values ordered by total descending.
@@ -546,6 +585,34 @@ class Transaction {
     }
 
     /**
+     * Retrieve total amounts by segment for a given year.
+     * Returns segment name with positive and negative totals ordered by total descending.
+     */
+    public static function getSegmentTotalsByYear(int $year): array {
+        $db = Database::getConnection();
+
+        $monthCases = [];
+        for ($m = 1; $m <= 12; $m++) {
+            $monthCases[] = "SUM(CASE WHEN MONTH(t.`date`) = $m THEN t.`amount` ELSE 0 END) AS `$m`";
+        }
+
+        $ignore = Tag::getIgnoreId();
+        $sql = 'SELECT COALESCE(s.`name`, \'Not Segmented\') AS `name`, '
+             . implode(', ', $monthCases)
+             . ', SUM(t.`amount`) AS `total`'
+             . ' FROM `transactions` t'
+             . ' LEFT JOIN `categories` c ON t.`category_id` = c.`id`'
+             . ' LEFT JOIN `segments` s ON c.`segment_id` = s.`id`'
+             . ' WHERE YEAR(t.`date`) = :year AND t.`transfer_id` IS NULL AND (t.`tag_id` IS NULL OR t.`tag_id` != :ignore)'
+             . ' GROUP BY `name`'
+             . ' ORDER BY `total` DESC';
+
+        $stmt = $db->prepare($sql);
+        $stmt->execute(['year' => $year, 'ignore' => $ignore]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
      * Retrieve tag totals across multiple years.
      */
     public static function getTagTotalsByYears(array $years): array {
@@ -622,6 +689,32 @@ class Transaction {
     }
 
     /**
+     * Retrieve segment totals across multiple years.
+     */
+    public static function getSegmentTotalsByYears(array $years): array {
+        if (empty($years)) { return []; }
+        $db = Database::getConnection();
+        $yearCases = [];
+        foreach ($years as $y) {
+            $y = (int)$y;
+            $yearCases[] = "SUM(CASE WHEN YEAR(t.`date`) = $y THEN t.`amount` ELSE 0 END) AS `$y`";
+        }
+        $ignore = Tag::getIgnoreId();
+        $sql = 'SELECT COALESCE(s.`name`, \'Not Segmented\') AS `name`, '
+             . implode(', ', $yearCases)
+             . ', SUM(t.`amount`) AS `total`'
+             . ' FROM `transactions` t'
+             . ' LEFT JOIN `categories` c ON t.`category_id` = c.`id`'
+             . ' LEFT JOIN `segments` s ON c.`segment_id` = s.`id`'
+             . ' WHERE t.`transfer_id` IS NULL AND (t.`tag_id` IS NULL OR t.`tag_id` != :ignore)'
+             . ' GROUP BY `name`'
+             . ' ORDER BY `total` DESC';
+        $stmt = $db->prepare($sql);
+        $stmt->execute(['ignore' => $ignore]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
      * Search transactions across fields.
      * Supports partial matches for text fields and exact matches for numeric fields.
      */
@@ -629,9 +722,10 @@ class Transaction {
         $db = Database::getConnection();
 
         $sql = 'SELECT t.`id`, t.`account_id`, t.`date`, t.`amount`, t.`description`, t.`memo`, t.`transfer_id`, '
-             . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name '
+             . 'c.`name` AS category_name, s.`name` AS segment_name, tg.`name` AS tag_name, g.`name` AS group_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '
+             . 'LEFT JOIN `segments` s ON c.`segment_id` = s.`id` '
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id`';
 
@@ -644,6 +738,7 @@ class Transaction {
                 . ' OR t.`date` LIKE :val'
                 . ' OR t.`ofx_id` LIKE :val'
                 . ' OR c.`name` LIKE :val'
+                . ' OR s.`name` LIKE :val'
                 . ' OR tg.`name` LIKE :val'
                 . ' OR g.`name` LIKE :val)';
             $params['val'] = '%' . $value . '%';
@@ -652,6 +747,7 @@ class Transaction {
                 $conditions[] = '(t.`id` = :num'
                     . ' OR t.`account_id` = :num'
                     . ' OR t.`category_id` = :num'
+                    . ' OR c.`segment_id` = :num'
                     . ' OR t.`tag_id` = :num'
                     . ' OR t.`group_id` = :num'
                     . ' OR t.`amount` = :num)';


### PR DESCRIPTION
## Summary
- support segment-based transaction queries with new `getSegmentTotalsByMonth`, `getSegmentTotalsByYear`, and `getSegmentTotalsByYears` helpers
- extend transaction filter and retrieval queries to join `segments` and expose `segment_name`

## Testing
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_68a201a14e6c832eb556c1dd0df0eee4