### PR TITLE
Add segments management API and models

### DIFF
--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -14,6 +14,8 @@ DROP TABLE IF EXISTS transaction_groups;
 DROP TABLE IF EXISTS category_tags;
 DROP TABLE IF EXISTS tags;
 DROP TABLE IF EXISTS budgets;
+DROP TABLE IF EXISTS segment_categories;
+DROP TABLE IF EXISTS segments;
 DROP TABLE IF EXISTS categories;
 DROP TABLE IF EXISTS accounts;
 SQL;
@@ -49,6 +51,20 @@ CREATE TABLE IF NOT EXISTS budgets (
     year INT NOT NULL,
     amount DECIMAL(10,2) NOT NULL,
     UNIQUE KEY unique_budget (category_id, month, year),
+    FOREIGN KEY (category_id) REFERENCES categories(id)
+);
+
+CREATE TABLE IF NOT EXISTS segments (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT DEFAULT NULL
+);
+
+CREATE TABLE IF NOT EXISTS segment_categories (
+    segment_id INT NOT NULL,
+    category_id INT NOT NULL,
+    PRIMARY KEY (segment_id, category_id),
+    FOREIGN KEY (segment_id) REFERENCES segments(id),
     FOREIGN KEY (category_id) REFERENCES categories(id)
 );
 

