### PR TITLE
Improve TOTP validation and switch UI icons to favicon

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -13,7 +13,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
 
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <!-- Reuse site favicon for inline icons instead of Font Awesome -->
     <style>
         body { font-family: 'Inter', sans-serif; }
 
@@ -27,8 +27,8 @@
         <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <div class="flex items-center mb-4">
-                <h1 class="text-2xl font-semibold flex-1 text-indigo-700"><i class="fas fa-shield-alt mr-2"></i>Two-Factor Authentication</h1>
-                <button id="help-btn" class="text-indigo-600 accent"><i class="fas fa-circle-info"></i></button>
+                <h1 class="text-2xl font-semibold flex-1 text-indigo-700"><img src="../favicon.svg" class="inline w-6 h-6 mr-2" alt="">Two-Factor Authentication</h1>
+                <button id="help-btn" class="text-indigo-600 accent"><img src="../favicon.svg" class="inline w-5 h-5" alt=""></button>
             </div>
             <p class="mb-4">Set up TOTP-based authentication and verify your one-time codes.</p>
 
@@ -36,7 +36,7 @@
                 <h2 class="text-xl mb-4">Setup</h2>
                 <form id="generate-form" class="space-y-4">
                     <input id="gen-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">
-                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-qrcode mr-2"></i>Generate QR</button>
+                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-2" alt="">Generate QR</button>
                 </form>
 
                 <div id="qr" class="mt-4 mx-auto"></div>
@@ -48,7 +48,7 @@
                 <form id="verify-form" class="space-y-4">
                     <input id="ver-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">
                     <input id="token" type="text" placeholder="TOTP Code" class="border p-2 rounded w-full" data-help="Enter the 6-digit code from your authenticator">
-                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-check mr-2"></i>Verify</button>
+                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-2" alt="">Verify</button>
                 </form>
             </div>
         </main>

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -45,7 +45,7 @@
     }
 
     function creditCardFormatter(cell){
-        return cell.getValue() ? '<i class="fa-solid fa-credit-card text-indigo-600"></i>' : '';
+        return cell.getValue() ? '<img src="../favicon.svg" class="w-4 h-4" alt="">' : '';
     }
 
     fetch('../php_backend/public/account_dashboard.php')

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>AI Tags</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <!-- Icons use favicon.svg; no external library needed -->
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
 <div class="flex min-h-screen">
@@ -28,7 +28,7 @@
         <section>
             <h2 class="text-xl font-semibold mb-2">Generate Tags</h2>
             <p class="mb-4">Use AI to suggest tags and categories for untagged transactions.</p>
-            <button id="run" class="bg-green-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-robot mr-1"></i>Run AI Tagging</button>
+            <button id="run" class="bg-green-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Run AI Tagging</button>
             <div id="result" class="mt-4"></div>
         </section>
     </main>
