### PR TITLE
Include segments in backup and restore options

### DIFF
--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -28,6 +28,7 @@
                     <label class="block"><input type="checkbox" name="parts" value="categories" class="mr-2">Categories</label>
                     <label class="block"><input type="checkbox" name="parts" value="tags" class="mr-2">Tags</label>
                     <label class="block"><input type="checkbox" name="parts" value="groups" class="mr-2">Groups</label>
+                    <label class="block"><input type="checkbox" name="parts" value="segments" class="mr-2">Segments</label>
                     <label class="block"><input type="checkbox" name="parts" value="budgets" class="mr-2">Budgets</label>
 
                 </div>
@@ -38,7 +39,7 @@
             </section>
             <section class="bg-white p-6 rounded shadow space-y-4">
                 <h2 class="text-xl font-semibold">Restore Backup</h2>
-                <p>Select a gzipped JSON backup file to restore any included transactions, categories, tags, groups, or budgets.</p>
+                <p>Select a gzipped JSON backup file to restore any included transactions, categories, tags, groups, segments, or budgets.</p>
                 <form id="restore-form" action="../php_backend/public/restore.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                     <input type="file" id="backup-file" name="backup_file" accept="application/gzip,application/json" required data-help="Choose a previously downloaded compressed backup file">
                     <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-upload mr-2"></i>Restore</button>

--- a/frontend/js/backup.js
+++ b/frontend/js/backup.js
@@ -7,7 +7,7 @@ function initBackup() {
     if (dlBtn) {
         dlBtn.addEventListener('click', () => {
             const parts = Array.from(document.querySelectorAll('input[name="parts"]:checked')).map(cb => cb.value);
-            const allParts = ['categories','tags','groups','transactions','budgets'];
+            const allParts = ['categories','tags','groups','transactions','budgets','segments'];
             const selected = parts.length ? parts : allParts;
             const qs = parts.length ? `?parts=${parts.join(',')}` : '';
             fetch(`../php_backend/public/backup.php${qs}`)

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -1,7 +1,7 @@
 <?php
 // Exports selected data as JSON. Allows selecting categories, tags, groups,
-// transactions, and budgets via the `parts` query parameter. User and account
-// information is always included so a full backup can be restored.
+// segments, transactions, and budgets via the `parts` query parameter. User
+// and account information is always included so a full backup can be restored.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -1,6 +1,7 @@
 <?php
 
-// Restores users, accounts, categories, tags, groups, transactions, and budgets from an uploaded gzipped JSON backup.
+// Restores users, accounts, segments, categories, tags, groups,
+// transactions, and budgets from an uploaded gzipped JSON backup.
 
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';


### PR DESCRIPTION
## Summary
- add segments checkbox to backup page and reflect in restore instructions
- include segments in default backup parts array
- document segment support in backup and restore scripts

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3396767ec832eb6e5c605e0428fa8