### PR TITLE
Replace PHP enum with string constants for transaction types

### DIFF
--- a/php_backend/TransactionType.php
+++ b/php_backend/TransactionType.php
@@ -1,25 +1,31 @@
 <?php
 namespace Ofx;
 
-enum TransactionType: string {
-    case CREDIT = 'CREDIT';
-    case DEBIT = 'DEBIT';
-    case INT = 'INT';
-    case DIV = 'DIV';
-    case FEE = 'FEE';
-    case SRVCHG = 'SRVCHG';
-    case DEP = 'DEP';
-    case ATM = 'ATM';
-    case POS = 'POS';
-    case XFER = 'XFER';
-    case CHECK = 'CHECK';
-    case PAYMENT = 'PAYMENT';
-    case CASH = 'CASH';
-    case DIRECTDEP = 'DIRECTDEP';
-    case DIRECTDEBIT = 'DIRECTDEBIT';
-    case REPEATPMT = 'REPEATPMT';
-    case HOLD = 'HOLD';
-    case OTHER = 'OTHER';
-    case UNKNOWN = 'UNKNOWN';
+// Simple enumeration of transaction types represented as string constants.
+// Using a class with constants keeps compatibility with PHP 7.x while
+// providing namespaced values for mapping TRNTYPE codes.
+class TransactionType
+{
+    const CREDIT      = 'CREDIT';
+    const DEBIT       = 'DEBIT';
+    const INT         = 'INT';
+    const DIV         = 'DIV';
+    const FEE         = 'FEE';
+    const SRVCHG      = 'SRVCHG';
+    const DEP         = 'DEP';
+    const ATM         = 'ATM';
+    const POS         = 'POS';
+    const XFER        = 'XFER';
+    const CHECK       = 'CHECK';
+    const PAYMENT     = 'PAYMENT';
+    const CASH        = 'CASH';
+    const DIRECTDEP   = 'DIRECTDEP';
+    const DIRECTDEBIT = 'DIRECTDEBIT';
+    const REPEATPMT   = 'REPEATPMT';
+    const HOLD        = 'HOLD';
+    const OTHER       = 'OTHER';
+    const UNKNOWN     = 'UNKNOWN';
 }
+
 ?>
+

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -125,7 +125,8 @@ try {
                 $date = $txn->date;
                 $desc = $txn->desc;
                 $memo = $txn->memo;
-                $type = $txn->type instanceof TransactionType ? $txn->type->value : (string)$txn->type;
+                // TransactionType is represented by string constants; cast to string if present
+                $type = $txn->type === null ? null : (string)$txn->type;
                 $bankId = $txn->bankId ? $txn->bankId : null;
 
                 if ($txn->ref) {


### PR DESCRIPTION
## Summary
- Replace PHP 8 `enum` for transaction types with a class of string constants compatible with PHP 7
- Adjust OFX upload to treat transaction type as plain string

## Testing
- `php tests/run_tests.php`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a7405eaefc832ea79f70b2eaf564e5