### PR TITLE
Prevent duplicate transactions and handle credit card statements

### DIFF
--- a/tests/OfxParserTest.php
+++ b/tests/OfxParserTest.php
@@ -9,17 +9,23 @@ class OfxParserTest extends TestCase
     {
         $ofx = <<<OFX
 <OFX>
-<BANKACCTFROM>
-<BANKID>123456</BANKID>
-<ACCTID>12345678</ACCTID>
-<ACCTNAME>Main</ACCTNAME>
-</BANKACCTFROM>
-<BANKTRANLIST>
-<STMTTRN>
-<DTPOSTED>20240101</DTPOSTED>
-<TRNAMT>-10.00</TRNAMT>
-</STMTTRN>
-</BANKTRANLIST>
+  <BANKMSGSRSV1>
+    <STMTTRNRS>
+      <STMTRS>
+        <BANKACCTFROM>
+          <BANKID>123456</BANKID>
+          <ACCTID>12345678</ACCTID>
+          <ACCTNAME>Main</ACCTNAME>
+        </BANKACCTFROM>
+        <BANKTRANLIST>
+          <STMTTRN>
+            <DTPOSTED>20240101</DTPOSTED>
+            <TRNAMT>-10.00</TRNAMT>
+          </STMTTRN>
+        </BANKTRANLIST>
+      </STMTRS>
+    </STMTTRNRS>
+  </BANKMSGSRSV1>
 </OFX>
 OFX;
         $parsed = OfxParser::parse($ofx);

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -27,9 +27,9 @@ class TransactionTest extends TestCase
     {
         $first = Transaction::create(1, '2024-08-01', 10.0, 'First', null, null, 0, null, null, 'DEBIT', 'DUP123');
         $second = Transaction::create(1, '2024-08-02', 20.0, 'Second', null, null, 0, null, null, 'DEBIT', 'DUP123');
-        $this->assertNotSame($first, $second);
-        $secondFitid = $this->db->query('SELECT bank_ofx_id FROM transactions WHERE id = ' . $second)->fetchColumn();
-        $this->assertSame('DUP123-1', $secondFitid);
+        $this->assertSame(0, $second);
+        $count = $this->db->query('SELECT COUNT(*) FROM transactions')->fetchColumn();
+        $this->assertSame(1, (int)$count);
         $logCount = $this->db->query("SELECT COUNT(*) FROM logs WHERE level = 'WARNING'")->fetchColumn();
         $this->assertSame(1, (int)$logCount);
     }
@@ -38,7 +38,7 @@ class TransactionTest extends TestCase
     {
         $first = Transaction::create(1, '2024-08-03', 30.0, 'Dup', null, null, 0);
         $second = Transaction::create(1, '2024-08-03', 30.0, 'Dup', null, null, 0);
-        $this->assertSame($first, $second);
+        $this->assertSame(0, $second);
         $count = $this->db->query("SELECT COUNT(*) FROM transactions WHERE description = 'Dup'")->fetchColumn();
         $this->assertSame(1, (int)$count);
     }


### PR DESCRIPTION
## Summary
- Skip inserting transactions when OFX IDs or bank FITIDs already exist
- Parse only the first statement in an OFX file so credit card data is matched to the correct account
- Update tests for new duplicate handling and parser behaviour

## Testing
- `php tests/run_tests.php`
- `composer install` *(fails: curl error 56 while downloading packages.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a739eae844832e81ebeba42799bc91