### PR TITLE
Add inactivity auto logout timer

### DIFF
--- a/frontend/js/auto_logout.js
+++ b/frontend/js/auto_logout.js
@@ -1,0 +1,22 @@
+// Logs out the user after a period of inactivity based on server settings.
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('../php_backend/public/session_timeout.php')
+    .then(r => (r.ok ? r.json() : Promise.reject()))
+    .then(data => {
+      const minutes = parseInt(data.minutes, 10);
+      if (minutes > 0) {
+        let timer;
+        const reset = () => {
+          clearTimeout(timer);
+          timer = setTimeout(() => {
+            window.location.href = '../logout.php';
+          }, minutes * 60 * 1000);
+        };
+        ['click', 'mousemove', 'keydown', 'scroll', 'touchstart'].forEach(evt =>
+          document.addEventListener(evt, reset, true)
+        );
+        reset();
+      }
+    })
+    .catch(err => console.error('Session timeout check failed', err));
+});

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -242,4 +242,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const hintScript = document.createElement('script');
   hintScript.src = 'js/keyboard_hints.js';
   document.body.appendChild(hintScript);
+
+  const logoutScript = document.createElement('script');
+  logoutScript.src = 'js/auto_logout.js';
+  document.body.appendChild(logoutScript);
 });

--- a/php_backend/public/session_timeout.php
+++ b/php_backend/public/session_timeout.php
@@ -1,0 +1,14 @@
+<?php
+// Returns inactivity timeout in minutes for the current user.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Setting.php';
+ini_set('session.cookie_secure', '1');
+session_start();
+header('Content-Type: application/json');
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Not logged in']);
+    exit;
+}
+$minutes = (int) (Setting::get('session_timeout_minutes') ?? 0);
+echo json_encode(['minutes' => $minutes]);

--- a/settings.php
+++ b/settings.php
@@ -14,11 +14,13 @@ $message = '';
 $openai = Setting::get('openai_api_token') ?? '';
 $batch = Setting::get('ai_tag_batch_size') ?? '20';
 $retention = Setting::get('log_retention_days') ?? '30';
+$timeout = Setting::get('session_timeout_minutes') ?? '0';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $openai = trim($_POST['openai_api_token'] ?? '');
     $batch = trim($_POST['ai_tag_batch_size'] ?? '');
     $retention = trim($_POST['log_retention_days'] ?? '');
+    $timeout = trim($_POST['session_timeout_minutes'] ?? '');
     Setting::set('openai_api_token', $openai);
     Log::write('Updated OpenAI API token');
     if ($batch !== '') {
@@ -28,6 +30,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($retention !== '') {
         Setting::set('log_retention_days', $retention);
         Log::write('Updated log retention days');
+    }
+    if ($timeout !== '') {
+        Setting::set('session_timeout_minutes', $timeout);
+        Log::write('Updated session timeout minutes');
     }
     $message = 'Settings updated.';
 }
@@ -73,6 +79,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </label>
             <label class="block">Log Retention Days:
                 <input type="number" name="log_retention_days" value="<?= htmlspecialchars($retention) ?>" class="border p-2 rounded w-full" data-help="Automatically prune logs older than this many days">
+            </label>
+            <label class="block">Auto-Logout Minutes:
+                <input type="number" name="session_timeout_minutes" value="<?= htmlspecialchars($timeout) ?>" class="border p-2 rounded w-full" data-help="Minutes of inactivity before automatic logout">
             </label>
             <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
         </form>


### PR DESCRIPTION
## Summary
- add server endpoint and setting to configure inactivity logout timer
- add frontend script and hook to logout after configured inactivity

## Testing
- `php -l settings.php php_backend/public/session_timeout.php`
- `node -c frontend/js/auto_logout.js frontend/js/menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68a85002efe0832eb99a6d883c4aea18