### PR TITLE
Fix credit card account creation during OFX import

### DIFF
--- a/php_backend/OfxParser.php
+++ b/php_backend/OfxParser.php
@@ -16,11 +16,21 @@ class OfxParser {
         }
         // Account details
         $acctNode = $xml->xpath('//BANKACCTFROM | //CCACCTFROM | //ACCTFROM');
-        if (!$acctNode || trim((string)$acctNode[0]->ACCTID) === '') {
+        $rawAcctId = $acctNode ? trim((string)$acctNode[0]->ACCTID) : '';
+        // Some providers mask account numbers (e.g. 552213******8609). Remove
+        // any characters except alphanumerics and asterisks so masked IDs are
+        // stored consistently without losing placeholder digits.
+        $accountNumber = preg_replace('/[^A-Za-z0-9*]/', '', $rawAcctId);
+        if ($accountNumber === '') {
             throw new Exception('Missing account number');
         }
+        // Credit card statements may include a BANKID that is not a real
+        // sort code. Identify CCACCTFROM nodes explicitly and ignore any
+        // BANKID so the account is treated as a credit card when imported.
         $sortCode = trim((string)$acctNode[0]->BANKID) ?: null;
-        $accountNumber = trim((string)$acctNode[0]->ACCTID);
+        if (strtoupper($acctNode[0]->getName()) === 'CCACCTFROM') {
+            $sortCode = null;
+        }
         $accountName = trim((string)$acctNode[0]->ACCTNAME) ?: 'Default';
         // Ledger balance
         $ledger = null;

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -36,6 +36,16 @@ function assertEqual($expected, $actual, string $message) {
 // Database driver should be sqlite
 assertEqual('sqlite', $db->getAttribute(PDO::ATTR_DRIVER_NAME), 'Database driver is sqlite');
 
+// Masked credit card numbers should have masking removed
+$maskedOfx = <<<OFX
+<OFX>
+<CCACCTFROM><ACCTID>552213******8609</ACCTID></CCACCTFROM>
+<BANKTRANLIST><STMTTRN><DTPOSTED>20240101</DTPOSTED><TRNAMT>-10.00</TRNAMT></STMTTRN></BANKTRANLIST>
+</OFX>
+OFX;
+$parsedMasked = OfxParser::parse($maskedOfx);
+assertEqual('552213******8609', $parsedMasked['account']['number'], 'Masked account numbers retain placeholder digits');
+
 // Test user creation and retrieval
 $userId = User::create('alice', 'secret');
 assertEqual(1, $userId, 'User ID starts at 1');


### PR DESCRIPTION
## Summary
- Treat credit card OFX account nodes (CCACCTFROM) as credit card accounts regardless of BANKID
- Ignore BANKID for credit cards so sort code is stored as NULL
- Preserve asterisks in masked account numbers so credit card IDs like `552213******8609` are stored consistently

## Testing
- `php -l php_backend/OfxParser.php`
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a718f1a1d0832e81a67dd765daca62