### PR TITLE
Handle missing accounts in ignored transactions list

### DIFF
--- a/php_backend/public/ignored_transactions.php
+++ b/php_backend/public/ignored_transactions.php
@@ -10,7 +10,7 @@ try {
     $ignore = Tag::getIgnoreId();
     $db = Database::getConnection();
     $sql = 'SELECT t.id, t.date, t.amount, t.description, a.name AS account_name '
-         . 'FROM transactions t JOIN accounts a ON t.account_id = a.id '
+         . 'FROM transactions t LEFT JOIN accounts a ON t.account_id = a.id '
          . 'WHERE t.tag_id = :ignore ORDER BY t.date DESC, t.id DESC';
     $stmt = $db->prepare($sql);
     $stmt->execute(['ignore' => $ignore]);


### PR DESCRIPTION
## Summary
- Use LEFT JOIN so ignored transactions still appear even when their account no longer exists

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a360b97fd8832ea735c2ce63a27b4e