### PR TITLE
Sanitize search results output to handle HTML encoding

### DIFF
--- a/frontend/search.html
+++ b/frontend/search.html
@@ -42,6 +42,13 @@
         return '£' + parseFloat(value).toFixed(2);
     }
 
+    // Escape a string for safe insertion into HTML
+    function escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+
     function runSearch(){
         const term = document.getElementById('term').value;
         const amount = document.getElementById('amount').value;
@@ -61,7 +68,10 @@
                             { title: 'Date', field: 'date' },
                             { title: 'Description', field: 'description', formatter: function(cell){
                                 const id = cell.getRow().getData().id;
-                                return `<a href="transaction.html?id=${id}">${cell.getValue()}</a>`;
+                                const link = document.createElement('a');
+                                link.href = `transaction.html?id=${id}`;
+                                link.textContent = cell.getValue();
+                                return link;
                             } },
                             { title: 'Memo', field: 'memo' },
                             { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
@@ -93,7 +103,7 @@
                         let buckets = {};
                         let categories = [];
                         let values = [];
-                        let chartTitle = term ? `Spending for "${term}"` : 'Search Results Spending';
+                        let chartTitle = term ? `Spending for "${escapeHtml(term)}"` : 'Search Results Spending';
                         if (amount) chartTitle += ` of £${parseFloat(amount).toFixed(2)}`;
                         let chartSubtitle = '';
 


### PR DESCRIPTION
## Summary
- escape search terms and result descriptions on search page
- ensure chart titles render safely when queries contain special characters

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68a43f48e8dc832e993cefb4075704d4