### PR TITLE
Summarise duplicate FITIDs in import message

### DIFF
--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -189,7 +189,8 @@ try {
         // Summarise the results for this account
         $msg = "Inserted $inserted transactions for account $accountName. Tagged $tagged transactions. Categorised $categorised transactions.";
         if (!empty($duplicates)) {
-            $msg .= " Skipped duplicates with FITID(s): " . implode(', ', $duplicates) . '.';
+            $count = count($duplicates);
+            $msg .= " Skipped $count duplicate transaction" . ($count === 1 ? '' : 's') . '.';
         }
         $messages[] = $msg;
         Log::write($msg);


### PR DESCRIPTION
## Summary
- Condense duplicate transaction import log to report only the number of duplicates instead of listing every FITID.

## Testing
- `php -l php_backend/public/upload_ofx.php`
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8310e7fdc832eb97601a0f8346061