### PR TITLE
Optimize import process and reduce logging noise

### DIFF
--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -173,22 +173,26 @@ try {
             if ($createdId === 0) {
                 if ($bankId !== null) {
                     $duplicates[] = $bankId;
-
                 }
-
                 $inserted++;
             }
+        }
 
+        // Apply tags and categories after processing all transactions for the account
+        // Only run if new transactions were inserted to avoid unnecessary work
+        $tagged = $categorised = 0;
+        if ($inserted > 0) {
             $tagged = Tag::applyToAccountTransactions($accountId);
             $categorised = CategoryTag::applyToAccountTransactions($accountId);
+        }
 
-            $msg = "Inserted $inserted transactions for account $accountName. Tagged $tagged transactions. Categorised $categorised transactions.";
-            if (!empty($duplicates)) {
-                $msg .= " Skipped duplicates with FITID(s): " . implode(', ', $duplicates) . '.';
-            }
-            $messages[] = $msg;
-            Log::write($msg);
-          }
+        // Summarise the results for this account
+        $msg = "Inserted $inserted transactions for account $accountName. Tagged $tagged transactions. Categorised $categorised transactions.";
+        if (!empty($duplicates)) {
+            $msg .= " Skipped duplicates with FITID(s): " . implode(', ', $duplicates) . '.';
+        }
+        $messages[] = $msg;
+        Log::write($msg);
       }
   }
 


### PR DESCRIPTION
## Summary
- Apply tags and categories once per account after processing all transactions
- Log a single summary per account instead of per transaction
- Skip costly tagging when no new transactions are inserted

## Testing
- `php -l php_backend/public/upload_ofx.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a82eb2e3a8832e9113cfe37b7a5331