### PR TITLE
Add sunburst chart for segments, categories, and tags

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -19,6 +19,7 @@
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full"></select>
             </label>
+            <div class="bg-white p-6 rounded shadow"><div id="sunburst-chart" style="height:600px"></div></div>
             <div class="bg-white p-6 rounded shadow"><div id="monthly-chart" style="height:400px"></div></div>
             <div class="bg-white p-6 rounded shadow"><div id="cumulative-chart" style="height:400px"></div></div>
             <div class="bg-white p-6 rounded shadow"><div id="pie-chart" style="height:400px"></div></div>
@@ -35,6 +36,8 @@
     <script src="js/menu.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/highcharts-3d.js"></script>
+    <script src="https://code.highcharts.com/modules/sunburst.js"></script>
+    <script src="https://code.highcharts.com/modules/accessibility.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
@@ -45,8 +48,9 @@
     function loadYear(year){
         Promise.all([
             fetch('../php_backend/public/dashboard.php?year=' + year).then(r => r.json()),
-            fetch('../php_backend/public/yearly_dashboard.php?year=' + year).then(r => r.json())
-        ]).then(([monthly, yearly]) => {
+            fetch('../php_backend/public/yearly_dashboard.php?year=' + year).then(r => r.json()),
+            fetch('../php_backend/public/categories.php').then(r => r.json())
+        ]).then(([monthly, yearly, categories]) => {
             const months = monthly.map(m => new Date(0, m.month - 1).toLocaleString('default', { month: 'short' }));
             const totals = monthly.map(m => parseFloat(m.spent));
             const categorySeries = yearly.categories.map(c => ({
@@ -156,10 +160,74 @@
 
             });
 
+            renderSunburst(yearly, categories);
+
             if (yearly.segments) {
                 renderSegments(yearly.segments);
             }
         }).catch(err => console.error('Graph data load failed', err));
+    }
+
+    function renderSunburst(yearly, categories){
+        const makeId = str => (str ? String(str).replace(/\s+/g, '_') : '');
+        const categoryMap = {};
+        categories.forEach(c => {
+            if (c.name) {
+                categoryMap[c.name] = c.segment_name || 'Not Segmented';
+            }
+        });
+
+        const segments = {};
+        yearly.categories.forEach(c => {
+            if (!c.name) return;
+            const segName = categoryMap[c.name] || 'Not Segmented';
+            const segId = 'seg_' + makeId(segName);
+            if (!segments[segName]) segments[segName] = { id: segId, name: segName, total: 0, categories: {} };
+            segments[segName].total += parseFloat(c.total);
+            const catId = 'cat_' + makeId(c.name);
+            segments[segName].categories[c.name] = { id: catId, name: c.name, total: parseFloat(c.total), tags: {} };
+        });
+
+        yearly.tags.forEach(t => {
+            if (!t.name || !t.category) return;
+            const catName = t.category;
+            const segName = categoryMap[catName] || 'Not Segmented';
+            const segId = 'seg_' + makeId(segName);
+            if (!segments[segName]) segments[segName] = { id: segId, name: segName, total: 0, categories: {} };
+            const catId = 'cat_' + makeId(catName);
+            if (!segments[segName].categories[catName]) segments[segName].categories[catName] = { id: catId, name: catName, total: 0, tags: {} };
+            const tagId = 'tag_' + makeId(t.name) + '_' + makeId(catName);
+            segments[segName].categories[catName].tags[t.name] = { id: tagId, name: t.name, total: parseFloat(t.total) };
+        });
+
+        const data = [{ id: 'root', parent: '', name: 'Total' }];
+        Object.values(segments).forEach(seg => {
+            data.push({ id: seg.id, parent: 'root', name: seg.name, value: seg.total });
+            Object.values(seg.categories).forEach(cat => {
+                data.push({ id: cat.id, parent: seg.id, name: cat.name, value: cat.total });
+                Object.values(cat.tags).forEach(tag => {
+                    data.push({ id: tag.id, parent: cat.id, name: tag.name, value: tag.total });
+                });
+            });
+        });
+
+        Highcharts.chart('sunburst-chart', {
+            colors: gradientColors,
+            series: [{
+                type: 'sunburst',
+                data: data,
+                allowDrillToNode: true,
+                cursor: 'pointer',
+                dataLabels: { format: '{point.name}', filter: { property: 'innerArcLength', operator: '>', value: 16 } },
+                levels: [
+                    { level: 1, levelIsConstant: false, dataLabels: { rotationMode: 'parallel' } },
+                    { level: 2, colorByPoint: true },
+                    { level: 3, colorVariation: { key: 'brightness', to: -0.5 } }
+                ]
+            }],
+            title: { text: 'Segments, Categories and Tags' },
+            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
+        });
     }
 
     function renderSegments(segments){


### PR DESCRIPTION
## Summary
- Add Highcharts accessibility module on graphs page and container for new chart.
- Fetch category metadata and render hierarchical sunburst combining segments, categories, and tags.
- Sanitize identifiers and skip entries with missing names to prevent null errors in sunburst rendering.

## Testing
- `php -l php_backend/public/dashboard.php`
- `php -l php_backend/public/yearly_dashboard.php`
- `php -l php_backend/public/categories.php`


------
https://chatgpt.com/codex/tasks/task_e_68a21d9d1748832e9cb1f38142834fa9