### PR TITLE
Expose segment categories and CRUD endpoints

### DIFF
--- a/php_backend/models/Segment.php
+++ b/php_backend/models/Segment.php
@@ -44,9 +44,9 @@ class Segment {
     }
 
     /**
-     * Assign a category to a segment.
+     * Assign a category to a segment. Pass null to remove the category from any segment.
      */
-    public static function assignCategory(int $segmentId, int $categoryId): void {
+    public static function assignCategory(?int $segmentId, int $categoryId): void {
         $db = Database::getConnection();
         $stmt = $db->prepare('UPDATE categories SET segment_id = :segment WHERE id = :category');
         $stmt->execute(['segment' => $segmentId, 'category' => $categoryId]);

--- a/php_backend/public/segments.php
+++ b/php_backend/public/segments.php
@@ -1,18 +1,70 @@
 <?php
-
-// API endpoint returning all segments.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Segment.php';
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
 
+$method = $_SERVER['REQUEST_METHOD'];
+
 try {
-    echo json_encode(Segment::all());
+    $input = json_decode(file_get_contents('php://input'), true) ?? [];
+
+    switch ($method) {
+        case 'GET':
+            echo json_encode(Segment::allWithCategories());
+            break;
+        case 'POST':
+            if (isset($input['action'])) {
+                switch ($input['action']) {
+                    case 'add_category':
+                    case 'move_category':
+                        Segment::assignCategory((int)$input['segment_id'], (int)$input['category_id']);
+                        Log::write("Assigned category {$input['category_id']} to segment {$input['segment_id']}");
+                        echo json_encode(['status' => 'ok']);
+                        break;
+                    case 'remove_category':
+                        Segment::assignCategory(null, (int)$input['category_id']);
+                        Log::write("Removed category {$input['category_id']} from segment");
+                        echo json_encode(['status' => 'ok']);
+                        break;
+                    default:
+                        http_response_code(400);
+                        echo json_encode(['error' => 'Unknown action']);
+                }
+            } else {
+                $name = trim($input['name'] ?? '');
+                $description = $input['description'] ?? null;
+                if ($name === '') {
+                    http_response_code(400);
+                    echo json_encode(['error' => 'Name required']);
+                    break;
+                }
+                $id = Segment::create($name, $description);
+                Log::write("Created segment $name");
+                echo json_encode(['id' => $id]);
+            }
+            break;
+        case 'PUT':
+            $id = (int)$input['id'];
+            $name = $input['name'] ?? '';
+            $description = $input['description'] ?? null;
+            Segment::update($id, $name, $description);
+            Log::write("Updated segment $id");
+            echo json_encode(['status' => 'ok']);
+            break;
+        case 'DELETE':
+            $id = (int)$input['id'];
+            Segment::delete($id);
+            Log::write("Deleted segment $id");
+            echo json_encode(['status' => 'ok']);
+            break;
+        default:
+            http_response_code(405);
+            echo json_encode([]);
+    }
 } catch (Exception $e) {
     http_response_code(500);
     Log::write('Segment error: ' . $e->getMessage(), 'ERROR');
     echo json_encode([]);
 }
-
-?>


### PR DESCRIPTION
## Summary
- Return segments with their associated categories
- Allow creating, updating, deleting segments and assigning categories via POST/PUT/DELETE actions

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68a21ce0bbcc832e9cd83eedf842052f