### PR TITLE
Warn on duplicate FITIDs during OFX uploads

### DIFF
--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -2,6 +2,7 @@
 // Model representing financial transactions and related queries.
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/Tag.php';
+require_once __DIR__ . '/Log.php';
 
 class Transaction {
     /**
@@ -33,15 +34,8 @@ class Transaction {
             ]);
             $dup = $dupCheck->fetch(PDO::FETCH_ASSOC);
             if ($dup) {
-                $upd = $db->prepare('UPDATE `transactions` SET `description` = :description, `memo` = :memo, `ofx_id` = :ofx_id, `ofx_type` = :ofx_type WHERE `id` = :id');
-                $upd->execute([
-                    'description' => $description,
-                    'memo' => $memo,
-                    'ofx_id' => $ofx_id,
-                    'ofx_type' => $ofx_type,
-                    'id' => $dup['id']
-                ]);
-                return (int)$dup['id'];
+                Log::write("Duplicate FITID $bank_ofx_id for account $account", 'WARNING');
+                return 0; // signal duplicate to caller
             }
         }
 


### PR DESCRIPTION
## Summary
- log and flag duplicate FITID collisions in Transaction::create
- surface duplicate FITID warnings during OFX upload
- exercise duplicate path with new test harness

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a4451ced70832ea0336f9b47671e4b