### PR TITLE
Fix OfxParser to return DTO objects

### DIFF
--- a/tests/OfxParserTest.php
+++ b/tests/OfxParserTest.php
@@ -23,8 +23,8 @@ class OfxParserTest extends TestCase
 </OFX>
 OFX;
         $parsed = OfxParser::parse($ofx);
-        $this->assertSame('12345678', $parsed['account']['number']);
-        $this->assertSame('123456', $parsed['account']['sort_code']);
-        $this->assertSame('Main', $parsed['account']['name']);
+        $this->assertSame('12345678', $parsed['account']->number);
+        $this->assertSame('123456', $parsed['account']->sortCode);
+        $this->assertSame('Main', $parsed['account']->name);
     }
 }


### PR DESCRIPTION
## Summary
- Ensure `OfxParser` returns account, ledger and transaction DTO objects instead of arrays
- Adjust ledger/transaction parsing helpers and update unit test expectations

## Testing
- `php -l php_backend/OfxParser.php`
- `php -l tests/OfxParserTest.php`
- `php tests/run_tests.php`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a72cb5a808832e98114709f5460e01