### PR TITLE
Display values on sunburst segments

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -246,7 +246,13 @@
                 data: data,
                 allowDrillToNode: true,
                 cursor: 'pointer',
-                dataLabels: { format: '{point.name}', filter: { property: 'innerArcLength', operator: '>', value: 16 } },
+                dataLabels: {
+                    formatter: function(){
+                        const sum = this.point.node && this.point.node.sum;
+                        return sum ? `${this.point.name}: £${Highcharts.numberFormat(sum, 2)}` : this.point.name;
+                    },
+                    filter: { property: 'innerArcLength', operator: '>', value: 16 }
+                },
                 levels: [
                     { level: 1, levelIsConstant: false, dataLabels: { rotationMode: 'parallel' } },
                     { level: 2, colorByPoint: true },


### PR DESCRIPTION
## Summary
- Show monetary values on each sunburst section using a custom data-label formatter

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a2ef77aacc832e96c9f4439277435a