### PR TITLE
Fix OFX upload transaction loop

### DIFF
--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -102,45 +102,16 @@ try {
         $inserted = 0;
         $duplicates = [];
 
-        foreach ($matches[1] as $block) {
-            if (preg_match('/<DTPOSTED>([^<]+)/i', $block, $m)) {
-                $dateStr = substr(trim($m[1]), 0, 8); // YYYYMMDD
-                $dt = DateTime::createFromFormat('Ymd', $dateStr);
-                if (!$dt || $dt->format('Ymd') !== $dateStr) {
-                    Log::write('Invalid date ' . $dateStr . ' in ' . $files['name'][$i], 'ERROR');
-                    continue; // skip invalid entry
-                }
-                $date = $dt->format('Y-m-d');
-            } else {
-                Log::write('Missing DTPOSTED in transaction block', 'ERROR');
-                continue; // skip invalid entry
-            }
-            if (!preg_match('/<TRNAMT>([^<]+)/i', $block, $am)) {
-                Log::write('Missing TRNAMT in transaction block', 'ERROR');
-                continue;
-            }
-            $amount = (float)trim($am[1]);
-            $desc = '';
-            $memo = '';
-            $type = null;
-            if (preg_match('/<NAME>([^<]+)/i', $block, $dm)) {
-                $desc = trim($dm[1]);
-            }
-            if (preg_match('/<MEMO>([^<]+)/i', $block, $mm)) {
-                $memo = trim($mm[1]);
-                if ($desc === '') {
-                    $desc = $memo;
-                }
-            }
-            if (preg_match('/<TRNTYPE>([^<]+)/i', $block, $tm)) {
-                $type = strtoupper(trim($tm[1]));
-            }
-            // Optional reference and cheque numbers with character limits
-            $ref = '';
-            $chk = '';
-            if (preg_match('/<REFNUM>([^<]+)/i', $block, $rm)) {
-                $ref = substr(trim($rm[1]), 0, 32);
+        foreach ($parsed['transactions'] as $txn) {
+            $amount = $txn['amount'];
+            $date = $txn['date'];
+            $desc = $txn['desc'] ?? '';
+            $memo = $txn['memo'] ?? '';
+            $type = $txn['type'];
+            $bankId = $txn['bank_id'] ?: null;
 
+            if ($txn['ref']) {
+                $ref = substr($txn['ref'], 0, 32);
                 $memo .= ($memo === '' ? '' : ' ') . 'Ref:' . $ref;
             }
             if ($txn['check']) {
@@ -154,16 +125,13 @@ try {
             $bankId = $bankId === null ? null : $substr($bankId, 0, 255);
             $type = $type === null ? null : $substr($type, 0, 50);
 
-
-            // Generate synthetic ID incorporating optional reference data
-
             $amountStr = number_format($amount, 2, '.', '');
             $normalise = function (string $text): string {
                 $text = strtoupper(trim($text));
                 return preg_replace('/\s+/', ' ', $text);
             };
             $normDesc = $normalise($desc);
-
+            $syntheticId = sha1($accountId . $date . $amountStr . $normDesc);
 
             $createdId = Transaction::create($accountId, $date, $amount, $desc, $memo, null, null, null, $syntheticId, $type, $bankId);
             if ($createdId === 0) {


### PR DESCRIPTION
## Summary
- Iterate over parsed transactions instead of undefined `$matches` array during OFX import
- Preserve reference and cheque numbers, enforce field lengths, and generate synthetic IDs
- Report skipped duplicates with their FITIDs

## Testing
- `php -l php_backend/public/upload_ofx.php`


------
https://chatgpt.com/codex/tasks/task_e_68a449b34ea4832e826bceece72597b7