### PR TITLE
Show 2FA status in top bar

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -199,11 +199,16 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       const userEl = document.getElementById('current-user');
+      const iconEl = document.getElementById('user-icon');
       if (userEl) {
         fetch('../php_backend/public/current_user.php')
           .then(r => (r.ok ? r.json() : Promise.reject()))
           .then(u => {
             userEl.textContent = u.username || 'Guest';
+            if (u.has2fa && iconEl) {
+              iconEl.classList.remove('fa-user');
+              iconEl.classList.add('fa-user-shield');
+            }
           })
           .catch(() => {
             userEl.textContent = 'Guest';

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -20,7 +20,7 @@
         <span id="latest-statement-text">Latest Statement</span>
       </a>
       <div id="user-info" class="flex items-center">
-        <i class="fas fa-user h-4 w-4 mr-1"></i>
+        <i id="user-icon" class="fas fa-user h-4 w-4 mr-1"></i>
         <span id="current-user">&nbsp;</span>
       </div>
     </div>

--- a/php_backend/public/current_user.php
+++ b/php_backend/public/current_user.php
@@ -1,13 +1,20 @@
 <?php
 // Returns the username of the currently logged-in user.
 require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../Database.php';
 ini_set('session.cookie_secure', '1');
 session_start();
 
 header('Content-Type: application/json');
 
 if (isset($_SESSION['username'])) {
-    echo json_encode(['username' => $_SESSION['username']]);
+    $username = $_SESSION['username'];
+    $db = Database::getConnection();
+    $stmt = $db->prepare('SELECT 1 FROM totp_secrets WHERE username = :username');
+    $stmt->execute(['username' => $username]);
+    $has2fa = (bool)$stmt->fetchColumn();
+
+    echo json_encode(['username' => $username, 'has2fa' => $has2fa]);
 } else {
     http_response_code(401);
     echo json_encode(['error' => 'Not logged in']);


### PR DESCRIPTION
## Summary
- identify two-factor authentication status in `current_user.php`
- switch top bar icon to a shielded user when 2FA is enabled
- expose user icon element for runtime updates

## Testing
- `php -l php_backend/public/current_user.php`
- `node -c frontend/js/menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68a836dccf08832e90662f4226b988cb