### PR TITLE
Display logged-in user in top bar

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -177,6 +177,18 @@ document.addEventListener('DOMContentLoaded', () => {
             releaseEl.textContent = 'v?';
           });
       }
+
+      const userEl = document.getElementById('current-user');
+      if (userEl) {
+        fetch('../php_backend/public/current_user.php')
+          .then(r => (r.ok ? r.json() : Promise.reject()))
+          .then(u => {
+            userEl.textContent = u.username || 'Guest';
+          })
+          .catch(() => {
+            userEl.textContent = 'Guest';
+          });
+      }
     })
     .catch(err => console.error('Top bar load failed', err));
 

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -19,6 +19,10 @@
         <i class="fa-solid fa-file-invoice-dollar mr-1"></i>
         <span id="latest-statement-text">Latest Statement</span>
       </a>
+      <div id="user-info" class="flex items-center">
+        <i class="fa-solid fa-circle-user mr-1"></i>
+        <span id="current-user">&nbsp;</span>
+      </div>
     </div>
   </div>
 </header>

--- a/php_backend/public/current_user.php
+++ b/php_backend/public/current_user.php
@@ -1,0 +1,14 @@
+<?php
+// Returns the username of the currently logged-in user.
+require_once __DIR__ . '/../nocache.php';
+ini_set('session.cookie_secure', '1');
+session_start();
+
+header('Content-Type: application/json');
+
+if (isset($_SESSION['username'])) {
+    echo json_encode(['username' => $_SESSION['username']]);
+} else {
+    http_response_code(401);
+    echo json_encode(['error' => 'Not logged in']);
+}


### PR DESCRIPTION
## Summary
- show logged-in user name with a user icon in the top navigation
- provide a `current_user` API endpoint to expose the active session's username
- load the username into the UI via menu.js after fetching the topbar

## Testing
- `php -l php_backend/public/current_user.php`
- `node --check frontend/js/menu.js`
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a70b8fba70832ea253b617a2cef2a6