### PR TITLE
Add categorized warnings and counts to OFX parser

### DIFF
--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -74,9 +74,10 @@ try {
         }
 
         try {
-            $statements = OfxParser::parse($ofxData);
-            // OfxParser::parse now returns an array of statements
-            // so we iterate over each parsed account separately.
+            $result = OfxParser::parse($ofxData);
+            $statements = $result['statements'];
+            $warningCounts = $result['warningCounts'];
+            // Iterate over each parsed account separately.
         } catch (Exception $e) {
             $msg = 'Error parsing ' . $files['name'][$i] . ': ' . $e->getMessage();
             $messages[] = $msg;

--- a/tests/OfxParserTest.php
+++ b/tests/OfxParserTest.php
@@ -29,7 +29,7 @@ class OfxParserTest extends TestCase
   </BANKMSGSRSV1>
 </OFX>
 OFX;
-        $parsed = OfxParser::parse($ofx)[0];
+        $parsed = OfxParser::parse($ofx)['statements'][0];
         $this->assertSame('12345678', $parsed['account']->number);
         $this->assertSame('123456', $parsed['account']->sortCode);
         $this->assertSame('Main', $parsed['account']->name);
@@ -58,10 +58,12 @@ OFX;
   </BANKMSGSRSV1>
 </OFX>
 OFX;
-        $parsed = OfxParser::parse($ofx, false)[0];
+        $result = OfxParser::parse($ofx, false);
+        $parsed = $result['statements'][0];
         $this->assertSame(TransactionType::UNKNOWN, $parsed['transactions'][0]->type);
         $this->assertArrayHasKey('UNKNOWN', $parsed['transactions'][0]->extensions);
         $this->assertNotEmpty($parsed['warnings']);
+        $this->assertArrayHasKey('category', $parsed['warnings'][0]);
     }
 
     public function testTrnTypeMappedToEnum(): void
@@ -83,7 +85,7 @@ OFX;
   </BANKMSGSRSV1>
 </OFX>
 OFX;
-        $parsed = OfxParser::parse($ofx)[0];
+        $parsed = OfxParser::parse($ofx)['statements'][0];
         $this->assertSame(TransactionType::DEBIT, $parsed['transactions'][0]->type);
     }
 
@@ -109,7 +111,7 @@ OFX;
   </BANKMSGSRSV1>
 </OFX>
 OFX;
-        $transactions = OfxParser::parse($ofx)[0]['transactions'];
+        $transactions = OfxParser::parse($ofx)['statements'][0]['transactions'];
         $this->assertSame(6, $transactions[0]->line);
         $this->assertSame(strpos($ofx, '<STMTTRN>'), $transactions[0]->offset);
         $secondPos = strpos($ofx, '<STMTTRN>', $transactions[0]->offset + 1);
@@ -172,7 +174,8 @@ OFX;
   </BANKMSGSRSV1>
 </OFX>
 OFX;
-        $parsed = OfxParser::parse($ofx)[0];
+        $result = OfxParser::parse($ofx);
+        $parsed = $result['statements'][0];
 
         $this->assertNotEmpty($parsed['warnings']);
     }
@@ -203,11 +206,13 @@ OFX;
   </BANKMSGSRSV1>
 </OFX>
 OFX;
-        $parsed = OfxParser::parse($ofx)[0];
+        $result = OfxParser::parse($ofx);
+        $parsed = $result['statements'][0];
 
         $this->assertSame('1900-01-01', $parsed['transactions'][0]->date);
         $this->assertSame('2100-12-31', $parsed['transactions'][1]->date);
         $this->assertNotEmpty($parsed['warnings']);
+        $this->assertArrayHasKey('date', $result['warningCounts']);
 
     }
 }

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -49,7 +49,7 @@ $maskedOfx = <<<OFX
 </CREDITCARDMSGSRSV1>
 </OFX>
 OFX;
-$parsedMasked = OfxParser::parse($maskedOfx)[0];
+$parsedMasked = OfxParser::parse($maskedOfx)['statements'][0];
 
 assertEqual('552213******8609', $parsedMasked['account']->number, 'Masked account numbers retain placeholder digits');
 
@@ -61,7 +61,7 @@ $compactOfx = <<<OFX
 <BANKTRANLIST><STMTTRN><DTPOSTED>20240101<TRNAMT>-1<FITID>1<NAME>A</STMTTRN><STMTTRN><DTPOSTED>20240102<TRNAMT>-2<FITID>2<NAME>B</STMTTRN></BANKTRANLIST>
 </STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>
 OFX;
-$parsedCompact = OfxParser::parse($compactOfx)[0];
+$parsedCompact = OfxParser::parse($compactOfx)['statements'][0];
 assertEqual(2, count($parsedCompact['transactions']), 'Parser handles tags without newlines');
 
 // Profile-based normalisation and field caps
@@ -73,7 +73,7 @@ $profileOfx = <<<OFX
 <BANKTRANLIST><STMTTRN><DTPOSTED>20240101</DTPOSTED><TRNAMT>-1</TRNAMT><CHECKNUM>AB-12 34</CHECKNUM><REFNUM>ref-ABCDEFGHIJKLMNOPQRSTUVWXYZ</REFNUM><MEMO>Some memo that exceeds</MEMO><FITID>1</FITID></STMTTRN></BANKTRANLIST>
 </STMTRS></STMTTRNRS></BANKMSGSRSV1></OFX>
 OFX;
-$parsedProfile = OfxParser::parse($profileOfx)[0];
+$parsedProfile = OfxParser::parse($profileOfx)['statements'][0];
 $tx = $parsedProfile['transactions'][0];
 assertEqual('1234', $tx->check, 'Profile regex removes non-digits from CHECKNUM');
 assertEqual('REF-ABCDEFGHIJK', $tx->ref, 'Profile uppercases and truncates REFNUM');


### PR DESCRIPTION
## Summary
- add warning categories and per-category counts to OFX parser results
- return overall warning counts and update upload handler
- adjust tests for new parse result structure and warning categories

## Testing
- `composer install` *(fails: curl error 56 CONNECT tunnel failed 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php tests/run_tests.php` *(fails: Profile regex removes non-digits from CHECKNUM, Profile uppercases and truncates REFNUM, Profile enforces MEMO length cap)*

------
https://chatgpt.com/codex/tasks/task_e_68a8274816e4832eac5afcc2ac8e2633