### PR TITLE
Order sunburst graph by segments, categories, and tags

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -253,10 +253,12 @@
                     },
                     filter: { property: 'innerArcLength', operator: '>', value: 16 }
                 },
+                // Display a clear hierarchy with segments in the centre
+                // followed by categories and tags on the outer rings
                 levels: [
-                    { level: 1, levelIsConstant: false, dataLabels: { rotationMode: 'parallel' } },
-                    { level: 2, colorByPoint: true },
-                    { level: 3, colorVariation: { key: 'brightness', to: -0.5 } }
+                    { level: 1, colorByPoint: true, dataLabels: { rotationMode: 'parallel' } },
+                    { level: 2, colorVariation: { key: 'brightness', to: -0.5 } },
+                    { level: 3, colorVariation: { key: 'brightness', to: -0.8 } }
                 ]
             }],
             title: { text: 'Segments, Categories and Tags' },


### PR DESCRIPTION
## Summary
- highlight segments as the inner ring in the sunburst graph
- organise categories and tags on outer rings with clarity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a33d806990832ebc7a00fd510bede8