### PR TITLE
Drop custom color scheme from sunburst graph

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -241,7 +241,6 @@
         });
 
         Highcharts.chart('sunburst-chart', {
-            colors: gradientColors,
             series: [{
                 type: 'sunburst',
                 data: data,


### PR DESCRIPTION
## Summary
- Allow the sunburst chart to use the default Highcharts color palette by removing forced colors

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68a224659304832ebe6b470f434ed25b