### PR TITLE
Fix sunburst totals display

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -248,8 +248,8 @@
                 cursor: 'pointer',
                 dataLabels: {
                     formatter: function(){
-                        const sum = this.point.node && this.point.node.sum;
-                        return sum ? `${this.point.name}: £${Highcharts.numberFormat(sum, 2)}` : this.point.name;
+                        const sum = (this.point.node && this.point.node.childrenTotal) || this.point.value;
+                        return sum !== undefined ? `${this.point.name}: £${Highcharts.numberFormat(sum, 2)}` : this.point.name;
                     },
                     filter: { property: 'innerArcLength', operator: '>', value: 16 }
                 },
@@ -260,7 +260,12 @@
                 ]
             }],
             title: { text: 'Segments, Categories and Tags' },
-            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
+            tooltip: {
+                pointFormatter: function(){
+                    const sum = (this.node && this.node.childrenTotal) || this.value;
+                    return '£' + Highcharts.numberFormat(sum, 2);
+                }
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- show sums for parent nodes in the sunburst chart
- use summed values in sunburst tooltips

## Testing
- `node - <<'NODE'
const fs=require('fs');
const html=fs.readFileSync('frontend/graphs.html','utf8');
const regex=/<script>([\s\S]*?)<\/script>/g;
let match, i=0;
while((match=regex.exec(html))){
  try{
    new Function(match[1]);
    console.log('Script', ++i, 'parsed successfully');
  }catch(e){
    console.error('Script', ++i, 'failed:', e.message);
  }
}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a33a51216c832eb5a97769d27428a7