### PR TITLE
Improve transfer detection and clarity

### DIFF
--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -65,10 +65,12 @@
             layout: 'fitDataStretch',
             columns: [
                 { title: 'Date', field: 'date' },
-                { title: 'Description', field: 'description' },
-                { title: 'From', field: 'from_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.from_id}">${cell.getValue()}</a>`; } },
-                { title: 'To', field: 'to_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.to_id}">${cell.getValue()}</a>`; } },
-                { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
+                { title: 'From Account', field: 'from_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.from_id}">${cell.getValue()}</a>`; } },
+                { title: 'From Amount', field: 'from_amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
+                { title: 'From Description', field: 'from_description' },
+                { title: 'To Account', field: 'to_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.to_id}">${cell.getValue()}</a>`; } },
+                { title: 'To Amount', field: 'to_amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
+                { title: 'To Description', field: 'to_description' },
                 { title: 'Mark', formatter: function(){ return '<button class="bg-green-600 text-white px-2 py-1 rounded text-sm"><i class="fa-solid fa-check"></i></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); markTransfers([[r.from_id, r.to_id]]); } }
             ]
         });
@@ -102,10 +104,12 @@
             layout: 'fitDataStretch',
             columns: [
                 { title: 'Date', field: 'date' },
-                { title: 'Description', field: 'description' },
-                { title: 'From', field: 'from_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.from_id}">${cell.getValue()}</a>`; } },
-                { title: 'To', field: 'to_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.to_id}">${cell.getValue()}</a>`; } },
-                { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
+                { title: 'From Account', field: 'from_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.from_id}">${cell.getValue()}</a>`; } },
+                { title: 'From Amount', field: 'from_amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
+                { title: 'From Description', field: 'from_description' },
+                { title: 'To Account', field: 'to_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.to_id}">${cell.getValue()}</a>`; } },
+                { title: 'To Amount', field: 'to_amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
+                { title: 'To Description', field: 'to_description' },
                 { title: 'Undo', formatter: function(){ return '<button class="bg-red-600 text-white px-2 py-1 rounded text-sm"><i class="fa-solid fa-rotate-left"></i></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); unmarkTransfers([r.from_id]); } }
             ]
         });


### PR DESCRIPTION
## Summary
- Detect potential transfers only when matching entries are in different accounts and expose full details for each side.
- Display both sides of transfer candidates and linked transfers with account links, amounts and descriptions.
- Add regression tests for transfer detection and linking.

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68a44ecc6190832e99feaa524b6f7536