### PR TITLE
feat: use gpt-5 nano for AI tagging

### DIFF
--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -44,7 +44,7 @@ foreach ($txns as $t) {
 }
 
 $payload = [
-    'model' => 'gpt-4o-mini',
+    'model' => 'gpt-5-nano',
     'messages' => [
         ['role' => 'system', 'content' => 'You label bank transactions. Use JSON.'],
         ['role' => 'user', 'content' => $prompt]


### PR DESCRIPTION
## Summary
- switch AI tagging model to gpt-5 nano for better classification

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a34ea3a818832ebe23f5a99e5cc66a