### PR TITLE
Map OFX transaction types to enums

### DIFF
--- a/php_backend/TransactionType.php
+++ b/php_backend/TransactionType.php
@@ -1,0 +1,25 @@
+<?php
+namespace Ofx;
+
+enum TransactionType: string {
+    case CREDIT = 'CREDIT';
+    case DEBIT = 'DEBIT';
+    case INT = 'INT';
+    case DIV = 'DIV';
+    case FEE = 'FEE';
+    case SRVCHG = 'SRVCHG';
+    case DEP = 'DEP';
+    case ATM = 'ATM';
+    case POS = 'POS';
+    case XFER = 'XFER';
+    case CHECK = 'CHECK';
+    case PAYMENT = 'PAYMENT';
+    case CASH = 'CASH';
+    case DIRECTDEP = 'DIRECTDEP';
+    case DIRECTDEBIT = 'DIRECTDEBIT';
+    case REPEATPMT = 'REPEATPMT';
+    case HOLD = 'HOLD';
+    case OTHER = 'OTHER';
+    case UNKNOWN = 'UNKNOWN';
+}
+?>

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../OfxParser.php';
 
+use Ofx\TransactionType;
 try {
     if (!isset($_FILES['ofx_files'])) {
         http_response_code(400);
@@ -123,7 +124,7 @@ try {
                 $date = $txn->date;
                 $desc = $txn->desc;
                 $memo = $txn->memo;
-                $type = $txn->type;
+                $type = $txn->type instanceof TransactionType ? $txn->type->value : (string)$txn->type;
                 $bankId = $txn->bankId ? $txn->bankId : null;
 
                 if ($txn->ref) {

--- a/tests/OfxParserTest.php
+++ b/tests/OfxParserTest.php
@@ -2,6 +2,7 @@
 use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../php_backend/OfxParser.php';
+use Ofx\TransactionType;
 
 class OfxParserTest extends TestCase
 {
@@ -58,9 +59,32 @@ OFX;
 </OFX>
 OFX;
         $parsed = OfxParser::parse($ofx, false)[0];
-        $this->assertSame('UNKNOWN', $parsed['transactions'][0]->type);
+        $this->assertSame(TransactionType::UNKNOWN, $parsed['transactions'][0]->type);
         $this->assertArrayHasKey('UNKNOWN', $parsed['transactions'][0]->extensions);
         $this->assertNotEmpty($parsed['warnings']);
+    }
+
+    public function testTrnTypeMappedToEnum(): void
+    {
+        $ofx = <<<OFX
+<OFX>
+  <BANKMSGSRSV1>
+    <STMTTRNRS>
+      <STMTRS>
+        <BANKTRANLIST>
+          <STMTTRN>
+            <DTPOSTED>20240101</DTPOSTED>
+            <TRNAMT>-10.00</TRNAMT>
+            <TRNTYPE>DEBIT</TRNTYPE>
+          </STMTTRN>
+        </BANKTRANLIST>
+      </STMTRS>
+    </STMTTRNRS>
+  </BANKMSGSRSV1>
+</OFX>
+OFX;
+        $parsed = OfxParser::parse($ofx)[0];
+        $this->assertSame(TransactionType::DEBIT, $parsed['transactions'][0]->type);
     }
 
     public function testStrictModeThrowsOnMissingFields(): void


### PR DESCRIPTION
## Summary
- add TransactionType enum covering standard OFX TRNTYPE values
- map parsed TRNTYPE strings to enum in OfxParser, defaulting to UNKNOWN
- handle enums when importing OFX and extend parser tests

## Testing
- `composer install` *(fails: curl error 56 while downloading packages.json)*
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8232c98b0832e9eb16abfb31b53b7