### PR TITLE
Add segment column to monthly statement and search pages

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -291,7 +291,7 @@ function loadTransactions() {
         table = tailwindTabulator('#transactions-grid', {
             data: data,
             layout: 'fitDataStretch',
-            searchFields: ['date','description','memo','category_name','tag_name','amount'],
+            searchFields: ['date','description','memo','category_name','tag_name','segment_name','amount'],
             columns: [
                 { title: 'Date', field: 'date' },
                 { title: 'Description', field: 'description', formatter: function(cell) {
@@ -356,6 +356,19 @@ function loadTransactions() {
                             const name = groupValues[newId] || '';
                             cell.getRow().update({ group_name: name });
                         });
+                    }
+                },
+                {
+                    title: 'Segment',
+                    field: 'segment_name',
+                    formatter: function(cell){
+                        const value = cell.getValue();
+                        if (!value) return '';
+                        const badge = createBadge(value, 'bg-yellow-200 text-yellow-800');
+                        const link = document.createElement('a');
+                        link.href = `search.html?value=${encodeURIComponent(value)}`;
+                        link.appendChild(badge);
+                        return link;
                     }
                 },
                 { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -67,6 +67,7 @@
                             { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
                             { title: 'Tag', field: 'tag_name', formatter: badgeFormatter('bg-indigo-200 text-indigo-800') },
                             { title: 'Group', field: 'group_name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
+                            { title: 'Segment', field: 'segment_name', formatter: badgeFormatter('bg-yellow-200 text-yellow-800') },
                             { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' }
                         ]
                     });


### PR DESCRIPTION
## Summary
- show each transaction's segment in monthly statement table
- display segments in search results

## Testing
- `php -d detect_unicode=0 tests/run_tests.php` *(fails: table segments already exists)*

------
https://chatgpt.com/codex/tasks/task_e_68a20b7ae284832e90901148f3baca26