### PR TITLE
Add Manage Segments link to Data Organisation menu

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -58,8 +58,9 @@
         </li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="categories.html"><i class="fa-solid fa-folder-open text-indigo-600 mr-1"></i> Manage Categories</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="groups.html"><i class="fa-solid fa-users text-indigo-600 mr-1"></i> Manage Groups</a></li>
-    </ul>
-  </div>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="segments.html"><i class="fa-solid fa-layer-group text-indigo-600 mr-1"></i> Manage Segments</a></li>
+      </ul>
+    </div>
 
   <div>
     <h3 class="text-lg font-semibold text-gray-700 mb-2">Admin Tools</h3>


### PR DESCRIPTION
## Summary
- add menu link for managing segments under Data Organisation

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a201a55384832eb5a4c9523e4cc2ae