### PR TITLE
Fix TOTP verification and add 2FA logging

### DIFF
--- a/php_backend/public/totp_disable.php
+++ b/php_backend/public/totp_disable.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../Totp.php';
+require_once __DIR__ . '/../models/Log.php';
 
 ini_set('session.cookie_secure', '1');
 session_start();
@@ -8,6 +9,7 @@ $input = json_decode(file_get_contents('php://input'), true);
 $username = $input['username'] ?? ($_SESSION['username'] ?? '');
 
 if ($username === '') {
+    Log::write('2FA disable missing username', 'ERROR');
     echo json_encode(['disabled' => false, 'error' => 'Username required']);
     exit;
 }
@@ -16,8 +18,10 @@ $users = file_exists($file) ? json_decode(file_get_contents($file), true) : [];
 if (isset($users[$username])) {
     unset($users[$username]);
     file_put_contents($file, json_encode($users, JSON_PRETTY_PRINT));
+    Log::write("2FA disabled for '$username'");
     echo json_encode(['disabled' => true]);
 } else {
+    Log::write("2FA disable failed for '$username': no 2FA", 'ERROR');
     echo json_encode(['disabled' => false, 'error' => 'No 2FA to disable']);
 }
 ?>

--- a/php_backend/public/totp_generate.php
+++ b/php_backend/public/totp_generate.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../Totp.php';
+require_once __DIR__ . '/../models/Log.php';
 
 ini_set('session.cookie_secure', '1');
 session_start();
@@ -8,6 +9,7 @@ $input = json_decode(file_get_contents('php://input'), true);
 $username = $input['username'] ?? ($_SESSION['username'] ?? '');
 
 if ($username === '') {
+    Log::write('2FA generate missing username', 'ERROR');
     echo json_encode(['error' => 'Username required']);
     exit;
 }
@@ -16,6 +18,7 @@ $users = file_exists($file) ? json_decode(file_get_contents($file), true) : [];
 $secret = $users[$username] ?? Totp::generateSecret();
 $users[$username] = $secret;
 file_put_contents($file, json_encode($users, JSON_PRETTY_PRINT));
+Log::write("Generated 2FA secret for '$username'");
 
 $otpauth = Totp::getOtpAuthUri($username, $secret);
 echo json_encode(['secret' => $secret, 'otpauth' => $otpauth]);

--- a/php_backend/public/totp_verify.php
+++ b/php_backend/public/totp_verify.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../Totp.php';
+require_once __DIR__ . '/../models/Log.php';
 
 ini_set('session.cookie_secure', '1');
 session_start();
@@ -9,16 +10,19 @@ $username = $input['username'] ?? ($_SESSION['username'] ?? '');
 
 $token = isset($input['token']) ? (string)$input['token'] : '';
 if ($username === '' || trim($token) === '') {
+    Log::write("2FA verify missing fields for '$username'", 'ERROR');
     echo json_encode(['verified' => false, 'error' => 'Missing fields']);
     exit;
 }
 $file = __DIR__ . '/../totp_secrets.json';
 $users = file_exists($file) ? json_decode(file_get_contents($file), true) : [];
 if (!isset($users[$username])) {
+    Log::write("2FA verify unknown user '$username'", 'ERROR');
     echo json_encode(['verified' => false, 'error' => 'Unknown user']);
     exit;
 }
 $secret = $users[$username];
 $verified = Totp::verifyCode($secret, $token);
+Log::write("2FA verification for '$username': " . ($verified ? 'success' : 'failure'), $verified ? 'INFO' : 'ERROR');
 echo json_encode(['verified' => $verified]);
 ?>


### PR DESCRIPTION
## Summary
- Generate standards-compliant TOTP secrets
- Log TOTP generation, verification, and disable actions

## Testing
- `php -l php_backend/Totp.php php_backend/public/totp_generate.php php_backend/public/totp_verify.php php_backend/public/totp_disable.php`
- `php -r 'require "php_backend/Totp.php"; $secret=Totp::generateSecret(); $code=Totp::getCode($secret); $slice=floor(time()/30); echo $secret."\n".$code."\n".$slice."\n";'`
- `python3 - <<'PY'
import hmac,base64,struct
secret='NET5CFZ4DHTLG3BBBEL6GOL23HWWILT4'
code='335741'
slice=58526141
secret_padded=secret + '='*((8 - len(secret)%8)%8)
key=base64.b32decode(secret_padded, casefold=True)
msg=struct.pack('>Q', slice)
h=hmac.new(key,msg,'sha1').digest()
o=h[-1]&0x0F
calc=(struct.unpack('>I',h[o:o+4])[0]&0x7fffffff)%1000000
print(f"{calc:06d}")
print('match', str(calc).zfill(6)==code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a7232ec670832eb185db9e565522c2