### PR TITLE
Return OFX parser data as objects

### DIFF
--- a/php_backend/Account.php
+++ b/php_backend/Account.php
@@ -1,0 +1,16 @@
+<?php
+namespace Ofx;
+
+// Lightweight value object representing account details parsed from OFX files.
+class Account {
+    public $sortCode;
+    public $number;
+    public $name;
+
+    public function __construct($sortCode, $number, $name) {
+        $this->sortCode = $sortCode;
+        $this->number = $number;
+        $this->name = $name;
+    }
+}
+?>

--- a/php_backend/Ledger.php
+++ b/php_backend/Ledger.php
@@ -1,0 +1,14 @@
+<?php
+namespace Ofx;
+
+// Represents the ledger balance reported in an OFX file.
+class Ledger {
+    public $balance;
+    public $date;
+
+    public function __construct($balance, $date) {
+        $this->balance = (float)$balance;
+        $this->date = $date;
+    }
+}
+?>

--- a/php_backend/Transaction.php
+++ b/php_backend/Transaction.php
@@ -1,0 +1,26 @@
+<?php
+namespace Ofx;
+
+// Lightweight value object for a single transaction parsed from OFX.
+class Transaction {
+    public $date;
+    public $amount;
+    public $desc;
+    public $memo;
+    public $type;
+    public $ref;
+    public $check;
+    public $bankId;
+
+    public function __construct($date, $amount, $desc = '', $memo = '', $type = null, $ref = '', $check = '', $bankId = '') {
+        $this->date = $date;
+        $this->amount = (float)$amount;
+        $this->desc = $desc;
+        $this->memo = $memo;
+        $this->type = $type;
+        $this->ref = $ref;
+        $this->check = $check;
+        $this->bankId = $bankId;
+    }
+}
+?>

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -81,9 +81,9 @@ try {
             continue;
         }
 
-        $sortCode = $parsed['account']['sort_code'];
-        $accountNumber = $parsed['account']['number'];
-        $accountName = $parsed['account']['name'];
+        $sortCode = $parsed['account']->sortCode;
+        $accountNumber = $parsed['account']->number;
+        $accountName = $parsed['account']->name;
 
         $db = Database::getConnection();
         // Match existing accounts using account number and sort code. When the
@@ -106,26 +106,26 @@ try {
         }
 
         if ($parsed['ledger']) {
-            Account::updateLedgerBalance($accountId, $parsed['ledger']['balance'], $parsed['ledger']['date']);
+            Account::updateLedgerBalance($accountId, $parsed['ledger']->balance, $parsed['ledger']->date);
         }
 
         $inserted = 0;
         $duplicates = [];
 
         foreach ($parsed['transactions'] as $txn) {
-            $amount = $txn['amount'];
-            $date = $txn['date'];
-            $desc = $txn['desc'] ?? '';
-            $memo = $txn['memo'] ?? '';
-            $type = $txn['type'];
-            $bankId = $txn['bank_id'] ?: null;
+            $amount = $txn->amount;
+            $date = $txn->date;
+            $desc = $txn->desc;
+            $memo = $txn->memo;
+            $type = $txn->type;
+            $bankId = $txn->bankId ? $txn->bankId : null;
 
-            if ($txn['ref']) {
-                $ref = substr($txn['ref'], 0, 32);
+            if ($txn->ref) {
+                $ref = substr($txn->ref, 0, 32);
                 $memo .= ($memo === '' ? '' : ' ') . 'Ref:' . $ref;
             }
-            if ($txn['check']) {
-                $chk = substr($txn['check'], 0, 20);
+            if ($txn->check) {
+                $chk = substr($txn->check, 0, 20);
                 $memo .= ($memo === '' ? '' : ' ') . 'Chk:' . $chk;
             }
 

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -45,7 +45,7 @@ $maskedOfx = <<<OFX
 OFX;
 $parsedMasked = OfxParser::parse($maskedOfx);
 
-assertEqual('552213******8609', $parsedMasked['account']['number'], 'Masked account numbers retain placeholder digits');
+assertEqual('552213******8609', $parsedMasked['account']->number, 'Masked account numbers retain placeholder digits');
 
 
 // Test user creation and retrieval


### PR DESCRIPTION
## Summary
- add lightweight Account, Ledger and Transaction value objects under php_backend
- refactor OfxParser to build these objects and return them instead of arrays
- update OFX upload handler and tests for object-based parsing

## Testing
- `php -l php_backend/Account.php php_backend/Ledger.php php_backend/Transaction.php php_backend/OfxParser.php php_backend/public/upload_ofx.php`
- `php -l tests/run_tests.php`
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a72fb621a8832eaa8a9b54aff9749e