### PR TITLE
Handle missing accounts in ignored transactions list

### DIFF
--- a/php_backend/public/ignored_transactions.php
+++ b/php_backend/public/ignored_transactions.php
@@ -7,13 +7,15 @@ require_once __DIR__ . '/../models/Tag.php';
 header('Content-Type: application/json');
 
 try {
-    $ignore = Tag::getIgnoreId();
+    Tag::getIgnoreId();
     $db = Database::getConnection();
     $sql = 'SELECT t.id, t.date, t.amount, t.description, a.name AS account_name '
-         . 'FROM transactions t JOIN accounts a ON t.account_id = a.id '
-         . 'WHERE t.tag_id = :ignore ORDER BY t.date DESC, t.id DESC';
+         . 'FROM transactions t '
+         . 'LEFT JOIN accounts a ON t.account_id = a.id '
+         . 'LEFT JOIN tags tg ON t.tag_id = tg.id '
+         . 'WHERE UPPER(tg.name) = :ignore ORDER BY t.date DESC, t.id DESC';
     $stmt = $db->prepare($sql);
-    $stmt->execute(['ignore' => $ignore]);
+    $stmt->execute(['ignore' => 'IGNORE']);
     echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
 } catch (Exception $e) {
     http_response_code(500);

--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -59,8 +59,14 @@ try {
     }
     if ($tagId !== null || $tagName) {
         if (!$tagId && $tagName) {
-            $tagId = Tag::create($tagName, $description);
-            Log::write("Created tag $tagName");
+            $existing = Tag::getIdByName($tagName);
+            if ($existing === null) {
+                $tagId = Tag::create($tagName, $description);
+                Log::write("Created tag $tagName");
+            } else {
+                $tagId = $existing;
+                Tag::setKeyword((int)$tagId, $description);
+            }
         } else {
             Tag::setKeyword((int)$tagId, $description);
         }

--- a/php_backend/public/update_transaction_tag.php
+++ b/php_backend/public/update_transaction_tag.php
@@ -30,8 +30,14 @@ if (!$transactionId || !$accountId || (!$tagId && !$tagName) || !$description) {
 
 try {
     if (!$tagId && $tagName) {
-        $tagId = Tag::create($tagName, $description);
-        Log::write("Created tag $tagName");
+        $existing = Tag::getIdByName($tagName);
+        if ($existing === null) {
+            $tagId = Tag::create($tagName, $description);
+            Log::write("Created tag $tagName");
+        } else {
+            $tagId = $existing;
+            Tag::setKeyword((int)$tagId, $description);
+        }
     } else {
         Tag::setKeyword((int)$tagId, $description);
     }


### PR DESCRIPTION
## Summary
- Match ignored transactions by tag name so all IGNORE-tagged entries appear even if their tag IDs differ
- Reuse existing tags when updating transactions to avoid duplicate IGNORE tags

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a360b97fd8832ea735c2ce63a27b4e