### PR TITLE
Add segment reporting and dashboards

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -34,6 +34,10 @@
                 <div id="category-tag-outgoings" style="height:400px"></div>
             </div>
 
+            <h2 class="text-xl font-semibold mt-6 mb-2">Segment Totals</h2>
+            <div id="segments-table" class="mt-2"></div>
+            <div id="segments-chart" class="mt-4" style="height:400px"></div>
+
             <h2 class="text-xl font-semibold mt-6 mb-2">Group Totals</h2>
             <div id="groups-table" class="mt-2"></div>
             <div id="groups-chart" class="mt-4" style="height:400px"></div>
@@ -170,6 +174,8 @@
                 buildTable('categories-table', data.categories, data.years, 'bg-green-200 text-green-800');
                 buildChart('categories-chart', 'Category Totals', data.categories);
                 buildDonutCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
+                buildTable('segments-table', data.segments, data.years, 'bg-yellow-200 text-yellow-800');
+                buildChart('segments-chart', 'Segment Totals', data.segments);
                 buildTable('groups-table', data.groups, data.years, 'bg-purple-200 text-purple-800');
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -8,6 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Graphs</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
     <div class="flex min-h-screen">
@@ -23,12 +24,19 @@
             <div class="bg-white p-6 rounded shadow"><div id="pie-chart" style="height:400px"></div></div>
             <div class="bg-white p-6 rounded shadow"><div id="tag-chart" style="height:400px"></div></div>
             <div class="bg-white p-6 rounded shadow"><div id="scatter-chart" style="height:400px"></div></div>
+            <div class="bg-white p-6 rounded shadow space-y-4">
+                <h2 class="text-xl font-semibold">Segment Totals</h2>
+                <div id="segment-table"></div>
+                <div id="segment-chart" style="height:400px"></div>
+            </div>
         </main>
     </div>
 
     <script src="js/menu.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/highcharts-3d.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
     <script>
 
     // Retrieve data for the chosen year and draw charts with 3D bars where applicable
@@ -147,7 +155,40 @@
                 series: [{ name: 'Spending', data: totals.map((v, i) => [i, v]), colorByPoint: true }]
 
             });
+
+            if (yearly.segments) {
+                renderSegments(yearly.segments);
+            }
         }).catch(err => console.error('Graph data load failed', err));
