### PR TITLE
Centralize transaction field limits and expose parser amount cap

### DIFF
--- a/php_backend/OfxParser.php
+++ b/php_backend/OfxParser.php
@@ -33,7 +33,7 @@ class OfxParser {
         'OTHER' => TransactionType::OTHER,
     ];
 
-    private const MAX_AMOUNT = 1000000000; // clamp extremely large values
+    const MAX_AMOUNT = 1000000000; // clamp extremely large values
 
     public static function parse(string $data, bool $strict = false): array {
         $warnings = [];

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -1,6 +1,7 @@
 <?php
 // Resets and creates all database tables used by the application.
 require_once __DIR__ . '/Database.php';
+require_once __DIR__ . '/models/Transaction.php';
 
 $db = Database::getConnection();
 
@@ -257,10 +258,10 @@ while ($row = $txs->fetch(PDO::FETCH_ASSOC)) {
     $chk = '';
     if (!empty($row['memo'])) {
         if (preg_match('/Ref:([^\s]+)/i', $row['memo'], $m)) {
-            $ref = substr(trim($m[1]), 0, 32);
+            $ref = substr(trim($m[1]), 0, Transaction::REF_MAX_LENGTH);
         }
         if (preg_match('/Chk:([^\s]+)/i', $row['memo'], $m)) {
-            $chk = substr(trim($m[1]), 0, 20);
+            $chk = substr(trim($m[1]), 0, Transaction::CHECK_MAX_LENGTH);
         }
     }
     // Legacy transactions lack raw STMTTRN blocks, so include an empty placeholder

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -5,6 +5,12 @@ require_once __DIR__ . '/Tag.php';
 require_once __DIR__ . '/Log.php';
 
 class Transaction {
+    const DESC_MAX_LENGTH = 255;
+    const MEMO_MAX_LENGTH = 255;
+    const ID_MAX_LENGTH = 255;
+    const TYPE_MAX_LENGTH = 50;
+    const REF_MAX_LENGTH = 32;
+    const CHECK_MAX_LENGTH = 20;
     /**
      * Insert a new transaction and attempt to auto-tag and link transfers.
      */
@@ -16,6 +22,13 @@ class Transaction {
             }
         }
         $db = Database::getConnection();
+
+        $substr = function_exists('mb_substr') ? 'mb_substr' : 'substr';
+        $description = $substr($description, 0, self::DESC_MAX_LENGTH);
+        $memo = $memo === null ? null : $substr($memo, 0, self::MEMO_MAX_LENGTH);
+        $ofx_id = $ofx_id === null ? null : $substr($ofx_id, 0, self::ID_MAX_LENGTH);
+        $ofx_type = $ofx_type === null ? null : $substr($ofx_type, 0, self::TYPE_MAX_LENGTH);
+        $bank_ofx_id = $bank_ofx_id === null ? null : $substr($bank_ofx_id, 0, self::ID_MAX_LENGTH);
 
         // avoid duplicate inserts when an OFX id already exists
         if ($ofx_id !== null) {

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -128,20 +128,20 @@ try {
                 $bankId = $txn->bankId ? $txn->bankId : null;
 
                 if ($txn->ref) {
-                    $ref = substr($txn->ref, 0, 32);
+                    $ref = substr($txn->ref, 0, Transaction::REF_MAX_LENGTH);
                     $memo .= ($memo === '' ? '' : ' ') . 'Ref:' . $ref;
                 }
                 if ($txn->check) {
-                    $chk = substr($txn->check, 0, 20);
+                    $chk = substr($txn->check, 0, Transaction::CHECK_MAX_LENGTH);
                     $memo .= ($memo === '' ? '' : ' ') . 'Chk:' . $chk;
                 }
 
 
             $substr = function_exists('mb_substr') ? 'mb_substr' : 'substr';
-            $desc = $substr($desc, 0, 255);
-            $memo = $memo === '' ? null : $substr($memo, 0, 255);
-            $bankId = $bankId === null ? null : $substr($bankId, 0, 255);
-            $type = $type === null ? null : $substr($type, 0, 50);
+            $desc = $substr($desc, 0, Transaction::DESC_MAX_LENGTH);
+            $memo = $memo === '' ? null : $substr($memo, 0, Transaction::MEMO_MAX_LENGTH);
+            $bankId = $bankId === null ? null : $substr($bankId, 0, Transaction::ID_MAX_LENGTH);
+            $type = $type === null ? null : $substr($type, 0, Transaction::TYPE_MAX_LENGTH);
 
             $amountStr = number_format($amount, 2, '.', '');
             $normalise = function (string $text): string {
@@ -186,11 +186,13 @@ try {
             }
             $messages[] = $msg;
             Log::write($msg);
-        }
-    }
+          }
+      }
+  }
 
-    echo implode("\n", $messages);
-} catch (Exception $e) {
+  echo implode("\n", $messages);
+}
+catch (Exception $e) {
     http_response_code(500);
     $msg = 'Error: ' . $e->getMessage();
     Log::write($msg, 'ERROR');


### PR DESCRIPTION
## Summary
- Make `OfxParser::MAX_AMOUNT` a class constant and use it when normalising amounts
- Introduce constants for description, memo and ID lengths in `Transaction` and apply them across upload and database scripts
- Clamp transaction fields using these constants during uploads and creation to keep data within DB limits

## Testing
- `php tests/run_tests.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8253ee674832e88296ba5d3fe2dc3