### PR TITLE
Auto tag INT transactions as interest charge

### DIFF
--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -11,6 +11,9 @@ class Transaction {
     public static function create(int $account, string $date, float $amount, string $description, ?string $memo = null, ?int $category = null, ?int $tag = null, ?int $group = null, ?string $ofx_id = null, ?string $ofx_type = null, ?string $bank_ofx_id = null): int {
         if ($tag === null) {
             $tag = Tag::findMatch($description);
+            if ($tag === null && $ofx_type === 'INT') {
+                $tag = Tag::getInterestChargeId();
+            }
         }
         $db = Database::getConnection();
 


### PR DESCRIPTION
## Summary
- Tag transactions with OFX type `INT` as "interest charge"
- Add helper to create/retrieve the "interest charge" tag
- Include OFX type check during bulk auto-tagging

## Testing
- `php -l php_backend/models/Tag.php`
- `php -l php_backend/models/Transaction.php`


------
https://chatgpt.com/codex/tasks/task_e_68a722254b1c832ebe4c4ad60258362b