### PR TITLE
Add institution profiles and normalise transaction fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ description. When present, reference numbers (`<REFNUM>`), cheque numbers
 hash input. This composite value greatly reduces the chance of collisions when
 banks reuse identifiers or vary memo text.
 
+Institution-specific JSON profiles in `php_backend/profiles/` supply default
+behaviour and field caps. Profiles are selected using the `<FI>` `ORG` or
+`FID` value and can normalise `CHECKNUM`, `REFNUM` and `MEMO` fields or enforce
+length limits. A `default.json` profile is used when no matching file exists.
+
 
 ## Running a Local Server
 

--- a/php_backend/profiles/default.json
+++ b/php_backend/profiles/default.json
@@ -1,0 +1,7 @@
+{
+  "fields": {
+    "CHECKNUM": { "max": 12, "regex": "/[^A-Za-z0-9]/" },
+    "REFNUM": { "max": 32 },
+    "MEMO": { "max": 255 }
+  }
+}

--- a/php_backend/profiles/testbank.json
+++ b/php_backend/profiles/testbank.json
@@ -1,0 +1,7 @@
+{
+  "fields": {
+    "CHECKNUM": { "max": 6, "regex": "/[^0-9]/" },
+    "REFNUM": { "max": 15, "uppercase": true },
+    "MEMO": { "max": 9 }
+  }
+}


### PR DESCRIPTION
## Summary
- Add JSON-based institution profiles and loader to OFX parser
- Normalise CHECKNUM/REFNUM/MEMO using profile rules with length caps
- Document profiles and add tests for profile-driven field handling

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a74186e7b0832eba0b6d5be832a6d0