### PR TITLE
Add reset option for transaction tags, categories and segments

### DIFF
--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -21,6 +21,7 @@
                 <button id="tagging-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-tags mr-1"></i>Run Tagging</button>
                 <button id="categories-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-list mr-1"></i>Apply Categories</button>
                 <button id="segments-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-layer-group mr-1"></i>Apply Segments</button>
+                <button id="clear-btn" class="bg-red-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-eraser mr-1"></i>Clear Tags/Categories/Segments</button>
             </div>
             <div id="progress-container" class="w-full bg-gray-200 h-2 mt-4 rounded hidden">
                 <div id="progress-bar" class="h-full bg-indigo-600 w-0"></div>
@@ -56,6 +57,8 @@
                 showMessage(`Categorised ${data.categorised} transactions`);
             } else if(action === 'segments') {
                 showMessage(`Assigned segments to ${data.segmented} transactions`);
+            } else if(action === 'clear') {
+                showMessage(`Cleared tags from ${data.cleared_tags} transactions, categories from ${data.cleared_categories}, segments from ${data.cleared_segments}`);
             }
         } finally {
             clearInterval(interval);
@@ -69,6 +72,7 @@
     document.getElementById('tagging-btn').addEventListener('click', ()=>run('tagging'));
     document.getElementById('categories-btn').addEventListener('click', ()=>run('categories'));
     document.getElementById('segments-btn').addEventListener('click', ()=>run('segments'));
+    document.getElementById('clear-btn').addEventListener('click', ()=>run('clear'));
     </script>
     <script src="js/overlay.js"></script>
 </body>

--- a/php_backend/models/CategoryTag.php
+++ b/php_backend/models/CategoryTag.php
@@ -50,6 +50,17 @@ class CategoryTag {
     }
 
     /**
+     * Clear category assignments from all transactions.
+     * Returns the number of rows affected.
+     */
+    public static function clearFromTransactions(): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE transactions SET category_id = NULL WHERE category_id IS NOT NULL');
+        $stmt->execute();
+        return $stmt->rowCount();
+    }
+
+    /**
      * Apply category IDs to transactions for a specific account based on their tag.
      * Transactions are updated whenever their tag implies a different category,
      * ensuring changes in tagging are reflected in categorisation.

--- a/php_backend/models/Segment.php
+++ b/php_backend/models/Segment.php
@@ -110,6 +110,17 @@ class Segment {
     }
 
     /**
+     * Clear segment assignments from all transactions.
+     * Returns the number of rows affected.
+     */
+    public static function clearFromTransactions(): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE transactions SET segment_id = NULL WHERE segment_id IS NOT NULL');
+        $stmt->execute();
+        return $stmt->rowCount();
+    }
+
+    /**
      * Return totals grouped by segment.
      */
     public static function totals(): array {

--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -63,6 +63,17 @@ class Tag {
     }
 
     /**
+     * Clear tag references from all transactions.
+     * Returns the number of rows affected.
+     */
+    public static function clearFromTransactions(): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE `transactions` SET `tag_id` = NULL WHERE `tag_id` IS NOT NULL');
+        $stmt->execute();
+        return $stmt->rowCount();
+    }
+
+    /**
      * Find a tag whose keyword appears in the provided text.
      */
     public static function findMatch(string $text): ?int {

--- a/php_backend/public/run_processes.php
+++ b/php_backend/public/run_processes.php
@@ -32,6 +32,14 @@ try {
         $segmented = Segment::applyToTransactions();
         Log::write("Manual segment assignment applied to $segmented transactions");
         $response['segmented'] = $segmented;
+    } elseif ($action === 'clear') {
+        $clearedTags = Tag::clearFromTransactions();
+        $clearedCategories = CategoryTag::clearFromTransactions();
+        $clearedSegments = Segment::clearFromTransactions();
+        Log::write("Cleared tags from $clearedTags transactions; categories from $clearedCategories transactions; segments from $clearedSegments transactions");
+        $response['cleared_tags'] = $clearedTags;
+        $response['cleared_categories'] = $clearedCategories;
+        $response['cleared_segments'] = $clearedSegments;
     } elseif ($action === 'all' || $action === 'both') {
         $tagged = Tag::applyToAllTransactions();
         $categorised = CategoryTag::applyToAllTransactions();


### PR DESCRIPTION
## Summary
- add button on Run Processes page to clear existing tags, categories and segments
- implement backend action and model helpers to remove tag/category/segment links from all transactions

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/models/CategoryTag.php`
- `php -l php_backend/models/Segment.php`
- `php -l php_backend/public/run_processes.php`


------
https://chatgpt.com/codex/tasks/task_e_68a3524a8240832ead6be289d7101659