### PR TITLE
Collapse side menu subsections on hover

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -1,17 +1,17 @@
 <!-- Navigation menu shared across pages -->
 <h2 class="text-xl font-semibold text-gray-700 mb-4">Menu</h2>
 <div class="space-y-2">
-  <div>
-    <h3 class="text-lg font-semibold text-gray-700 mb-2">General Overview</h3>
-    <ul class="space-y-1">
+  <div class="group">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">General Overview</h3>
+    <ul class="space-y-1 hidden group-hover:block">
       <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="index.html"><i class="fa-solid fa-house text-indigo-600 mr-1"></i> Home</a></li>
       <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="upload.html"><i class="fa-solid fa-upload text-indigo-600 mr-1"></i> Upload OFX Files</a></li>
     </ul>
   </div>
 
-  <div>
-    <h3 class="text-lg font-semibold text-gray-700 mb-2">Transaction Hub</h3>
-    <ul class="space-y-1">
+  <div class="group">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Transaction Hub</h3>
+    <ul class="space-y-1 hidden group-hover:block">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar text-indigo-600 mr-1"></i> Monthly Statement</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="report.html"><i class="fa-solid fa-table text-indigo-600 mr-1"></i> Transaction Reports</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="search.html"><i class="fa-solid fa-magnifying-glass text-indigo-600 mr-1"></i> Search Transactions</a></li>
@@ -20,9 +20,9 @@
     </ul>
   </div>
 
-  <div>
-    <h3 class="text-lg font-semibold text-gray-700 mb-2">Data Dashboards</h3>
-    <ul class="space-y-1">
+  <div class="group">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Dashboards</h3>
+    <ul class="space-y-1 hidden group-hover:block">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line text-indigo-600 mr-1"></i> Yearly Dashboard</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar text-indigo-600 mr-1"></i> All Years Dashboard</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column text-indigo-600 mr-1"></i> Monthly Dashboard</a></li>
@@ -32,23 +32,23 @@
     </ul>
   </div>
 
-  <div>
-    <h3 class="text-lg font-semibold text-gray-700 mb-2">Data Graphs</h3>
-    <ul class="space-y-1">
+  <div class="group">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Graphs</h3>
+    <ul class="space-y-1 hidden group-hover:block">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="graphs.html"><i class="fa-solid fa-chart-pie text-indigo-600 mr-1"></i> Graphs</a></li>
     </ul>
   </div>
 
-  <div>
-    <h3 class="text-lg font-semibold text-gray-700 mb-2">Budget Plans</h3>
-    <ul class="space-y-1">
+  <div class="group">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Budget Plans</h3>
+    <ul class="space-y-1 hidden group-hover:block">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="budgets.html"><i class="fa-solid fa-wallet text-indigo-600 mr-1"></i> Budgets</a></li>
     </ul>
   </div>
 
-  <div>
-    <h3 class="text-lg font-semibold text-gray-700 mb-2">Data Organisation</h3>
-    <ul class="space-y-1">
+  <div class="group">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Organisation</h3>
+    <ul class="space-y-1 hidden group-hover:block">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="tags.html"><i class="fa-solid fa-tags text-indigo-600 mr-1"></i> Manage Tags</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ai_tags.html"><i class="fa-solid fa-robot text-indigo-600 mr-1"></i> AI Tags</a></li>
         <li>
@@ -63,9 +63,9 @@
       </ul>
     </div>
 
-  <div>
-    <h3 class="text-lg font-semibold text-gray-700 mb-2">Admin Tools</h3>
-    <ul class="space-y-1">
+  <div class="group">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Admin Tools</h3>
+    <ul class="space-y-1 hidden group-hover:block">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="processes.html"><i class="fa-solid fa-gear text-indigo-600 mr-1"></i> Run Processes</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="logs.html"><i class="fa-solid fa-clipboard-list text-indigo-600 mr-1"></i> View Logs</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="dedupe.html"><i class="fa-solid fa-clone text-indigo-600 mr-1"></i> Remove Duplicates</a></li>


### PR DESCRIPTION
## Summary
- Collapse each side menu subsection by default using Tailwind's `group` and `group-hover` classes so links expand when hovering their title.

## Testing
- `timeout 2 php -S localhost:8000 -t frontend`

------
https://chatgpt.com/codex/tasks/task_e_68a452e7b138832ea48e7ec9f38bfd92