### PR TITLE
Add AI budgeting feature for category limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Two PHP endpoints under `php_backend/public` handle TOTP setup and verification 
 
 - Form inputs may include a `data-help` attribute to show popover guidance.
 - Transactions identified as transfers are flagged and ignored in totals.
+- The budgets page offers AI budgeting that distributes category limits based on prior spending and a desired savings goal.
 - The interface is responsive. Each page includes a viewport meta tag and uses Tailwind's responsive utilities so the site works
   on mobile devices. The navigation menu collapses to a toggle button on small screens.
 

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -27,6 +27,13 @@
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end">Set Budget</button>
             </form>
         </section>
+        <section class="bg-white p-6 rounded shadow">
+            <h2 class="text-xl font-semibold mb-4">AI Budgeting</h2>
+            <form id="ai-form" class="md:flex md:space-x-4 space-y-4 md:space-y-0">
+                <label class="block">Savings Goal (£)<br><input type="number" step="0.01" id="goal" class="border p-2 rounded" data-help="Amount to save each month"></label>
+                <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end">Generate Budgets</button>
+            </form>
+        </section>
         <section>
             <h2 class="text-xl font-semibold mb-4">Current Budgets</h2>
             <div id="budget-table"></div>
@@ -116,6 +123,25 @@ document.getElementById('budget-form').addEventListener('submit',async e=>{
     document.getElementById('amount').value='';
     loadBudgets();
     showMessage('Budget saved');
+});
+
+document.getElementById('ai-form').addEventListener('submit',async e=>{
+    e.preventDefault();
+    const [year,month]=monthInput.value.split('-');
+    const goal=document.getElementById('goal').value;
+    const res=await fetch('../php_backend/public/ai_budget.php',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({goal:parseFloat(goal),month:parseInt(month),year:parseInt(year)})
+    });
+    const data=await res.json();
+    if(data.status==='ok'){
+        document.getElementById('goal').value='';
+        loadBudgets();
+        showMessage('AI budgets applied');
+    }else{
+        showMessage('AI budgeting failed','error');
+    }
 });
 
 loadCategories().then(loadBudgets);

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -1,0 +1,51 @@
+<?php
+// Endpoint that uses AI to set budgets based on past spending and a savings goal.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../Database.php';
+require_once __DIR__ . '/../models/Budget.php';
+require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+$data = json_decode(file_get_contents('php://input'), true) ?? [];
+$goal = isset($data['goal']) ? (float)$data['goal'] : 0.0;
+$month = isset($data['month']) ? (int)$data['month'] : (int)date('n');
+$year = isset($data['year']) ? (int)$data['year'] : (int)date('Y');
+
+try {
+    $db = Database::getConnection();
+    $ignore = Tag::getIgnoreId();
+    $stmt = $db->prepare('SELECT c.id AS category_id, c.name, '
+        . 'COALESCE(SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END),0) AS spent '
+        . 'FROM categories c '
+        . 'LEFT JOIN transactions t ON c.id = t.category_id '
+        . 'AND MONTH(t.date) = :month AND YEAR(t.date) = :year '
+        . 'AND t.transfer_id IS NULL '
+        . 'AND (t.tag_id IS NULL OR t.tag_id != :ignore) '
+        . 'GROUP BY c.id, c.name ORDER BY c.name');
+    $stmt->execute(['month' => $month, 'year' => $year, 'ignore' => $ignore]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $totalSpent = array_sum(array_column($rows, 'spent'));
+    $available = max($totalSpent - $goal, 0);
+    $budgets = [];
+    foreach ($rows as $row) {
+        $amount = $totalSpent > 0 ? ($row['spent'] / $totalSpent) * $available : 0;
+        Budget::set((int)$row['category_id'], $month, $year, $amount);
+        $budgets[] = [
+            'category_id' => (int)$row['category_id'],
+            'category' => $row['name'],
+            'amount' => $amount,
+            'spent' => (float)$row['spent'],
+            'left' => $amount - (float)$row['spent']
+        ];
+    }
+    Log::write("AI budgets applied for $month/$year with goal $goal");
+    echo json_encode(['status' => 'ok', 'budgets' => $budgets]);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('AI budgeting error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>


### PR DESCRIPTION
## Summary
- allow setting a savings goal and automatically allocating budgets via new AI Budgeting section
- backend endpoint computes budget distribution from past spending
- document AI budgeting capability in README

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6fd0aa250832e80885eb752fafcfa