### PR TITLE
Show series names in chart tooltips

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -68,7 +68,7 @@
                     title: { text: 'Balance Over Time' },
                     xAxis: { categories: dates },
                     yAxis: { title: { text: 'Balance (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-                    tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                    tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
                     series: [{ name: 'Balance', data: balances, colorByPoint: true }]
                 });
             });

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -110,7 +110,7 @@
                 },
                 tooltip: {
                     pointFormatter: function(){
-                        return '£' + Highcharts.numberFormat(this.y, 2);
+                        return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2);
                     }
                 },
                 series: [{

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -106,7 +106,7 @@
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
             series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
@@ -144,7 +144,7 @@
             Highcharts.chart(id, {
                 chart: { type: 'pie' },
                 title: { text: title },
-                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
                 plotOptions: {
                     pie: {
                         dataLabels: {

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -75,7 +75,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
                 plotOptions: { column: { stacking: 'normal', depth: 40 } },
                 series: categorySeries
             });
@@ -106,7 +106,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
                 plotOptions: { column: { stacking: 'normal', depth: 40 } },
                 series: categoryCumulative
             });
@@ -119,7 +119,7 @@
 
                 },
                 title: { text: 'Category Breakdown' },
-                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
                 plotOptions: { pie: { depth: 35 } },
                 series: [{ name: 'Categories', data: catData }]
             });
@@ -139,7 +139,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
                 plotOptions: { bar: { depth: 40 } },
                 series: [{ name: 'Total', data: incomeTags.map(t => parseFloat(t.total)), colorByPoint: true }]
             });
@@ -156,7 +156,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
                 plotOptions: { bar: { depth: 40 } },
                 series: [{ name: 'Total', data: outgoingTags.map(t => Math.abs(parseFloat(t.total))), colorByPoint: true }]
             });
@@ -174,7 +174,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return this.category + ': £' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: function(){ return this.series.name + ' - ' + this.category + ': £' + Highcharts.numberFormat(this.y, 2); } },
 
                 series: [{ name: 'Spending', data: totals.map((v, i) => [i, v]), colorByPoint: true }]
 
@@ -307,7 +307,7 @@
             tooltip: {
                 pointFormatter: function(){
                     const sum = (this.node && this.node.childrenTotal) || this.value;
-                    return '£' + Highcharts.numberFormat(sum, 2);
+                    return this.series.name + ': £' + Highcharts.numberFormat(sum, 2);
                 }
             }
         });
@@ -339,7 +339,7 @@
             title: { text: 'Segment Totals' },
             xAxis: { categories: segments.map(s => s.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
             series: [{ name: 'Total', data: segments.map(s => parseFloat(s.total)), colorByPoint: true }]
         });
     }

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -126,7 +126,7 @@
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value,2); } } },
-            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y,2); } },
+            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
             series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -128,7 +128,7 @@
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
             series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
@@ -166,7 +166,7 @@
             Highcharts.chart(id, {
                 chart: { type: 'pie' },
                 title: { text: title },
-                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
                 plotOptions: {
                     pie: {
                         dataLabels: {

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -429,7 +429,7 @@ function buildDonutChart(spendings, prevSpendings){
             pointFormatter: function(){
                 const change = this.change;
                 const sign = change >= 0 ? '+' : '-';
-                return `<b>${this.name}</b><br/>Spend: £${Highcharts.numberFormat(this.y, 2)}<br/>Change: ${sign}£${Highcharts.numberFormat(Math.abs(change), 2)}`;
+                return `<b>${this.series.name}: ${this.name}</b><br/>Spend: £${Highcharts.numberFormat(this.y, 2)}<br/>Change: ${sign}£${Highcharts.numberFormat(Math.abs(change), 2)}`;
             }
         },
         series: [{ data }]

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -110,7 +110,7 @@
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-            tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
             series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
@@ -148,7 +148,7 @@
             Highcharts.chart(id, {
                 chart: { type: 'pie' },
                 title: { text: title },
-                tooltip: { pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
                 plotOptions: {
                     pie: {
                         dataLabels: {


### PR DESCRIPTION
## Summary
- Include series names in Highcharts tooltips across account dashboards and graphs for clearer hover text

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68a859134154832e84b1db7897be1aa3