### PR TITLE
Refactor OFX parser into smaller helpers

### DIFF
--- a/php_backend/OfxParser.php
+++ b/php_backend/OfxParser.php
@@ -14,42 +14,59 @@ class OfxParser {
         if (!$xml) {
             throw new Exception('Failed to parse OFX');
         }
-        // Account details
+
+        $account = self::parseAccount($xml);
+        $ledger = self::parseLedger($xml);
+        $transactions = self::parseTransactions($xml);
+
+        return [
+            'account' => $account,
+            'ledger' => $ledger,
+            'transactions' => $transactions,
+        ];
+    }
+
+    private static function parseAccount(SimpleXMLElement $xml): array {
         $acctNode = $xml->xpath('//BANKACCTFROM | //CCACCTFROM | //ACCTFROM');
         $rawAcctId = $acctNode ? trim((string)$acctNode[0]->ACCTID) : '';
-        // Some providers mask account numbers (e.g. 552213******8609). Remove
-
-        // any characters except alphanumerics and asterisks so masked IDs are
-        // stored consistently without losing placeholder digits.
+        // Some providers mask account numbers (e.g. 552213******8609). Remove any
+        // characters except alphanumerics and asterisks so masked IDs are stored
+        // consistently without losing placeholder digits.
         $accountNumber = preg_replace('/[^A-Za-z0-9*]/', '', $rawAcctId);
 
         if ($accountNumber === '') {
             throw new Exception('Missing account number');
         }
-        // Credit card statements may include a BANKID that is not a real
-        // sort code. Identify CCACCTFROM nodes explicitly and ignore any
-        // BANKID so the account is treated as a credit card when imported.
+
+        // Credit card statements may include a BANKID that is not a real sort code.
+        // Identify CCACCTFROM nodes explicitly and ignore any BANKID so the account
+        // is treated as a credit card when imported.
         $sortCode = trim((string)$acctNode[0]->BANKID) ?: null;
         if (strtoupper($acctNode[0]->getName()) === 'CCACCTFROM') {
             $sortCode = null;
         }
 
-
         $accountName = trim((string)$acctNode[0]->ACCTNAME) ?: 'Default';
-        // Ledger balance
-        $ledger = null;
+
+        return ['sort_code' => $sortCode, 'number' => $accountNumber, 'name' => $accountName];
+    }
+
+    private static function parseLedger(SimpleXMLElement $xml) {
         $ledgerNode = $xml->xpath('//LEDGERBAL');
         if ($ledgerNode) {
             $balAmt = trim((string)$ledgerNode[0]->BALAMT);
             $dtAsOf = substr(trim((string)$ledgerNode[0]->DTASOF), 0, 8);
             if ($balAmt !== '' && $dtAsOf !== '') {
-                $ledger = [
+                return [
                     'balance' => (float)$balAmt,
                     'date' => date('Y-m-d', strtotime($dtAsOf))
                 ];
             }
         }
-        // Transactions
+        return null;
+    }
+
+    private static function parseTransactions(SimpleXMLElement $xml): array {
         $stmtTrns = $xml->xpath('//STMTTRN');
         if (!$stmtTrns) {
             throw new Exception('Missing STMTTRN');
@@ -76,11 +93,7 @@ class OfxParser {
                 'bank_id' => (string)$trn->FITID,
             ];
         }
-        return [
-            'account' => ['sort_code' => $sortCode, 'number' => $accountNumber, 'name' => $accountName],
-            'ledger' => $ledger,
-            'transactions' => $transactions,
-        ];
+        return $transactions;
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- Break monolithic OFX `parse` method into smaller helpers for account, ledger, and transactions

## Testing
- `php -l php_backend/OfxParser.php`
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a72f98baec832ebb22480cb772a4de