### PR TITLE
Style segment badges to match tables

### DIFF
--- a/frontend/js/segment_drag.js
+++ b/frontend/js/segment_drag.js
@@ -57,8 +57,8 @@
 
     const header = document.createElement('div');
     header.className = 'flex justify-between items-center mb-2';
-    const title = document.createElement('h2');
-    title.className = 'font-semibold';
+    const title = document.createElement('span');
+    title.className = 'inline-block px-2 py-1 text-xs font-semibold rounded bg-yellow-200 text-yellow-800';
     title.textContent = seg.name;
     header.appendChild(title);
 


### PR DESCRIPTION
## Summary
- Display segment names on Manage Segments page using the same yellow badge styling used in tables

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a85245dc00832eb0ab290788221690