### PR TITLE
Improve dedupe query to catch ignored duplicates

### DIFF
--- a/php_backend/public/dedupe_transactions.php
+++ b/php_backend/public/dedupe_transactions.php
@@ -15,9 +15,8 @@ try {
         $sql = 'SELECT GROUP_CONCAT(t.id) AS ids, COUNT(*) AS count, a.name AS account, '
              . 't.date, t.amount, MIN(TRIM(t.description)) AS description '
              . 'FROM transactions t JOIN accounts a ON t.account_id = a.id '
-             . 'WHERE (t.tag_id IS NULL OR t.tag_id != :ignore) '
              . 'GROUP BY t.account_id, t.date, t.amount, UPPER(TRIM(t.description)) '
-             . 'HAVING COUNT(*) > 1';
+             . 'HAVING COUNT(*) > 1 AND SUM(CASE WHEN t.tag_id = :ignore THEN 1 ELSE 0 END) < COUNT(*)';
         $stmt = $db->prepare($sql);
         $stmt->execute(['ignore' => $ignore]);
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- include transactions tagged as ignored when searching for duplicates so repeated entries aren't missed

## Testing
- `php -l php_backend/public/dedupe_transactions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a35d6e8fc0832e8c40e40dbe4bcaed