### PR TITLE
Improve OFX parsing robustness and streaming support

### DIFF
--- a/tests/OfxParserTest.php
+++ b/tests/OfxParserTest.php
@@ -28,7 +28,7 @@ class OfxParserTest extends TestCase
   </BANKMSGSRSV1>
 </OFX>
 OFX;
-        $parsed = OfxParser::parse($ofx);
+        $parsed = OfxParser::parse($ofx)[0];
         $this->assertSame('12345678', $parsed['account']->number);
         $this->assertSame('123456', $parsed['account']->sortCode);
         $this->assertSame('Main', $parsed['account']->name);

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -49,7 +49,7 @@ $maskedOfx = <<<OFX
 </CREDITCARDMSGSRSV1>
 </OFX>
 OFX;
-$parsedMasked = OfxParser::parse($maskedOfx);
+$parsedMasked = OfxParser::parse($maskedOfx)[0];
 
 assertEqual('552213******8609', $parsedMasked['account']->number, 'Masked account numbers retain placeholder digits');
 
@@ -61,7 +61,7 @@ $compactOfx = <<<OFX
 <BANKTRANLIST><STMTTRN><DTPOSTED>20240101<TRNAMT>-1<FITID>1<NAME>A</STMTTRN><STMTTRN><DTPOSTED>20240102<TRNAMT>-2<FITID>2<NAME>B</STMTTRN></BANKTRANLIST>
 </STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>
 OFX;
-$parsedCompact = OfxParser::parse($compactOfx);
+$parsedCompact = OfxParser::parse($compactOfx)[0];
 assertEqual(2, count($parsedCompact['transactions']), 'Parser handles tags without newlines');
 
 


### PR DESCRIPTION
## Summary
- add XMLReader-based OFX parser that auto-detects headers and repairs truncated or unbalanced tags
- process multiple statement blocks and update upload workflow accordingly
- adjust tests for new parser structure

## Testing
- `php -l php_backend/OfxParser.php`
- `php -l php_backend/public/upload_ofx.php`
- `php -l tests/OfxParserTest.php`
- `php -l tests/run_tests.php`
- `php tests/run_tests.php`
- `phpunit tests/OfxParserTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7417dd258832e9403aa09e6785307