### PR TITLE
Add Bitbucket pipeline for automated deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,19 @@ php tests/run_tests.php
 ```
 
 
+
+## Automated Deployment
+
+This project uses Bitbucket Pipelines to trigger deployments. Whenever changes are pushed to the `master` branch, Bitbucket sends a request to your deployment server:
+
+```
+curl https://your.web.server.com/automated_deployment.php
+```
+
+On the server, `automated_deployment.php` should pull the latest code:
+
+```
+<?php
+shell_exec('cd /var/www/myproject && git pull');
+```
+

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,10 @@
+image: atlassian/default-image:2
+
+pipelines:
+  branches:
+    master:
+      - parallel:
+          - step:
+              name: 'Automated Deployment'
+              script:
+                - curl https://your.web.server.com/automated_deployment.php


### PR DESCRIPTION
## Summary
- add Bitbucket Pipelines configuration to trigger deployment on master branch
- document new deployment process in README

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a32fde9368832ebfd1ba19b1115473