@@ -58,11 +58,11 @@ document.getElementById('run').addEventListener('click', async () => {
     const btn = document.getElementById('run');
     btn.disabled = true;
     btn.classList.add('opacity-50', 'cursor-not-allowed');
-    resultEl.innerHTML = '<i class="fa-solid fa-spinner fa-spin mr-2"></i>Submitting to AI...';
+    resultEl.innerHTML = '<img src="../favicon.svg" class="inline w-4 h-4 mr-2 animate-spin" alt="">Submitting to AI...';
     showMessage('AI tagging started');
     try {
         const res = await fetch('../php_backend/public/ai_tags.php', {method: 'POST'});
-        resultEl.innerHTML = '<i class="fa-solid fa-spinner fa-spin mr-2"></i>Awaiting AI response...';
+        resultEl.innerHTML = '<img src="../favicon.svg" class="inline w-4 h-4 mr-2 animate-spin" alt="">Awaiting AI response...';
         const data = await res.json();
         if (data.error) {
             resultEl.textContent = data.error;

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Backup & Restore</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-1P4Wf2M1yGvdfq3NzfIgVVP8341/ySfWaSrtwE0NtP28s8Qd8VVS6I5aOQSXgjOaX4nHCqB6f+GO6zkRgLpmMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <!-- Icons reuse favicon.svg, no external icon library needed -->
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
     <div class="flex min-h-screen">
@@ -32,17 +32,17 @@
                     <label class="block"><input type="checkbox" name="parts" value="budgets" class="mr-2">Budgets</label>
 
                 </div>
-                <button id="download-backup" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-download mr-2"></i>Download Backup</button>
+                <button id="download-backup" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-2" alt="">Download Backup</button>
 
                 <p class="mt-4">Export all transactions to a single OFX file.</p>
-                <button id="download-ofx" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-file-export mr-2"></i>Download OFX</button>
+                <button id="download-ofx" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-2" alt="">Download OFX</button>
             </section>
             <section class="bg-white p-6 rounded shadow space-y-4">
                 <h2 class="text-xl font-semibold">Restore Backup</h2>
                 <p>Select a gzipped JSON backup file to restore any included transactions, categories, tags, groups, segments, or budgets.</p>
                 <form id="restore-form" action="../php_backend/public/restore.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                     <input type="file" id="backup-file" name="backup_file" accept="application/gzip,application/json" required data-help="Choose a previously downloaded compressed backup file">
-                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-upload mr-2"></i>Restore</button>
+                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-2" alt="">Restore</button>
                 </form>
             </section>
         </main>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -11,7 +11,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <!-- Icons use favicon.svg; Font Awesome removed -->
 
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
@@ -34,7 +34,7 @@
             <p class="mb-4">Send your savings goal and the last 12 months of category totals to the AI to propose next month's budgets and provide a brief explanation.</p>
             <form id="ai-form" class="md:flex md:space-x-4 space-y-4 md:space-y-0">
                 <label class="block">Savings Goal (£)<br><input type="number" step="0.01" id="goal" class="border p-2 rounded" data-help="Monthly amount you want to save. The AI uses this plus a year of history to set budgets."></label>
-                <button id="ai-run" type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end"><i class="fa-solid fa-robot mr-1"></i>Generate Budgets</button>
+                <button id="ai-run" type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Generate Budgets</button>
             </form>
             <div id="ai-result" class="mt-4"></div>
 
@@ -87,7 +87,7 @@ async function loadBudgets(){
                 {title:'Budget',field:'amount',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
                 {title:'Spent',field:'spent',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
                 {title:'Left',field:'left',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
-                {formatter:()=>'<i class="fa-solid fa-trash text-red-600"></i>',width:40,hozAlign:'center',cellClick:async(e,cell)=>{
+                {formatter:()=>'<img src="../favicon.svg" class="w-4 h-4" alt="">',width:40,hozAlign:'center',cellClick:async(e,cell)=>{
                     if(!confirm('Delete this budget?')) return;
                     const id=cell.getRow().getData().id;
                     await fetch('../php_backend/public/budgets.php',{
@@ -139,7 +139,7 @@ document.getElementById('ai-form').addEventListener('submit',async e=>{
     const btn=document.getElementById('ai-run');
     btn.disabled=true;
     btn.classList.add('opacity-50','cursor-not-allowed');
-    resultEl.innerHTML='<i class="fa-solid fa-spinner fa-spin mr-2"></i>Submitting to AI...';
+    resultEl.innerHTML='<img src="../favicon.svg" class="inline w-4 h-4 mr-2 animate-spin" alt="">Submitting to AI...';
     showMessage('AI budgeting started');
     try{
         const res=await fetch('../php_backend/public/ai_budget.php',{
@@ -147,7 +147,7 @@ document.getElementById('ai-form').addEventListener('submit',async e=>{
             headers:{'Content-Type':'application/json'},
             body:JSON.stringify({goal:parseFloat(goal),month:parseInt(month),year:parseInt(year)})
         });
-        resultEl.innerHTML='<i class="fa-solid fa-spinner fa-spin mr-2"></i>Awaiting AI response...';
+        resultEl.innerHTML='<img src="../favicon.svg" class="inline w-4 h-4 mr-2 animate-spin" alt="">Awaiting AI response...';
         const data=await res.json();
         if(data.status==='ok'){
             document.getElementById('goal').value='';

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Categories</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <!-- Font Awesome removed; using favicon.svg for icons -->
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
     <div class="flex min-h-screen">

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -19,8 +19,8 @@
             <p class="mb-4">Remove unwanted duplicate entries to keep your records accurate.</p>
             <div class="bg-white p-6 rounded shadow">
                 <div class="mb-4 space-x-2">
-                    <button id="refresh" class="bg-indigo-600 text-white px-3 py-1 rounded"><i class="fa-solid fa-arrows-rotate mr-1"></i>Refresh</button>
-                    <button id="dedupe-all" class="bg-red-600 text-white px-3 py-1 rounded"><i class="fa-solid fa-broom mr-1"></i>Dedupe All</button>
+                    <button id="refresh" class="bg-indigo-600 text-white px-3 py-1 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Refresh</button>
+                    <button id="dedupe-all" class="bg-red-600 text-white px-3 py-1 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Dedupe All</button>
                 </div>
                 <div id="progress-container" class="hidden w-full bg-gray-200 h-2 rounded mb-4">
                     <div id="progress-bar" class="h-2 bg-indigo-600 rounded" style="width:0%"></div>
@@ -78,7 +78,7 @@
                         { title: 'Description', field: 'description' },
                         { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
                         { title: 'Count', field: 'count', hozAlign: 'right' },
-                        { title: 'Remove', formatter: function(){ return '<button class="bg-red-600 text-white px-2 py-1 rounded text-sm"><i class="fa-solid fa-trash"></i></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); dedupe(r.ids); } }
+                        { title: 'Remove', formatter: function(){ return '<button class="bg-red-600 text-white px-2 py-1 rounded text-sm"><img src="../favicon.svg" class="w-4 h-4" alt=""></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); dedupe(r.ids); } }
                     ]
                 });
             }

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -54,7 +54,7 @@ async function loadGroups() {
                 const g = cell.getRow().getData();
                 const container = document.createElement('div');
                 const edit = document.createElement('button');
-                edit.innerHTML = '<i class="fa-solid fa-pen"></i>';
+                edit.innerHTML = '<img src="../favicon.svg" class="w-4 h-4" alt="">';
                 edit.setAttribute('aria-label','Edit');
                 edit.className = 'bg-indigo-600 text-white px-2 py-1 rounded mr-2';
                 edit.addEventListener('click', async () => {
@@ -71,7 +71,7 @@ async function loadGroups() {
                     showMessage('Group updated');
                 });
                 const del = document.createElement('button');
-                del.innerHTML = '<i class="fa-solid fa-trash"></i>';
+                del.innerHTML = '<img src="../favicon.svg" class="w-4 h-4" alt="">';
                 del.setAttribute('aria-label','Delete');
                 del.className = 'bg-red-600 text-white px-2 py-1 rounded';
                 del.addEventListener('click', async () => {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <!-- Inline icons use favicon.svg; Font Awesome not required -->
     <style>
         body { font-family: 'Inter', sans-serif; }
         h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
@@ -28,15 +28,15 @@
 
             <section class="mt-8 grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="bg-white p-6 rounded shadow flex flex-col items-center text-center">
-                    <i class="fas fa-chart-line text-indigo-600 text-4xl mb-2"></i>
+                    <img src="../favicon.svg" class="w-16 h-16 mb-2" alt="">
                     <p class="text-gray-700">Visualise your spending trends with clear charts that highlight where your money goes.</p>
                 </div>
                 <div class="bg-white p-6 rounded shadow flex flex-col items-center text-center">
-                    <i class="fas fa-piggy-bank text-indigo-600 text-4xl mb-2"></i>
+                    <img src="../favicon.svg" class="w-16 h-16 mb-2" alt="">
                     <p class="text-gray-700">Track savings effortlessly to see how your balance grows over time.</p>
                 </div>
                 <div class="bg-white p-6 rounded shadow flex flex-col items-center text-center">
-                    <i class="fas fa-money-bill-wave text-indigo-600 text-4xl mb-2"></i>
+                    <img src="../favicon.svg" class="w-16 h-16 mb-2" alt="">
                     <p class="text-gray-700">Manage budgets with ease by setting targets and watching your progress.</p>
                 </div>
             </section>

--- a/frontend/js/category_drag.js
+++ b/frontend/js/category_drag.js
@@ -72,7 +72,7 @@
 
     const editBtn = document.createElement('button');
     editBtn.className = 'text-indigo-600';
-    editBtn.innerHTML = '<i class="fas fa-edit"></i>';
+    editBtn.innerHTML = '<img src="../favicon.svg" class="w-4 h-4" alt="">';
     editBtn.addEventListener('click', async () => {
       const name = prompt('Category Name', cat.name);
       if (name === null) return;
@@ -92,7 +92,7 @@
 
     const delBtn = document.createElement('button');
     delBtn.className = 'text-red-600';
-    delBtn.innerHTML = '<i class="fas fa-trash"></i>';
+    delBtn.innerHTML = '<img src="../favicon.svg" class="w-4 h-4" alt="">';
     delBtn.addEventListener('click', async () => {
       if (!confirm('Delete this category?')) return;
       await fetch('../php_backend/public/categories.php', {

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -45,15 +45,6 @@ document.addEventListener('DOMContentLoaded', () => {
       'z-40'
     );
 
-    // Load Font Awesome for menu icons if not already loaded
-    if (!document.getElementById('fa-icons')) {
-      const link = document.createElement('link');
-      link.id = 'fa-icons';
-      link.rel = 'stylesheet';
-      link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css';
-      document.head.appendChild(link);
-    }
-
     // Load site fonts and apply them to headings, body text and accents
     if (!document.getElementById('app-fonts')) {
       const fontLink = document.createElement('link');

--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -1,5 +1,4 @@
 // Provides a help overlay describing the purpose of the current page.
-// Loads Font Awesome for the help icon if it is not already available.
 const init = () => {
   const page = location.pathname.split('/').pop();
   const helpTexts = {
@@ -39,16 +38,8 @@ const init = () => {
   const helpText = helpTexts[page];
   if (!helpText) return;
 
-  if (!document.getElementById('fa-icons')) {
-    const link = document.createElement('link');
-    link.id = 'fa-icons';
-    link.rel = 'stylesheet';
-    link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css';
-    document.head.appendChild(link);
-  }
-
   const btn = document.createElement('button');
-  btn.innerHTML = '<i class="fas fa-question"></i>';
+  btn.innerHTML = '<img src="../favicon.svg" class="w-6 h-6" alt="">';
   btn.className = 'fixed bottom-4 right-4 bg-indigo-600 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg';
 
   const overlay = document.createElement('div');

--- a/frontend/js/segment_drag.js
+++ b/frontend/js/segment_drag.js
@@ -67,7 +67,7 @@
 
     const editBtn = document.createElement('button');
     editBtn.className = 'text-indigo-600';
-    editBtn.innerHTML = '<i class="fas fa-edit"></i>';
+    editBtn.innerHTML = '<img src="../favicon.svg" class="w-4 h-4" alt="">';
     editBtn.addEventListener('click', async () => {
       const name = prompt('Segment Name', seg.name);
       if (name === null) return;
@@ -87,7 +87,7 @@
 
     const delBtn = document.createElement('button');
     delBtn.className = 'text-red-600';
-    delBtn.innerHTML = '<i class="fas fa-trash"></i>';
+    delBtn.innerHTML = '<img src="../favicon.svg" class="w-4 h-4" alt="">';
     delBtn.addEventListener('click', async () => {
       if (!confirm('Delete this segment?')) return;
       await fetch('../php_backend/public/segments.php', {

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -4,74 +4,74 @@
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">General Overview</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-      <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="index.html"><i class="fa-solid fa-house text-indigo-600 mr-1"></i> Home</a></li>
-      <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="upload.html"><i class="fa-solid fa-upload text-indigo-600 mr-1"></i> Upload OFX Files</a></li>
+      <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="index.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Home</a></li>
+      <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="upload.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Upload OFX Files</a></li>
     </ul>
   </div>
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Transaction Hub</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_statement.html"><i class="fa-solid fa-file-invoice-dollar text-indigo-600 mr-1"></i> Monthly Statement</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="report.html"><i class="fa-solid fa-table text-indigo-600 mr-1"></i> Transaction Reports</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="search.html"><i class="fa-solid fa-magnifying-glass text-indigo-600 mr-1"></i> Search Transactions</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="transfers.html"><i class="fa-solid fa-right-left text-indigo-600 mr-1"></i> Transfers</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ignored.html"><i class="fa-solid fa-eye-slash text-indigo-600 mr-1"></i> Ignored Transactions</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_statement.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Monthly Statement</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="report.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Transaction Reports</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="search.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Search Transactions</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="transfers.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Transfers</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ignored.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Ignored Transactions</a></li>
     </ul>
   </div>
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Dashboards</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="yearly_dashboard.html"><i class="fa-solid fa-chart-line text-indigo-600 mr-1"></i> Yearly Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="all_years_dashboard.html"><i class="fa-solid fa-chart-bar text-indigo-600 mr-1"></i> All Years Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_dashboard.html"><i class="fa-solid fa-chart-column text-indigo-600 mr-1"></i> Monthly Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="group_dashboard.html"><i class="fa-solid fa-users text-indigo-600 mr-1"></i> Group Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="account_dashboard.html"><i class="fa-solid fa-wallet text-indigo-600 mr-1"></i> Account Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="recurring_spend.html"><i class="fa-solid fa-repeat text-indigo-600 mr-1"></i> Recurring Spend</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="yearly_dashboard.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Yearly Dashboard</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="all_years_dashboard.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> All Years Dashboard</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_dashboard.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Monthly Dashboard</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="group_dashboard.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Group Dashboard</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="account_dashboard.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Account Dashboard</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="recurring_spend.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Recurring Spend</a></li>
     </ul>
   </div>
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Graphs</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="graphs.html"><i class="fa-solid fa-chart-pie text-indigo-600 mr-1"></i> Graphs</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="graphs.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Graphs</a></li>
     </ul>
   </div>
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Budget Plans</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="budgets.html"><i class="fa-solid fa-wallet text-indigo-600 mr-1"></i> Budgets</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="budgets.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Budgets</a></li>
     </ul>
   </div>
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Organisation</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="tags.html"><i class="fa-solid fa-tags text-indigo-600 mr-1"></i> Manage Tags</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ai_tags.html"><i class="fa-solid fa-robot text-indigo-600 mr-1"></i> AI Tags</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="tags.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Manage Tags</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ai_tags.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> AI Tags</a></li>
         <li>
           <a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="missing_tags.html">
-            <span class="flex items-center"><i class="fa-solid fa-circle-question text-indigo-600 mr-1"></i> Missing Tags</span>
+            <span class="flex items-center"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Missing Tags</span>
             <span id="missing-tags-count" class="ml-auto bg-red-600 text-white text-xs font-bold rounded-full px-2 hidden"></span>
           </a>
         </li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="categories.html"><i class="fa-solid fa-folder-open text-indigo-600 mr-1"></i> Manage Categories</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="groups.html"><i class="fa-solid fa-users text-indigo-600 mr-1"></i> Manage Groups</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="segments.html"><i class="fa-solid fa-layer-group text-indigo-600 mr-1"></i> Manage Segments</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="categories.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Manage Categories</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="groups.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Manage Groups</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="segments.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Manage Segments</a></li>
       </ul>
     </div>
 
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Admin Tools</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="processes.html"><i class="fa-solid fa-gear text-indigo-600 mr-1"></i> Run Processes</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="logs.html"><i class="fa-solid fa-clipboard-list text-indigo-600 mr-1"></i> View Logs</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="dedupe.html"><i class="fa-solid fa-clone text-indigo-600 mr-1"></i> Remove Duplicates</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="backup.html"><i class="fa-solid fa-database text-indigo-600 mr-1"></i> Backup &amp; Restore</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="../users.php"><i class="fa-solid fa-user text-indigo-600 mr-1"></i> Manage Users</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="../logout.php"><i class="fa-solid fa-right-from-bracket text-indigo-600 mr-1"></i> Logout</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="processes.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Run Processes</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="logs.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> View Logs</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="dedupe.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Remove Duplicates</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="backup.html"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Backup &amp; Restore</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="../users.php"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Manage Users</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="../logout.php"><img src="../favicon.svg" class="w-4 h-4 mr-1" alt=""> Logout</a></li>
     </ul>
   </div>
 </div>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -12,7 +12,7 @@
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <!-- Icons rely on favicon.svg; no Font Awesome needed -->
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
     <div class="flex min-h-screen">

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Run Processes</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <!-- Icons use favicon.svg; no Font Awesome needed -->
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
     <div class="flex min-h-screen">
@@ -18,10 +18,10 @@
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Run Processes</h1>
             <p class="mb-4">Run background tasks like auto-tagging, category or segment assignment. These automated processes tidy your data so reports stay accurate without manual effort.</p>
             <div class="space-x-4">
-                <button id="tagging-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-tags mr-1"></i>Run Tagging</button>
-                <button id="categories-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-list mr-1"></i>Apply Categories</button>
-                <button id="segments-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-layer-group mr-1"></i>Apply Segments</button>
-                <button id="clear-btn" class="bg-red-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-eraser mr-1"></i>Clear Tags/Categories/Segments</button>
+                <button id="tagging-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Run Tagging</button>
+                <button id="categories-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Apply Categories</button>
+                <button id="segments-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Apply Segments</button>
+                <button id="clear-btn" class="bg-red-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Clear Tags/Categories/Segments</button>
             </div>
             <div id="progress-container" class="w-full bg-gray-200 h-2 mt-4 rounded hidden">
                 <div id="progress-bar" class="h-full bg-indigo-600 w-0"></div>

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -19,7 +19,7 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Recurring Spend Detection</h1>
             <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses. The results highlight ongoing commitments so you know where money leaves your account regularly.</p>
-            <button id="run-analysis" class="bg-indigo-600 text-white px-4 py-2 rounded mb-4"><i class="fa-solid fa-play mr-2"></i>Run Analysis</button>
+            <button id="run-analysis" class="bg-indigo-600 text-white px-4 py-2 rounded mb-4"><img src="../favicon.svg" class="inline w-4 h-4 mr-2" alt="">Run Analysis</button>
             <div id="results-grid"></div>
             <p id="total" class="mt-4 text-right"></p>
         </main>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -34,7 +34,7 @@
             </form>
             <div class="mt-4 flex items-center space-x-2">
                 <label class="block flex-1">Saved Reports: <select id="saved-reports" class="border p-2 rounded w-full" data-help="Load a saved report"></select></label>
-                <button type="button" id="delete-report" class="bg-red-600 text-white px-3 py-2 rounded" aria-label="Delete saved report"><i class="fa-solid fa-trash"></i></button>
+                <button type="button" id="delete-report" class="bg-red-600 text-white px-3 py-2 rounded" aria-label="Delete saved report"><img src="../favicon.svg" class="inline w-4 h-4" alt=""></button>
             </div>
             <div id="results-grid" class="mt-4"></div>
             <div id="chart" class="mt-6" style="height:400px;"></div>

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -9,7 +9,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Manage Segments</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+    <!-- Font Awesome removed; using favicon.svg for icons -->
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
     <div class="flex min-h-screen">

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -56,7 +56,7 @@ async function loadTags(){
                 const t = cell.getRow().getData();
                 const container = document.createElement('div');
                 const edit = document.createElement('button');
-                edit.innerHTML = '<i class="fa-solid fa-pen"></i>';
+                edit.innerHTML = '<img src="../favicon.svg" class="w-4 h-4" alt="">';
                 edit.setAttribute('aria-label','Edit');
                 edit.className = 'bg-indigo-600 text-white px-2 py-1 rounded mr-2';
                 edit.addEventListener('click', async () => {
@@ -75,7 +75,7 @@ async function loadTags(){
                     showMessage('Tag updated');
                 });
                 const del = document.createElement('button');
-                del.innerHTML = '<i class="fa-solid fa-trash"></i>';
+                del.innerHTML = '<img src="../favicon.svg" class="w-4 h-4" alt="">';
                 del.setAttribute('aria-label','Delete');
                 del.className = 'bg-red-600 text-white px-2 py-1 rounded';
                 del.addEventListener('click', async () => {

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -3,7 +3,7 @@
   <div class="w-full flex items-center justify-between px-4">
     <div class="flex items-center space-x-4">
       <img src="../favicon.svg" alt="Finance Manager Logo" class="h-8 w-8">
-      <button id="menu-toggle" class="md:hidden bg-indigo-700 p-2 rounded"><i class="fa-solid fa-bars"></i></button>
+      <button id="menu-toggle" class="md:hidden bg-indigo-700 p-2 rounded"><img src="../favicon.svg" class="h-4 w-4" alt=""></button>
       <div class="font-bold text-lg flex items-center">
         <span>Personal Finance Manager</span>
         <span id="release-number" class="ml-2 bg-indigo-700 text-white text-[0.675rem] px-2 py-0.5 rounded">v0.0.0</span>
@@ -12,15 +12,15 @@
     <div id="topbar-right" class="flex items-center space-x-4 transition-transform duration-300">
       <form id="topbar-search" action="search.html" method="get" class="flex">
         <input type="text" name="value" placeholder="Search transactions" class="p-1 rounded text-black" />
-        <button type="submit" class="ml-2"><i class="fa-solid fa-magnifying-glass"></i></button>
+        <button type="submit" class="ml-2"><img src="../favicon.svg" class="h-4 w-4" alt=""></button>
       </form>
       <a id="latest-statement-link" href="monthly_statement.html" class="flex items-center">
 
-        <i class="fa-solid fa-file-invoice-dollar mr-1"></i>
+        <img src="../favicon.svg" class="h-4 w-4 mr-1" alt="">
         <span id="latest-statement-text">Latest Statement</span>
       </a>
       <div id="user-info" class="flex items-center">
-        <i class="fa-solid fa-circle-user mr-1"></i>
+        <img src="../favicon.svg" class="h-4 w-4 mr-1" alt="">
         <span id="current-user">&nbsp;</span>
       </div>
     </div>

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Expires" content="0">
     <title>Transaction Details</title>
     <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <!-- Icons use favicon.svg; external icon library removed -->
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
     <div class="flex min-h-screen">
@@ -47,7 +47,7 @@
             const tagBtn = document.createElement('button');
             tagBtn.className = `flex items-center justify-between w-48 px-4 py-2 rounded text-white ${tx.tag_name ? 'bg-green-600' : 'bg-gray-400'}`;
             tagBtn.innerHTML = `
-                <i class="fa-solid fa-tag fa-2x"></i>
+                <img src="../favicon.svg" class="w-8 h-8" alt="">
                 <span class="ml-4 flex-1 text-right">${tx.tag_name || 'No tag'}</span>
             `;
             icons.appendChild(tagBtn);
@@ -55,7 +55,7 @@
             const catBtn = document.createElement('button');
             catBtn.className = `flex items-center justify-between w-48 px-4 py-2 rounded text-white ${tx.category_name ? 'bg-blue-600' : 'bg-gray-400'}`;
             catBtn.innerHTML = `
-                <i class="fa-solid ${tx.category_name ? 'fa-folder-open' : 'fa-folder'} fa-2x"></i>
+                <img src="../favicon.svg" class="w-8 h-8" alt="">
                 <span class="ml-4 flex-1 text-right">${tx.category_name || 'No category'}</span>
             `;
             icons.appendChild(catBtn);
@@ -63,7 +63,7 @@
             const groupBtn = document.createElement('button');
             groupBtn.className = `flex items-center justify-between w-48 px-4 py-2 rounded text-white ${tx.group_name ? 'bg-purple-600' : 'bg-gray-400'}`;
             groupBtn.innerHTML = `
-                <i class="fa-solid fa-layer-group fa-2x"></i>
+                <img src="../favicon.svg" class="w-8 h-8" alt="">
                 <span class="ml-4 flex-1 text-right">${tx.group_name || 'No group'}</span>
             `;
             icons.appendChild(groupBtn);
@@ -86,7 +86,7 @@
                     <div class="flex"><dt class="font-semibold w-40">OFX Type</dt><dd>${tx.ofx_type || ''}</dd></div>
                     ${tx.ofx_id ? `<div class="flex"><dt class="font-semibold w-40">OFX ID</dt><dd>${tx.ofx_id}</dd></div>` : ''}
                     ${tx.bank_ofx_id ? `<div class="flex"><dt class="font-semibold w-40">Bank OFX ID</dt><dd>${tx.bank_ofx_id}</dd></div>` : ''}
-                    <div class="flex"><dt class="font-semibold w-40">Transfer</dt><dd>${tx.transfer_id ? '<span class="text-blue-600"><i class="fa-solid fa-right-left mr-1"></i>Yes – ignored in KPI, income and expense totals (ID ' + tx.transfer_id + ')</span>' : 'No'}</dd></div>
+                    <div class="flex"><dt class="font-semibold w-40">Transfer</dt><dd>${tx.transfer_id ? '<span class="text-blue-600"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Yes – ignored in KPI, income and expense totals (ID ' + tx.transfer_id + ')</span>' : 'No'}</dd></div>
                     <div class="flex"><dt class="font-semibold w-40">Category</dt><dd>${tx.category_name || 'None'}</dd></div>
                 </dl>
                 <label class="block">Tag: <input type="text" id="tag" class="border p-2 rounded w-full" data-help="Enter a new tag name to auto-tag similar transactions"></label>

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -21,8 +21,8 @@
                     Detected Transfers
 
                     <span class="space-x-2">
-                        <button id="assist-btn" class="bg-indigo-600 text-white px-3 py-1 rounded text-sm"><i class="fa-solid fa-wand-magic-sparkles mr-1"></i>Assist</button>
-                        <button id="mark-all" class="bg-green-600 text-white px-3 py-1 rounded text-sm"><i class="fa-solid fa-check-double mr-1"></i>Mark All</button>
+                        <button id="assist-btn" class="bg-indigo-600 text-white px-3 py-1 rounded text-sm"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Assist</button>
+                        <button id="mark-all" class="bg-green-600 text-white px-3 py-1 rounded text-sm"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Mark All</button>
                     </span>
 
                 </h1>
@@ -32,7 +32,7 @@
             <section>
                 <h2 class="text-xl font-semibold mb-4 flex items-center justify-between">
                     Marked Transfers
-                    <button id="undo-all" class="bg-red-600 text-white px-3 py-1 rounded text-sm"><i class="fa-solid fa-rotate-left mr-1"></i>Undo All</button>
+                    <button id="undo-all" class="bg-red-600 text-white px-3 py-1 rounded text-sm"><img src="../favicon.svg" class="inline w-4 h-4 mr-1" alt="">Undo All</button>
                 </h2>
                 <div id="linked-table"></div>
             </section>
@@ -41,7 +41,7 @@
                 <form id="link-form" class="space-y-4">
                     <input type="number" id="id1" placeholder="First transaction ID" class="border p-2 rounded w-full" data-help="ID of the first transaction">
                     <input type="number" id="id2" placeholder="Second transaction ID" class="border p-2 rounded w-full" data-help="ID of the matching transaction">
-                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fa-solid fa-link mr-2"></i>Link</button>
+                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="../favicon.svg" class="inline w-4 h-4 mr-2" alt="">Link</button>
                 </form>
             </section>
         </main>
@@ -71,7 +71,7 @@
                 { title: 'To Account', field: 'to_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.to_id}">${cell.getValue()}</a>`; } },
                 { title: 'To Amount', field: 'to_amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
                 { title: 'To Description', field: 'to_description' },
-                { title: 'Mark', formatter: function(){ return '<button class="bg-green-600 text-white px-2 py-1 rounded text-sm"><i class="fa-solid fa-check"></i></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); markTransfers([[r.from_id, r.to_id]]); } }
+                { title: 'Mark', formatter: function(){ return '<button class="bg-green-600 text-white px-2 py-1 rounded text-sm"><img src="../favicon.svg" class="w-4 h-4" alt=""></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); markTransfers([[r.from_id, r.to_id]]); } }
             ]
         });
     }
@@ -110,7 +110,7 @@
                 { title: 'To Account', field: 'to_account', formatter: function(cell){ const row = cell.getRow().getData(); return `<a href="transaction.html?id=${row.to_id}">${cell.getValue()}</a>`; } },
                 { title: 'To Amount', field: 'to_amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
                 { title: 'To Description', field: 'to_description' },
-                { title: 'Undo', formatter: function(){ return '<button class="bg-red-600 text-white px-2 py-1 rounded text-sm"><i class="fa-solid fa-rotate-left"></i></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); unmarkTransfers([r.from_id]); } }
+                { title: 'Undo', formatter: function(){ return '<button class="bg-red-600 text-white px-2 py-1 rounded text-sm"><img src="../favicon.svg" class="w-4 h-4" alt=""></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); unmarkTransfers([r.from_id]); } }
             ]
         });
     }

--- a/php_backend/Totp.php
+++ b/php_backend/Totp.php
@@ -8,17 +8,17 @@ class Totp {
 
 
     public static function getOtpAuthUri($username, $secret) {
-        $issuer = 'Accounts';
-        return sprintf('otpauth://totp/%s?secret=%s&issuer=%s',
-
+        return sprintf('otpauth://totp/%s?secret=%s',
             rawurlencode($username),
-            $secret,
-            rawurlencode($issuer)
+            $secret
         );
-
     }
 
-    public static function verifyCode($secret, $code, $window = 1) {
+    public static function verifyCode($secret, $code, $window = 2) {
+        $code = preg_replace('/\s+/', '', $code);
+        if (!preg_match('/^\d{6}$/', $code)) {
+            return false;
+        }
         $key = self::base32Decode($secret);
         $time = floor(time() / 30);
         for ($i = -$window; $i <= $window; $i++) {

--- a/php_backend/public/totp_verify.php
+++ b/php_backend/public/totp_verify.php
@@ -7,8 +7,8 @@ header('Content-Type: application/json');
 $input = json_decode(file_get_contents('php://input'), true);
 $username = $input['username'] ?? ($_SESSION['username'] ?? '');
 
-$token = $input['token'] ?? '';
-if ($username === '' || $token === '') {
+$token = isset($input['token']) ? (string)$input['token'] : '';
+if ($username === '' || trim($token) === '') {
     echo json_encode(['verified' => false, 'error' => 'Missing fields']);
     exit;
 }

--- a/users.php
+++ b/users.php
@@ -57,7 +57,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
 
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <!-- Use favicon.svg for inline icons instead of Font Awesome -->
     <style>
         body { font-family: 'Inter', sans-serif; }
         h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
@@ -99,7 +99,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div class="bg-white p-4 rounded shadow space-y-4 mb-6">
             <form id="generate-form" class="space-y-4">
                 <input type="hidden" id="gen-username" value="<?= htmlspecialchars($username) ?>">
-                <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-qrcode mr-2"></i>Generate QR</button>
+                <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><img src="favicon.svg" class="inline w-4 h-4 mr-2" alt="">Generate QR</button>
             </form>
 
             <div id="qr" class="mt-4 mx-auto"></div>
@@ -108,8 +108,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <input type="hidden" id="ver-username" value="<?= htmlspecialchars($username) ?>">
                 <input id="token" type="text" placeholder="TOTP Code" class="border p-2 rounded w-full" data-help="Enter the 6-digit code from your authenticator">
                 <div class="flex space-x-2">
-                    <button type="submit" class="flex-1 bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-check mr-2"></i>Verify</button>
-                    <button id="disable-2fa" type="button" class="flex-1 bg-gray-500 text-white px-4 py-2 rounded"><i class="fas fa-ban mr-2"></i>Disable</button>
+                    <button type="submit" class="flex-1 bg-indigo-600 text-white px-4 py-2 rounded"><img src="favicon.svg" class="inline w-4 h-4 mr-2" alt="">Verify</button>
+                    <button id="disable-2fa" type="button" class="flex-1 bg-gray-500 text-white px-4 py-2 rounded"><img src="favicon.svg" class="inline w-4 h-4 mr-2" alt="">Disable</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- Trim and validate TOTP codes with a larger time window and QR codes without an issuer
- Replace Font Awesome icons across the interface with the shared `favicon.svg`

## Testing
- `php -l php_backend/Totp.php`
- `php -l php_backend/public/totp_verify.php`
- `php -l users.php`
- `php /tmp/test_totp_flow.php`


------
https://chatgpt.com/codex/tasks/task_e_68a710b0efb8832e8650197999fa2cf5