### PR TITLE
Use narrower heading font

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@
 - Display monetary values with the pound symbol (£).
 - Style the frontend with Tailwind CSS. Wrap primary sections in white card components (`bg-white p-6 rounded shadow`).
 - Use Font Awesome for interface icons.
-- Headings should use bold Montserrat, body text should use Inter, and buttons or highlights should use light Source Sans Pro.
+- Headings should use bold Roboto, body text should use Inter, and buttons or highlights should use light Source Sans Pro.
 - Tabulator tables should apply Tailwind utility classes.
 - Provide popover help for form inputs using `data-help` attributes handled by `frontend/js/input_help.js`.
 - Ensure the site remains mobile-friendly: include `<meta name="viewport" content="width=device-width, initial-scale=1.0">` on

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Two PHP endpoints under `php_backend/public` handle TOTP setup and verification 
 - Highcharts is used for graphs, while Tabulator renders interactive tables.
 - Display all monetary values using the pound symbol (£) instead of the dollar sign ($).
 - Tailwind CSS provides the styling and Font Awesome supplies icons. Sections are wrapped in card components.
-- Headings use bold Montserrat, body text uses Inter, and buttons or highlights use light Source Sans Pro.
+- Headings use bold Roboto, body text uses Inter, and buttons or highlights use light Source Sans Pro.
 
 - Tabulator tables apply Tailwind utility classes for a consistent look and use the Simple theme.
 

--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -9,12 +9,12 @@
     <meta http-equiv="Expires" content="0">
     <title>Two-Factor Authentication</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
         body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Montserrat', sans-serif; font-weight: 700; }
+        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
     </style>
 </head>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,12 +9,12 @@
     <meta http-equiv="Expires" content="0">
     <title>Finance Manager</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
         body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Montserrat', sans-serif; font-weight: 700; }
+        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
     </style>
 </head>

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -59,13 +59,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const fontLink = document.createElement('link');
       fontLink.id = 'app-fonts';
       fontLink.rel = 'stylesheet';
-      fontLink.href = 'https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap';
+      fontLink.href = 'https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap';
       document.head.appendChild(fontLink);
     }
     const fontStyle = document.createElement('style');
     fontStyle.textContent = `
       body { font-family: 'Inter', sans-serif; font-weight: 400; }
-      h1, h2, h3, h4, h5, h6 { font-family: 'Montserrat', sans-serif; font-weight: 700; }
+      h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
       button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
     `;
     document.head.appendChild(fontStyle);

--- a/index.php
+++ b/index.php
@@ -66,10 +66,10 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <title>Login</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <style>
         body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Montserrat', sans-serif; font-weight: 700; }
+        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
         a { transition: color 0.2s ease; }
         a:hover { color: #4f46e5; }

--- a/users.php
+++ b/users.php
@@ -54,11 +54,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <title>User Management</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <style>
         body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Montserrat', sans-serif; font-weight: 700; }
+        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
         a { transition: color 0.2s ease; }
         a:hover { color: #4f46e5; }


### PR DESCRIPTION
## Summary
- swap Montserrat for narrower Roboto on all headings
- load Roboto via shared menu script and page templates
- document Roboto as the new heading font

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6f74ed82c832e896e92912a8d48b8