### PR TITLE
Add segment support to dashboard APIs and report filtering

### DIFF
--- a/php_backend/public/all_years_dashboard.php
+++ b/php_backend/public/all_years_dashboard.php
@@ -1,5 +1,5 @@
 <?php
-// API endpoint returning totals across all available years for tags, categories, and groups.
+// API endpoint returning totals across all available years for segments, tags, categories, and groups.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
@@ -8,11 +8,13 @@ header('Content-Type: application/json');
 
 try {
     $years = Transaction::getAvailableYears();
+    $segments = Transaction::getSegmentTotalsByYears($years);
     $tags = Transaction::getTagTotalsByYears($years);
     $categories = Transaction::getCategoryTotalsByYears($years);
     $groups = Transaction::getGroupTotalsByYears($years);
     echo json_encode([
         'years' => $years,
+        'segments' => $segments,
         'tags' => $tags,
         'categories' => $categories,
         'groups' => $groups

--- a/php_backend/public/monthly_dashboard.php
+++ b/php_backend/public/monthly_dashboard.php
@@ -1,5 +1,5 @@
 <?php
-// API endpoint returning monthly totals for tags, categories, groups and income/outgoings.
+// API endpoint returning monthly totals for segments, tags, categories, groups and income/outgoings.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
@@ -11,11 +11,13 @@ $month = isset($_GET['month']) ? (int)$_GET['month'] : date('n');
 
 try {
     $totals = Transaction::getMonthlyTotals($month, $year);
+    $segments = Transaction::getSegmentTotalsByMonth($month, $year);
     $tags = Transaction::getTagTotalsByMonth($month, $year);
     $categories = Transaction::getCategoryTotalsByMonth($month, $year);
     $groups = Transaction::getGroupTotalsByMonth($month, $year);
     echo json_encode([
         'totals' => $totals,
+        'segments' => $segments,
         'tags' => $tags,
         'categories' => $categories,
         'groups' => $groups

--- a/php_backend/public/report.php
+++ b/php_backend/public/report.php
@@ -9,9 +9,10 @@ header('Content-Type: application/json');
 $category = isset($_GET['category']) ? (int)$_GET['category'] : null;
 $tag = isset($_GET['tag']) ? (int)$_GET['tag'] : null;
 $group = isset($_GET['group']) ? (int)$_GET['group'] : null;
+$segment = isset($_GET['segment']) ? (int)$_GET['segment'] : null;
 $text = isset($_GET['text']) ? trim($_GET['text']) : null;
 $start = isset($_GET['start']) ? $_GET['start'] : null;
 $end = isset($_GET['end']) ? $_GET['end'] : null;
 
-echo json_encode(Transaction::filter($category, $tag, $group, $text, $start, $end));
+echo json_encode(Transaction::filter($category, $tag, $group, $segment, $text, $start, $end));
 ?>

--- a/php_backend/public/yearly_dashboard.php
+++ b/php_backend/public/yearly_dashboard.php
@@ -1,5 +1,5 @@
 <?php
-// API endpoint returning yearly totals for tags, categories, and groups.
+// API endpoint returning yearly totals for segments, tags, categories, and groups.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
@@ -9,10 +9,12 @@ header('Content-Type: application/json');
 $year = isset($_GET['year']) ? (int)$_GET['year'] : date('Y');
 
 try {
+    $segments = Transaction::getSegmentTotalsByYear($year);
     $tags = Transaction::getTagTotalsByYear($year);
     $categories = Transaction::getCategoryTotalsByYear($year);
     $groups = Transaction::getGroupTotalsByYear($year);
     echo json_encode([
+        'segments' => $segments,
         'tags' => $tags,
         'categories' => $categories,
         'groups' => $groups


### PR DESCRIPTION
## Summary
- include segment totals in monthly, yearly, and all-years dashboards
- allow report endpoint to filter by segment

## Testing
- `php -l php_backend/public/monthly_dashboard.php`
- `php -l php_backend/public/yearly_dashboard.php`
- `php -l php_backend/public/all_years_dashboard.php`
- `php -l php_backend/public/report.php`


------
https://chatgpt.com/codex/tasks/task_e_68a201a20310832e9306ab90bf91ea30