### PR TITLE
Enable collapsible mobile side menu

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -74,6 +74,17 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(resp => resp.text())
       .then(html => {
         menu.innerHTML = html;
+        // Enable collapsible sections with animated height transition
+        menu.querySelectorAll('.group').forEach(section => {
+          const header = section.querySelector('h3');
+          const list = section.querySelector('ul');
+          if (header && list) {
+            header.addEventListener('click', () => {
+              const expanded = list.style.maxHeight && list.style.maxHeight !== '0px';
+              list.style.maxHeight = expanded ? '0px' : `${list.scrollHeight}px`;
+            });
+          }
+        });
         // Hide menu after clicking a link on mobile
         menu.querySelectorAll('a').forEach(a =>
           a.addEventListener('click', () => menu.classList.add('hidden'))

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -3,7 +3,7 @@
 <div class="space-y-2">
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">General Overview</h3>
-    <ul class="space-y-1 hidden group-hover:block">
+    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
       <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="index.html"><i class="fa-solid fa-house text-indigo-600 mr-1"></i> Home</a></li>
       <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="upload.html"><i class="fa-solid fa-upload text-indigo-600 mr-1"></i> Upload OFX Files</a></li>
     </ul>
@@ -11,7 +11,7 @@
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Transaction Hub</h3>
-    <ul class="space-y-1 hidden group-hover:block">
+    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar text-indigo-600 mr-1"></i> Monthly Statement</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="report.html"><i class="fa-solid fa-table text-indigo-600 mr-1"></i> Transaction Reports</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="search.html"><i class="fa-solid fa-magnifying-glass text-indigo-600 mr-1"></i> Search Transactions</a></li>
@@ -22,7 +22,7 @@
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Dashboards</h3>
-    <ul class="space-y-1 hidden group-hover:block">
+    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line text-indigo-600 mr-1"></i> Yearly Dashboard</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar text-indigo-600 mr-1"></i> All Years Dashboard</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column text-indigo-600 mr-1"></i> Monthly Dashboard</a></li>
@@ -34,21 +34,21 @@
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Graphs</h3>
-    <ul class="space-y-1 hidden group-hover:block">
+    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="graphs.html"><i class="fa-solid fa-chart-pie text-indigo-600 mr-1"></i> Graphs</a></li>
     </ul>
   </div>
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Budget Plans</h3>
-    <ul class="space-y-1 hidden group-hover:block">
+    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="budgets.html"><i class="fa-solid fa-wallet text-indigo-600 mr-1"></i> Budgets</a></li>
     </ul>
   </div>
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Organisation</h3>
-    <ul class="space-y-1 hidden group-hover:block">
+    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="tags.html"><i class="fa-solid fa-tags text-indigo-600 mr-1"></i> Manage Tags</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ai_tags.html"><i class="fa-solid fa-robot text-indigo-600 mr-1"></i> AI Tags</a></li>
         <li>
@@ -65,7 +65,7 @@
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Admin Tools</h3>
-    <ul class="space-y-1 hidden group-hover:block">
+    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="processes.html"><i class="fa-solid fa-gear text-indigo-600 mr-1"></i> Run Processes</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="logs.html"><i class="fa-solid fa-clipboard-list text-indigo-600 mr-1"></i> View Logs</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="dedupe.html"><i class="fa-solid fa-clone text-indigo-600 mr-1"></i> Remove Duplicates</a></li>


### PR DESCRIPTION
## Summary
- Replace hover-only side navigation with click-to-toggle sections for mobile devices
- Animate menu group expansion using a height transition for a smoother UI

## Testing
- `node --check frontend/js/menu.js`

------
https://chatgpt.com/codex/tasks/task_e_68a6d7113524832e8bb3234b978a65fe