--- a/php_backend/models/Segment.php
+++ b/php_backend/models/Segment.php
@@ -1,0 +1,80 @@
+<?php
+// Model handling segment records and their category mappings.
+require_once __DIR__ . '/../Database.php';
+
+class Segment {
+    /**
+     * Insert a new segment and return its ID.
+     */
+    public static function create(string $name, ?string $description = null): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT INTO segments (name, description) VALUES (:name, :description)');
+        $stmt->execute(['name' => $name, 'description' => $description]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Update the name and description of an existing segment.
+     */
+    public static function update(int $id, string $name, ?string $description = null): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE segments SET name = :name, description = :description WHERE id = :id');
+        $stmt->execute(['id' => $id, 'name' => $name, 'description' => $description]);
+    }
+
+    /**
+     * Retrieve all segments and their associated categories.
+     */
+    public static function allWithCategories(): array {
+        $db = Database::getConnection();
+        $sql = 'SELECT s.id AS segment_id, s.name AS segment_name, s.description AS segment_description, '
+             . 'c.id AS category_id, c.name AS category_name '
+             . 'FROM segments s '
+             . 'LEFT JOIN segment_categories sc ON s.id = sc.segment_id '
+             . 'LEFT JOIN categories c ON c.id = sc.category_id '
+             . 'ORDER BY s.id';
+        $stmt = $db->query($sql);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        $segments = [];
+        foreach ($rows as $row) {
+            $id = (int)$row['segment_id'];
+            if (!isset($segments[$id])) {
+                $segments[$id] = [
+                    'id' => $id,
+                    'name' => $row['segment_name'],
+                    'description' => $row['segment_description'],
+                    'categories' => []
+                ];
+            }
+            if ($row['category_id'] !== null) {
+                $segments[$id]['categories'][] = [
+                    'id' => (int)$row['category_id'],
+                    'name' => $row['category_name']
+                ];
+            }
+        }
+        return array_values($segments);
+    }
+
+    /**
+     * Delete a segment and remove all category mappings to it.
+     */
+    public static function delete(int $id): void {
+        $db = Database::getConnection();
+        $db->beginTransaction();
+        try {
+            $stmt = $db->prepare('DELETE FROM segment_categories WHERE segment_id = :id');
+            $stmt->execute(['id' => $id]);
+
+            $stmt = $db->prepare('DELETE FROM segments WHERE id = :id');
+            $stmt->execute(['id' => $id]);
+
+            $db->commit();
+        } catch (Exception $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+}
+?>

--- a/php_backend/models/SegmentCategory.php
+++ b/php_backend/models/SegmentCategory.php
@@ -1,0 +1,49 @@
+<?php
+// Links segments and categories ensuring each category belongs to at most one segment.
+require_once __DIR__ . '/../Database.php';
+
+class SegmentCategory {
+    /**
+     * Link a category to a segment, ensuring it isn't already assigned.
+     */
+    public static function add(int $segmentId, int $categoryId): void {
+        $db = Database::getConnection();
+        $check = $db->prepare('SELECT 1 FROM segment_categories WHERE category_id = :category');
+        $check->execute(['category' => $categoryId]);
+        if ($check->fetch()) {
+            throw new Exception('Category is already assigned to a segment');
+        }
+        $stmt = $db->prepare('INSERT INTO segment_categories (segment_id, category_id) VALUES (:segment, :category)');
+        $stmt->execute(['segment' => $segmentId, 'category' => $categoryId]);
+    }
+
+    /**
+     * Remove the association between a segment and a category.
+     */
+    public static function remove(int $segmentId, int $categoryId): void {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('DELETE FROM segment_categories WHERE segment_id = :segment AND category_id = :category');
+        $stmt->execute(['segment' => $segmentId, 'category' => $categoryId]);
+    }
+
+    /**
+     * Move a category from one segment to another atomically.
+     */
+    public static function move(int $oldSegmentId, int $newSegmentId, int $categoryId): void {
+        $db = Database::getConnection();
+        $db->beginTransaction();
+        try {
+            $del = $db->prepare('DELETE FROM segment_categories WHERE segment_id = :old AND category_id = :category');
+            $del->execute(['old' => $oldSegmentId, 'category' => $categoryId]);
+
+            $ins = $db->prepare('INSERT INTO segment_categories (segment_id, category_id) VALUES (:new, :category)');
+            $ins->execute(['new' => $newSegmentId, 'category' => $categoryId]);
+
+            $db->commit();
+        } catch (Exception $e) {
+            $db->rollBack();
+            throw $e;
+        }
+    }
+}
+?>

--- a/php_backend/public/segments.php
+++ b/php_backend/public/segments.php
@@ -1,0 +1,110 @@
+<?php
+// API endpoint for managing segments and their category assignments.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Segment.php';
+require_once __DIR__ . '/../models/SegmentCategory.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    try {
+        echo json_encode(Segment::allWithCategories());
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Segment error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode([]);
+    }
+    return;
+}
+
+$data = json_decode(file_get_contents('php://input'), true) ?? [];
+$action = $data['action'] ?? null;
+
+try {
+    if ($method === 'POST') {
+        switch ($action) {
+            case null:
+            case 'create':
+                $name = trim($data['name'] ?? '');
+                $description = $data['description'] ?? null;
+                if ($name === '') {
+                    http_response_code(400);
+                    echo json_encode(['error' => 'Name required']);
+                    return;
+                }
+                $id = Segment::create($name, $description);
+                Log::write("Created segment $name");
+                echo json_encode(['id' => $id]);
+                break;
+            case 'add_category':
+                $segmentId = (int)($data['segment_id'] ?? 0);
+                $categoryId = (int)($data['category_id'] ?? 0);
+                try {
+                    SegmentCategory::add($segmentId, $categoryId);
+                    Log::write("Added category $categoryId to segment $segmentId");
+                    echo json_encode(['status' => 'ok']);
+                } catch (Exception $e) {
+                    http_response_code(400);
+                    Log::write('Add category error: ' . $e->getMessage(), 'ERROR');
+                    echo json_encode(['error' => $e->getMessage()]);
+                }
+                break;
+            case 'remove_category':
+                $segmentId = (int)($data['segment_id'] ?? 0);
+                $categoryId = (int)($data['category_id'] ?? 0);
+                SegmentCategory::remove($segmentId, $categoryId);
+                Log::write("Removed category $categoryId from segment $segmentId");
+                echo json_encode(['status' => 'ok']);
+                break;
+            case 'move_category':
+                $newSegmentId = (int)($data['segment_id'] ?? 0);
+                $oldSegmentId = (int)($data['old_segment_id'] ?? 0);
+                $categoryId = (int)($data['category_id'] ?? 0);
+                try {
+                    SegmentCategory::move($oldSegmentId, $newSegmentId, $categoryId);
+                    Log::write("Moved category $categoryId from segment $oldSegmentId to $newSegmentId");
+                    echo json_encode(['status' => 'ok']);
+                } catch (Exception $e) {
+                    http_response_code(400);
+                    Log::write('Move category error: ' . $e->getMessage(), 'ERROR');
+                    echo json_encode(['error' => $e->getMessage()]);
+                }
+                break;
+            default:
+                http_response_code(400);
+                echo json_encode(['error' => 'Invalid action']);
+        }
+    } elseif ($method === 'DELETE') {
+        $id = (int)($data['id'] ?? 0);
+        if ($id <= 0) {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID required']);
+            return;
+        }
+        Segment::delete($id);
+        Log::write("Deleted segment $id");
+        echo json_encode(['status' => 'ok']);
+    } elseif ($method === 'PUT') {
+        $id = (int)($data['id'] ?? 0);
+        $name = trim($data['name'] ?? '');
+        $description = $data['description'] ?? null;
+        if ($id <= 0 || $name === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID and name required']);
+            return;
+        }
+        Segment::update($id, $name, $description);
+        Log::write("Updated segment $id");
+        echo json_encode(['status' => 'ok']);
+    } else {
+        http_response_code(405);
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Segment error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+
+?>


### PR DESCRIPTION
## Summary
- Introduce Segment and SegmentCategory models for grouping categories
- Create segments API endpoint supporting CRUD and category assignments
- Extend database setup to include segments and segment_categories tables

## Testing
- `php -l php_backend/models/Segment.php php_backend/models/SegmentCategory.php php_backend/public/segments.php php_backend/create_tables.php`


------
https://chatgpt.com/codex/tasks/task_e_68a2019fe4b4832e996c92122074429e