### PR TITLE
Add segment support for categories

### DIFF
--- a/php_backend/models/Category.php
+++ b/php_backend/models/Category.php
@@ -6,20 +6,20 @@ class Category {
     /**
      * Insert a new category and return its ID.
      */
-    public static function create(string $name, ?string $description = null): int {
+    public static function create(string $name, ?string $description = null, ?int $segmentId = null): int {
         $db = Database::getConnection();
-        $stmt = $db->prepare('INSERT INTO categories (name, description) VALUES (:name, :description)');
-        $stmt->execute(['name' => $name, 'description' => $description]);
+        $stmt = $db->prepare('INSERT INTO categories (name, description, segment_id) VALUES (:name, :description, :segment_id)');
+        $stmt->execute(['name' => $name, 'description' => $description, 'segment_id' => $segmentId]);
         return (int)$db->lastInsertId();
     }
 
     /**
-     * Update the name and description of an existing category.
+     * Update the name, description and segment of an existing category.
      */
-    public static function update(int $id, string $name, ?string $description = null): void {
+    public static function update(int $id, string $name, ?string $description = null, ?int $segmentId = null): void {
         $db = Database::getConnection();
-        $stmt = $db->prepare('UPDATE categories SET name = :name, description = :description WHERE id = :id');
-        $stmt->execute(['id' => $id, 'name' => $name, 'description' => $description]);
+        $stmt = $db->prepare('UPDATE categories SET name = :name, description = :description, segment_id = :segment_id WHERE id = :id');
+        $stmt->execute(['id' => $id, 'name' => $name, 'description' => $description, 'segment_id' => $segmentId]);
     }
 
     /**
@@ -28,8 +28,10 @@ class Category {
     public static function allWithTags(): array {
         $db = Database::getConnection();
         $sql = 'SELECT c.id AS category_id, c.name AS category_name, c.description AS category_description, '
+             . 'c.segment_id AS segment_id, s.name AS segment_name, '
              . 't.id AS tag_id, t.name AS tag_name '
              . 'FROM categories c '
+             . 'LEFT JOIN segments s ON c.segment_id = s.id '
              . 'LEFT JOIN category_tags ct ON c.id = ct.category_id '
              . 'LEFT JOIN tags t ON t.id = ct.tag_id '
              . 'ORDER BY c.id';
@@ -44,6 +46,8 @@ class Category {
                     'id' => $id,
                     'name' => $row['category_name'],
                     'description' => $row['category_description'],
+                    'segment_id' => $row['segment_id'] !== null ? (int)$row['segment_id'] : null,
+                    'segment_name' => $row['segment_name'],
                     'tags' => []
                 ];
             }

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -29,12 +29,13 @@ try {
             case 'create':
                 $name = trim($data['name'] ?? '');
                 $description = $data['description'] ?? null;
+                $segmentId = isset($data['segment_id']) ? (int)$data['segment_id'] : null;
                 if ($name === '') {
                     http_response_code(400);
                     echo json_encode(['error' => 'Name required']);
                     return;
                 }
-                $id = Category::create($name, $description);
+                $id = Category::create($name, $description, $segmentId);
                 Log::write("Created category $name");
                 echo json_encode(['id' => $id]);
                 break;
@@ -90,12 +91,13 @@ try {
         $id = (int)($data['id'] ?? 0);
         $name = trim($data['name'] ?? '');
         $description = $data['description'] ?? null;
+        $segmentId = isset($data['segment_id']) ? (int)$data['segment_id'] : null;
         if ($id <= 0 || $name === '') {
             http_response_code(400);
             echo json_encode(['error' => 'ID and name required']);
             return;
         }
-        Category::update($id, $name, $description);
+        Category::update($id, $name, $description, $segmentId);
         Log::write("Updated category $id");
         echo json_encode(['status' => 'ok']);
     } else {

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -10,7 +10,8 @@ $db = Database::getConnection();
 // Create minimal schema used by the models under test.
 $db->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);');
 $db->exec('CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, keyword TEXT, description TEXT);');
-$db->exec('CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT);');
+$db->exec('CREATE TABLE segments (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);');
+$db->exec('CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, segment_id INTEGER);');
 $db->exec('CREATE TABLE category_tags (category_id INTEGER, tag_id INTEGER);');
 $db->exec('CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTOINCREMENT, description TEXT, account_id INTEGER, tag_id INTEGER, category_id INTEGER);');
 $db->exec('CREATE TABLE budgets (id INTEGER PRIMARY KEY AUTOINCREMENT, category_id INTEGER, amount REAL);');
@@ -75,13 +76,17 @@ $txTag = $db->query('SELECT tag_id FROM transactions WHERE id = 1')->fetchColumn
 assertEqual($tagId, (int)$txTag, 'Transaction tagged correctly');
 
 // --- Category tests ---
-$catId = Category::create('Essentials', 'Essential spend');
+$db->exec("INSERT INTO segments (name) VALUES ('Living')");
+$segmentId = (int)$db->lastInsertId();
+$catId = Category::create('Essentials', 'Essential spend', $segmentId);
 $db->exec("INSERT INTO category_tags (category_id, tag_id) VALUES ($catId, $tagId)");
 $cats = Category::allWithTags();
 assertEqual('Essentials', $cats[0]['name'] ?? null, 'Category retrieved with tag');
 assertEqual($tagId, $cats[0]['tags'][0]['id'] ?? null, 'Category has associated tag');
+assertEqual($segmentId, $cats[0]['segment_id'] ?? null, 'Category segment id stored');
+assertEqual('Living', $cats[0]['segment_name'] ?? null, 'Category segment name retrieved');
 
-Category::update($catId, 'Essentials Updated', 'Updated desc');
+Category::update($catId, 'Essentials Updated', 'Updated desc', $segmentId);
 $cats = Category::allWithTags();
 assertEqual('Essentials Updated', $cats[0]['name'] ?? null, 'Category updated');
 


### PR DESCRIPTION
## Summary
- allow categories to be created and updated with an optional `segment_id`
- return `segment_id` and `segment_name` when listing categories
- support segment IDs in categories API and tests

## Testing
- `php -l php_backend/models/Category.php`
- `php -l php_backend/public/categories.php`
- `php -l tests/run_tests.php`
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a2019d1ea0832e9ba1874ce2b58e0d