+    }
+
+    function renderSegments(segments){
+        const tableEl = document.getElementById('segment-table');
+        tableEl.innerHTML = '';
+        tailwindTabulator(tableEl, {
+            data: segments,
+            layout: 'fitDataStretch',
+            columns: [
+                { title: 'Name', field: 'name', formatter: function(cell){
+                    const value = cell.getValue();
+                    const badge = createBadge(value, 'bg-yellow-200 text-yellow-800');
+                    const link = document.createElement('a');
+                    link.href = `search.html?value=${encodeURIComponent(value)}`;
+                    link.appendChild(badge);
+                    return link;
+                } },
+                { title: 'Total', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: 'sum', bottomCalcFormatter: 'money', bottomCalcFormatterParams: { symbol: '£', precision: 2 } }
+            ]
+        });
+        Highcharts.chart('segment-chart', {
+            colors: gradientColors,
+            chart: { type: 'column' },
+            title: { text: 'Segment Totals' },
+            xAxis: { categories: segments.map(s => s.name) },
+            yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            series: [{ name: 'Total', data: segments.map(s => parseFloat(s.total)), colorByPoint: true }]
+        });
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -55,6 +55,10 @@
                 <div id="category-tag-outgoings" style="height:400px"></div>
             </div>
 
+            <h2 class="text-xl font-semibold mt-6 mb-2">Segment Totals</h2>
+            <div id="segments-table" class="mt-2"></div>
+            <div id="segments-chart" class="mt-4" style="height:400px"></div>
+
             <h2 class="text-xl font-semibold mt-6 mb-2">Group Totals</h2>
             <div id="groups-table" class="mt-2"></div>
             <div id="groups-chart" class="mt-4" style="height:400px"></div>
@@ -202,6 +206,8 @@
                 buildTable('categories-table', data.categories, days, 'bg-green-200 text-green-800');
                 buildChart('categories-chart', 'Category Totals', data.categories);
                 buildDonutCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
+                buildTable('segments-table', data.segments, days, 'bg-yellow-200 text-yellow-800');
+                buildChart('segments-chart', 'Segment Totals', data.segments);
                 buildTable('groups-table', data.groups, days, 'bg-purple-200 text-purple-800');
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -23,6 +23,7 @@
                 <label class="block">Category: <select id="category" class="border p-2 rounded w-full" data-help="Filter by category"></select></label>
                 <label class="block">Tag: <select id="tag" class="border p-2 rounded w-full" data-help="Filter by tag"></select></label>
                 <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Filter by group"></select></label>
+                <label class="block">Segment: <select id="segment" class="border p-2 rounded w-full" data-help="Filter by segment"></select></label>
                 <label class="block">Text: <input type="text" id="text" class="border p-2 rounded w-full" data-help="Filter by description text"></label>
                 <label class="block">Start Date: <input type="date" id="start" class="border p-2 rounded w-full" data-help="Start date for report"></label>
                 <label class="block">End Date: <input type="date" id="end" class="border p-2 rounded w-full" data-help="End date for report"></label>
@@ -49,17 +50,20 @@
 
     // Load filter options for categories, tags and groups
     async function loadOptions() {
-        const [catRes, tagRes, grpRes] = await Promise.all([
+        const [catRes, tagRes, grpRes, segRes] = await Promise.all([
             fetch('../php_backend/public/categories.php'),
             fetch('../php_backend/public/tags.php'),
-            fetch('../php_backend/public/groups.php')
+            fetch('../php_backend/public/groups.php'),
+            fetch('../php_backend/public/segments.php')
         ]);
         const categories = await catRes.json();
         const tags = await tagRes.json();
         const groups = await grpRes.json();
+        const segments = await segRes.json();
         const catSelect = document.getElementById('category');
         const tagSelect = document.getElementById('tag');
         const groupSelect = document.getElementById('group');
+        const segmentSelect = document.getElementById('segment');
         catSelect.innerHTML = '<option value="">All</option>';
         categories.forEach(c => {
             const opt = document.createElement('option');
@@ -80,6 +84,13 @@
             opt.value = g.id;
             opt.textContent = g.name;
             groupSelect.appendChild(opt);
+        });
+        segmentSelect.innerHTML = '<option value="">All</option>';
+        segments.forEach(s => {
+            const opt = document.createElement('option');
+            opt.value = s.id;
+            opt.textContent = s.name;
+            segmentSelect.appendChild(opt);
         });
     }
 
@@ -102,6 +113,7 @@
         const category = document.getElementById('category').value;
         const tag = document.getElementById('tag').value;
         const group = document.getElementById('group').value;
+        const segment = document.getElementById('segment').value;
         const text = document.getElementById('text').value;
         const start = document.getElementById('start').value;
         const end = document.getElementById('end').value;
@@ -109,6 +121,7 @@
         if (category) params.append('category', category);
         if (tag) params.append('tag', tag);
         if (group) params.append('group', group);
+        if (segment) params.append('segment', segment);
         if (text) params.append('text', text);
         if (start) params.append('start', start);
         if (end) params.append('end', end);
@@ -129,6 +142,7 @@
                             { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
                             { title: 'Tag', field: 'tag_name', formatter: badgeFormatter('bg-indigo-200 text-indigo-800') },
                             { title: 'Group', field: 'group_name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
+                            { title: 'Segment', field: 'segment_name', formatter: badgeFormatter('bg-yellow-200 text-yellow-800') },
                             { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: function(values) { var total = 0; values.forEach(function(value) { total += parseFloat(value) || 0; }); return total; }, bottomCalcFormatter: 'money', bottomCalcFormatterParams: { symbol: '£', precision: 2 } }
                         ]
                     });
@@ -161,6 +175,7 @@
             category: document.getElementById('category').value,
             tag: document.getElementById('tag').value,
             group: document.getElementById('group').value,
+            segment: document.getElementById('segment').value,
             text: document.getElementById('text').value,
             start: document.getElementById('start').value,
             end: document.getElementById('end').value
@@ -179,6 +194,7 @@
         document.getElementById('category').value = r.category || '';
         document.getElementById('tag').value = r.tag || '';
         document.getElementById('group').value = r.group || '';
+        document.getElementById('segment').value = r.segment || '';
         document.getElementById('text').value = r.text || '';
         document.getElementById('start').value = r.start || '';
         document.getElementById('end').value = r.end || '';

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -37,6 +37,10 @@
                 <div id="category-tag-outgoings" style="height:400px"></div>
             </div>
 
+            <h2 class="text-xl font-semibold mt-6 mb-2">Segment Totals</h2>
+            <div id="segments-table" class="mt-2"></div>
+            <div id="segments-chart" class="mt-4" style="height:400px"></div>
+
             <h2 class="text-xl font-semibold mt-6 mb-2">Group Totals</h2>
             <div id="groups-table" class="mt-2"></div>
             <div id="groups-chart" class="mt-4" style="height:400px"></div>
@@ -175,6 +179,8 @@
                 buildTable('categories-table', data.categories, 'bg-green-200 text-green-800');
                 buildChart('categories-chart', 'Category Totals ' + year, data.categories);
                 buildDonutCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
+                buildTable('segments-table', data.segments, 'bg-yellow-200 text-yellow-800');
+                buildChart('segments-chart', 'Segment Totals ' + year, data.segments);
                 buildTable('groups-table', data.groups, 'bg-purple-200 text-purple-800');
                 buildChart('groups-chart', 'Group Totals ' + year, data.groups);
             });

