### PR TITLE
Improve duplicate transaction detection

### DIFF
--- a/php_backend/public/dedupe_transactions.php
+++ b/php_backend/public/dedupe_transactions.php
@@ -13,12 +13,10 @@ try {
     if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         $ignore = Tag::getIgnoreId();
         $sql = 'SELECT GROUP_CONCAT(t.id) AS ids, COUNT(*) AS count, a.name AS account, '
-
-             . 't.date, t.amount, MIN(t.description) AS description '
+             . 't.date, t.amount, MIN(TRIM(t.description)) AS description '
              . 'FROM transactions t JOIN accounts a ON t.account_id = a.id '
              . 'WHERE (t.tag_id IS NULL OR t.tag_id != :ignore) '
-             . 'GROUP BY t.account_id, t.date, t.amount, UPPER(TRIM(t.description)), UPPER(TRIM(COALESCE(t.memo, ""))) '
-
+             . 'GROUP BY t.account_id, t.date, t.amount, UPPER(TRIM(t.description)) '
              . 'HAVING COUNT(*) > 1';
         $stmt = $db->prepare($sql);
         $stmt->execute(['ignore' => $ignore]);


### PR DESCRIPTION
## Summary
- Normalise description comparison and ignore memo when checking for duplicate transactions on insert
- Broaden duplicate transaction query to detect duplicates regardless of memo differences

## Testing
- `php -l php_backend/models/Transaction.php`
- `php -l php_backend/public/dedupe_transactions.php`
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3344adcf8832e8b21a52be62643ed