### PR TITLE
Fix credit card account creation during OFX import

### DIFF
--- a/php_backend/OfxParser.php
+++ b/php_backend/OfxParser.php
@@ -19,7 +19,13 @@ class OfxParser {
         if (!$acctNode || trim((string)$acctNode[0]->ACCTID) === '') {
             throw new Exception('Missing account number');
         }
+        // Credit card statements may include a BANKID that is not a real
+        // sort code. Identify CCACCTFROM nodes explicitly and ignore any
+        // BANKID so the account is treated as a credit card when imported.
         $sortCode = trim((string)$acctNode[0]->BANKID) ?: null;
+        if (strtoupper($acctNode[0]->getName()) === 'CCACCTFROM') {
+            $sortCode = null;
+        }
         $accountNumber = trim((string)$acctNode[0]->ACCTID);
         $accountName = trim((string)$acctNode[0]->ACCTNAME) ?: 'Default';
         // Ledger balance


### PR DESCRIPTION
## Summary
- Treat credit card OFX account nodes (CCACCTFROM) as credit card accounts regardless of BANKID
- Ignore BANKID for credit cards so sort code is stored as NULL

## Testing
- `php tests/run_tests.php`
- `php -l php_backend/OfxParser.php`


------
https://chatgpt.com/codex/tasks/task_e_68a718f1a1d0832e81a67dd765daca62