--- a/php_backend/models/Segment.php
+++ b/php_backend/models/Segment.php
@@ -1,0 +1,15 @@
+<?php
+// Model for retrieving transaction segments.
+require_once __DIR__ . '/../Database.php';
+
+class Segment {
+    /**
+     * Return all segments with id, name, and description.
+     */
+    public static function all(): array {
+        $db = Database::getConnection();
+        $stmt = $db->query('SELECT `id`, `name`, `description` FROM `segments`');
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+?>

--- a/php_backend/public/all_years_dashboard.php
+++ b/php_backend/public/all_years_dashboard.php
@@ -11,11 +11,13 @@ try {
     $tags = Transaction::getTagTotalsByYears($years);
     $categories = Transaction::getCategoryTotalsByYears($years);
     $groups = Transaction::getGroupTotalsByYears($years);
+    $segments = Transaction::getSegmentTotalsByYears($years);
     echo json_encode([
         'years' => $years,
         'tags' => $tags,
         'categories' => $categories,
-        'groups' => $groups
+        'groups' => $groups,
+        'segments' => $segments
     ]);
 } catch (Exception $e) {
     http_response_code(500);

--- a/php_backend/public/monthly_dashboard.php
+++ b/php_backend/public/monthly_dashboard.php
@@ -14,11 +14,13 @@ try {
     $tags = Transaction::getTagTotalsByMonth($month, $year);
     $categories = Transaction::getCategoryTotalsByMonth($month, $year);
     $groups = Transaction::getGroupTotalsByMonth($month, $year);
+    $segments = Transaction::getSegmentTotalsByMonth($month, $year);
     echo json_encode([
         'totals' => $totals,
         'tags' => $tags,
         'categories' => $categories,
-        'groups' => $groups
+        'groups' => $groups,
+        'segments' => $segments
     ]);
 } catch (Exception $e) {
     http_response_code(500);

--- a/php_backend/public/report.php
+++ b/php_backend/public/report.php
@@ -9,9 +9,10 @@ header('Content-Type: application/json');
 $category = isset($_GET['category']) ? (int)$_GET['category'] : null;
 $tag = isset($_GET['tag']) ? (int)$_GET['tag'] : null;
 $group = isset($_GET['group']) ? (int)$_GET['group'] : null;
+$segment = isset($_GET['segment']) ? (int)$_GET['segment'] : null;
 $text = isset($_GET['text']) ? trim($_GET['text']) : null;
 $start = isset($_GET['start']) ? $_GET['start'] : null;
 $end = isset($_GET['end']) ? $_GET['end'] : null;
 
-echo json_encode(Transaction::filter($category, $tag, $group, $text, $start, $end));
+echo json_encode(Transaction::filter($category, $tag, $group, $segment, $text, $start, $end));
 ?>

--- a/php_backend/public/segments.php
+++ b/php_backend/public/segments.php
@@ -1,0 +1,16 @@
+<?php
+// API endpoint returning all segments.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Segment.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+try {
+    echo json_encode(Segment::all());
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Segment error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode([]);
+}
+?>

--- a/php_backend/public/yearly_dashboard.php
+++ b/php_backend/public/yearly_dashboard.php
@@ -12,10 +12,12 @@ try {
     $tags = Transaction::getTagTotalsByYear($year);
     $categories = Transaction::getCategoryTotalsByYear($year);
     $groups = Transaction::getGroupTotalsByYear($year);
+    $segments = Transaction::getSegmentTotalsByYear($year);
     echo json_encode([
         'tags' => $tags,
         'categories' => $categories,
-        'groups' => $groups
+        'groups' => $groups,
+        'segments' => $segments
     ]);
 } catch (Exception $e) {
     http_response_code(500);


### PR DESCRIPTION
## Summary
- Extend yearly, monthly, and all-years dashboards plus graphs page to display segment tables and charts.
- Add segment filter to transaction reports and support saving/loading with segment selections.
- Implement segment-aware report backend, model utilities, and new segments API.

## Testing
- `php -l php_backend/public/report.php`
- `php -l php_backend/public/monthly_dashboard.php`
- `php -l php_backend/public/yearly_dashboard.php`
- `php -l php_backend/public/all_years_dashboard.php`
- `php -l php_backend/public/segments.php`
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/models/Segment.php`


------
https://chatgpt.com/codex/tasks/task_e_68a201a5ad0c832e9d4fe450b9f6b6e4