### PR TITLE
Add PHPUnit tests for OFX parsing and duplicate transactions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "accounts/app",
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^9"
+    },
+    "autoload": {
+        "classmap": ["php_backend/"]
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/OfxParserTest.php
+++ b/tests/OfxParserTest.php
@@ -1,0 +1,30 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../php_backend/OfxParser.php';
+
+class OfxParserTest extends TestCase
+{
+    public function testAccountExtraction(): void
+    {
+        $ofx = <<<OFX
+<OFX>
+<BANKACCTFROM>
+<BANKID>123456</BANKID>
+<ACCTID>12345678</ACCTID>
+<ACCTNAME>Main</ACCTNAME>
+</BANKACCTFROM>
+<BANKTRANLIST>
+<STMTTRN>
+<DTPOSTED>20240101</DTPOSTED>
+<TRNAMT>-10.00</TRNAMT>
+</STMTTRN>
+</BANKTRANLIST>
+</OFX>
+OFX;
+        $parsed = OfxParser::parse($ofx);
+        $this->assertSame('12345678', $parsed['account']['number']);
+        $this->assertSame('123456', $parsed['account']['sort_code']);
+        $this->assertSame('Main', $parsed['account']['name']);
+    }
+}

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -1,0 +1,45 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../php_backend/models/Transaction.php';
+require_once __DIR__ . '/../php_backend/models/Log.php';
+require_once __DIR__ . '/../php_backend/Database.php';
+
+class TransactionTest extends TestCase
+{
+    private PDO $db;
+
+    protected function setUp(): void
+    {
+        putenv('DB_DSN=sqlite::memory:');
+        $ref = new ReflectionClass(Database::class);
+        $prop = $ref->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null);
+        $this->db = Database::getConnection();
+        $this->db->exec('CREATE TABLE accounts (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);');
+        $this->db->exec('INSERT INTO accounts (name) VALUES ("Checking");');
+        $this->db->exec('CREATE TABLE logs (id INTEGER PRIMARY KEY AUTOINCREMENT, level TEXT, message TEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP);');
+        $this->db->exec('CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTOINCREMENT, account_id INTEGER, date TEXT, amount REAL, description TEXT, memo TEXT, category_id INTEGER, segment_id INTEGER, tag_id INTEGER, group_id INTEGER, transfer_id INTEGER, ofx_id TEXT, ofx_type TEXT, bank_ofx_id TEXT);');
+    }
+
+    public function testDuplicateFitidHandling(): void
+    {
+        $first = Transaction::create(1, '2024-08-01', 10.0, 'First', null, null, 0, null, null, 'DEBIT', 'DUP123');
+        $second = Transaction::create(1, '2024-08-02', 20.0, 'Second', null, null, 0, null, null, 'DEBIT', 'DUP123');
+        $this->assertNotSame($first, $second);
+        $secondFitid = $this->db->query('SELECT bank_ofx_id FROM transactions WHERE id = ' . $second)->fetchColumn();
+        $this->assertSame('DUP123-1', $secondFitid);
+        $logCount = $this->db->query("SELECT COUNT(*) FROM logs WHERE level = 'WARNING'")->fetchColumn();
+        $this->assertSame(1, (int)$logCount);
+    }
+
+    public function testDuplicateTransactionRejection(): void
+    {
+        $first = Transaction::create(1, '2024-08-03', 30.0, 'Dup', null, null, 0);
+        $second = Transaction::create(1, '2024-08-03', 30.0, 'Dup', null, null, 0);
+        $this->assertSame($first, $second);
+        $count = $this->db->query("SELECT COUNT(*) FROM transactions WHERE description = 'Dup'")->fetchColumn();
+        $this->assertSame(1, (int)$count);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+$autoloader = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($autoloader)) {
+    require $autoloader;
+}


### PR DESCRIPTION
## Summary
- add PHPUnit config and bootstrap
- test OFX parser for account extraction
- test duplicate FITID suffixing and duplicate transaction rejection

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a72fbd2350832e8b2cf27482551b93