### PR TITLE
Switch categories to row layout and fix OFX masking

### DIFF
--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -23,9 +23,9 @@
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Category</button>
             </form>
 
-            <div id="category-layout" class="mt-6 flex items-start gap-4">
-                <div id="unassigned" class="flex-shrink-0"></div>
-                <div id="category-container" class="flex-1 flex gap-4 overflow-x-auto items-start"></div>
+            <div id="category-layout" class="mt-6 flex flex-col gap-4">
+                <div id="unassigned"></div>
+                <div id="category-container" class="flex flex-col gap-4"></div>
             </div>
         </main>
     </div>

--- a/frontend/js/category_drag.js
+++ b/frontend/js/category_drag.js
@@ -43,7 +43,7 @@
   function createTagBadge(tag){
     const span = document.createElement('span');
     span.textContent = tag.name;
-    span.className = 'bg-indigo-200 text-indigo-800 px-2 py-1 rounded cursor-move w-full text-center';
+    span.className = 'bg-indigo-200 text-indigo-800 px-2 py-1 rounded cursor-move text-center';
     span.draggable = true;
     span.dataset.tagId = tag.id;
     span.addEventListener('dragstart', handleDragStart);
@@ -57,7 +57,7 @@
 
   function createCategoryCard(cat){
     const card = document.createElement('div');
-    card.className = 'bg-white p-4 rounded shadow w-64 flex-shrink-0';
+    card.className = 'bg-white p-4 rounded shadow w-full';
     card.dataset.categoryId = cat.id;
 
     const header = document.createElement('div');
@@ -115,7 +115,7 @@
     }
 
     const tagWrap = document.createElement('div');
-    tagWrap.className = 'min-h-[3rem] flex flex-col gap-2';
+    tagWrap.className = 'min-h-[3rem] flex flex-row flex-wrap gap-2';
     tagWrap.dataset.categoryId = cat.id;
     (cat.tags || []).forEach(t => tagWrap.appendChild(createTagBadge(t)));
     card.appendChild(tagWrap);
@@ -126,13 +126,13 @@
 
   function createUnassignedCard(tags){
     const card = document.createElement('div');
-    card.className = 'bg-white p-4 rounded shadow w-64 flex-shrink-0';
+    card.className = 'bg-white p-4 rounded shadow w-full';
     const title = document.createElement('h2');
     title.className = 'font-semibold mb-2';
     title.textContent = 'Unassigned Tags';
     card.appendChild(title);
     const tagWrap = document.createElement('div');
-    tagWrap.className = 'min-h-[3rem] flex flex-col gap-2';
+    tagWrap.className = 'min-h-[3rem] flex flex-row flex-wrap gap-2';
     tags.forEach(t => tagWrap.appendChild(createTagBadge(t)));
     card.appendChild(tagWrap);
     addDropHandlers(tagWrap);

--- a/php_backend/OfxParser.php
+++ b/php_backend/OfxParser.php
@@ -32,8 +32,6 @@ class OfxParser {
             $sortCode = null;
         }
 
-        $accountNumber = trim((string)$acctNode[0]->ACCTID);
-
         $accountName = trim((string)$acctNode[0]->ACCTNAME) ?: 'Default';
         // Ledger balance
         $ledger = null;


### PR DESCRIPTION
## Summary
- Show categories as stacked rows with tags wrapping horizontally
- Preserve unmasked account numbers in OFX parsing

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a724e0877c832eb8a775799c4f8dc5