### PR TITLE
Ensure icons on colored buttons render white

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -12,7 +12,15 @@ window.fetch = (input, init = {}) => {
 document.addEventListener('DOMContentLoaded', () => {
   const applyIconColor = (root = document) => {
     root.querySelectorAll('i').forEach(icon => {
-      if (!icon.closest('header')) {
+      if (icon.closest('header')) return;
+      const parent = icon.closest('button, a');
+      const parentClasses = parent ? Array.from(parent.classList) : [];
+      const coloredBg = parentClasses.some(c => c.startsWith('bg-') && c !== 'bg-white');
+      const hasColor = Array.from(icon.classList).some(c => c.startsWith('text-'));
+      if (coloredBg) {
+        icon.classList.forEach(c => { if (c.startsWith('text-')) icon.classList.remove(c); });
+        icon.classList.add('text-white');
+      } else if (!hasColor) {
         icon.classList.add('text-indigo-600');
       }
     });

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -3,7 +3,7 @@
   <div class="w-full flex items-center justify-between px-4">
     <div class="flex items-center space-x-4">
       <i class="fas fa-piggy-bank h-8 w-8"></i>
-      <button id="menu-toggle" class="md:hidden bg-indigo-700 p-2 rounded"><i class="fas fa-bars h-4 w-4"></i></button>
+      <button id="menu-toggle" class="md:hidden bg-indigo-700 text-white p-2 rounded"><i class="fas fa-bars h-4 w-4"></i></button>
       <div class="font-bold text-lg flex items-center">
         <span>Personal Finance Manager</span>
         <span id="release-number" class="ml-2 bg-indigo-700 text-white text-[0.675rem] px-2 py-0.5 rounded">v0.0.0</span>


### PR DESCRIPTION
## Summary
- whiten the mobile menu toggle icon on the top bar
- update global icon styling to keep icons white on colored buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72796f44c832e920d732c72007c1d