### PR TITLE
Add amount range filter to transaction search

### DIFF
--- a/frontend/search.html
+++ b/frontend/search.html
@@ -21,7 +21,8 @@
             <p class="mb-4">Find specific transactions using keywords and view the results below. Quick searches help you jump straight to the entries you need.</p>
             <form id="search-form" class="space-y-4">
                 <input type="text" id="term" placeholder="Search value" class="border p-2 rounded w-full" data-help="Value to search across transactions">
-                <input type="number" step="0.01" id="amount" placeholder="Amount (£)" class="border p-2 rounded w-full" data-help="Exact amount to match">
+                <input type="number" step="0.01" id="min-amount" placeholder="Min Amount (£)" class="border p-2 rounded w-full" data-help="Minimum amount to match">
+                <input type="number" step="0.01" id="max-amount" placeholder="Max Amount (£)" class="border p-2 rounded w-full" data-help="Maximum amount to match">
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Search</button>
             </form>
             <div id="results-grid" class="mt-4"></div>
@@ -51,10 +52,12 @@
 
     function runSearch(){
         const term = document.getElementById('term').value;
-        const amount = document.getElementById('amount').value;
+        const minAmount = document.getElementById('min-amount').value;
+        const maxAmount = document.getElementById('max-amount').value;
         const params = new URLSearchParams();
         if (term) params.append('value', term);
-        if (amount) params.append('amount', amount);
+        if (minAmount) params.append('min_amount', minAmount);
+        if (maxAmount) params.append('max_amount', maxAmount);
         fetch('../php_backend/public/search_transactions.php?' + params.toString())
             .then(resp => resp.json())
             .then(data => {
@@ -104,7 +107,13 @@
                         let categories = [];
                         let values = [];
                         let chartTitle = term ? `Spending for "${escapeHtml(term)}"` : 'Search Results Spending';
-                        if (amount) chartTitle += ` of £${parseFloat(amount).toFixed(2)}`;
+                        if (minAmount && maxAmount) {
+                            chartTitle += ` between £${parseFloat(minAmount).toFixed(2)} and £${parseFloat(maxAmount).toFixed(2)}`;
+                        } else if (minAmount) {
+                            chartTitle += ` from £${parseFloat(minAmount).toFixed(2)}`;
+                        } else if (maxAmount) {
+                            chartTitle += ` up to £${parseFloat(maxAmount).toFixed(2)}`;
+                        }
                         let chartSubtitle = '';
 
                         if (diffDays > 1095) {
@@ -181,8 +190,12 @@
 
     const urlParams = new URLSearchParams(window.location.search);
     const initialValue = urlParams.get('value');
-    if (initialValue) {
-        document.getElementById('term').value = initialValue;
+    const initialMin = urlParams.get('min_amount');
+    const initialMax = urlParams.get('max_amount');
+    if (initialValue) document.getElementById('term').value = initialValue;
+    if (initialMin) document.getElementById('min-amount').value = initialMin;
+    if (initialMax) document.getElementById('max-amount').value = initialMax;
+    if (initialValue || initialMin || initialMax) {
         runSearch();
     }
     </script>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -730,9 +730,9 @@ class Transaction {
 
     /**
      * Search transactions across fields.
-     * Supports partial matches for text fields and exact matches for numeric fields.
+     * Supports partial matches for text fields and numeric range searches for the amount field.
      */
-    public static function search(?string $value, ?float $amount = null): array {
+    public static function search(?string $value, ?float $minAmount = null, ?float $maxAmount = null): array {
         $db = Database::getConnection();
 
         $sql = 'SELECT t.`id`, t.`account_id`, t.`date`, t.`amount`, t.`description`, t.`memo`, t.`transfer_id`, '
@@ -769,9 +769,16 @@ class Transaction {
             }
         }
 
-        if ($amount !== null) {
-            $conditions[] = 't.`amount` = :amount';
-            $params['amount'] = $amount;
+        if ($minAmount !== null && $maxAmount !== null) {
+            $conditions[] = 't.`amount` BETWEEN :min_amount AND :max_amount';
+            $params['min_amount'] = $minAmount;
+            $params['max_amount'] = $maxAmount;
+        } elseif ($minAmount !== null) {
+            $conditions[] = 't.`amount` >= :min_amount';
+            $params['min_amount'] = $minAmount;
+        } elseif ($maxAmount !== null) {
+            $conditions[] = 't.`amount` <= :max_amount';
+            $params['max_amount'] = $maxAmount;
         }
 
         $ignore = Tag::getIgnoreId();

--- a/php_backend/public/search_transactions.php
+++ b/php_backend/public/search_transactions.php
@@ -8,15 +8,25 @@ header('Content-Type: application/json');
 
 $value = $_GET['value'] ?? '';
 $amount = isset($_GET['amount']) ? $_GET['amount'] : null;
+$min = isset($_GET['min_amount']) ? $_GET['min_amount'] : null;
+$max = isset($_GET['max_amount']) ? $_GET['max_amount'] : null;
 
-if ($value === '' && $amount === null) {
+if ($amount !== null) {
+    $min = $max = $amount;
+}
+
+if ($value === '' && $min === null && $max === null) {
     http_response_code(400);
-    echo json_encode(['error' => 'Search value or amount is required']);
+    echo json_encode(['error' => 'Search value or amount range is required']);
     exit;
 }
 
 try {
-    $results = Transaction::search($value, $amount !== null ? (float)$amount : null);
+    $results = Transaction::search(
+        $value,
+        $min !== null ? (float)$min : null,
+        $max !== null ? (float)$max : null
+    );
     $total = 0.0;
     foreach ($results as $row) {
         if ($row['transfer_id'] === null) {


### PR DESCRIPTION
## Summary
- allow searching transactions by amount range via new min and max parameters
- expose min/max amount inputs on search page and adjust chart titles

## Testing
- php -l php_backend/models/Transaction.php
- php -l php_backend/public/search_transactions.php

------
https://chatgpt.com/codex/tasks/task_e_68a444fbff94832e87aa3037f0a7c305