### PR TITLE
Fix credit card account creation during OFX import

### DIFF
--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -36,6 +36,16 @@ function assertEqual($expected, $actual, string $message) {
 // Database driver should be sqlite
 assertEqual('sqlite', $db->getAttribute(PDO::ATTR_DRIVER_NAME), 'Database driver is sqlite');
 
+// Masked credit card numbers should have masking removed
+$maskedOfx = <<<OFX
+<OFX>
+<CCACCTFROM><ACCTID>552213******8609</ACCTID></CCACCTFROM>
+<BANKTRANLIST><STMTTRN><DTPOSTED>20240101</DTPOSTED><TRNAMT>-10.00</TRNAMT></STMTTRN></BANKTRANLIST>
+</OFX>
+OFX;
+$parsedMasked = OfxParser::parse($maskedOfx);
+assertEqual('5522138609', $parsedMasked['account']['number'], 'Masked account numbers are normalised');
+
 // Test user creation and retrieval
 $userId = User::create('alice', 'secret');
 assertEqual(1, $userId, 'User ID starts at 1');


### PR DESCRIPTION
## Summary
- Treat credit card OFX account nodes (CCACCTFROM) as credit card accounts regardless of BANKID
- Ignore BANKID for credit cards so sort code is stored as NULL
- Strip non-alphanumeric characters from account numbers so masked IDs are stored consistently

## Testing
- `php tests/run_tests.php`
- `php -l php_backend/OfxParser.php`


------
https://chatgpt.com/codex/tasks/task_e_68a718f1a1d0832e81a67dd765daca62