### PR TITLE
Improve Highcharts tooltips

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -38,6 +38,15 @@
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    function balanceTooltip(){
+        const prev = this.point.index > 0 ? this.series.yData[this.point.index - 1] : null;
+        let text = `Date: ${this.category}<br/>Balance: £${Highcharts.numberFormat(this.y, 2)}`;
+        if(prev !== null){
+            const delta = this.y - prev;
+            text += `<br/>Change: £${Highcharts.numberFormat(delta, 2)}`;
+        }
+        return text;
+    }
     // Format balance cells with currency and positive/negative colouring
     function balanceFormatter(cell){
         const value = cell.getValue();
@@ -68,7 +77,7 @@
                     title: { text: 'Balance Over Time' },
                     xAxis: { categories: dates },
                     yAxis: { title: { text: 'Balance (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-                    tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+                    tooltip: { pointFormatter: balanceTooltip },
                     series: [{ name: 'Balance', data: balances, colorByPoint: true }]
                 });
             });

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -35,6 +35,12 @@
 
     <script>
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    function waterfallTooltip(){
+        const name = this.point.name || this.category;
+        const change = this.y;
+        const total = this.point.stackY;
+        return `<b>${name}</b><br/>Change: £${Highcharts.numberFormat(change, 2)}<br/>Total: £${Highcharts.numberFormat(total, 2)}`;
+    }
     // Format balance cells with currency and positive/negative colouring
     function balanceFormatter(cell){
         const value = cell.getValue();
@@ -108,11 +114,7 @@
                         }
                     }
                 },
-                tooltip: {
-                    pointFormatter: function(){
-                        return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2);
-                    }
-                },
+                tooltip: { pointFormatter: waterfallTooltip },
                 series: [{
                     type: 'waterfall',
                     name: 'Balance',

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -50,6 +50,17 @@
     <script src="https://code.highcharts.com/modules/sunburst.js"></script>
     <script>
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    function columnTooltip(){
+        const total = this.series.yData.reduce((sum, v) => sum + v, 0);
+        const pct = total ? (this.y / total * 100) : 0;
+        return `<b>${this.series.name}</b><br/>${this.category}: £${Highcharts.numberFormat(this.y, 2)} (${Highcharts.numberFormat(pct, 1)}% of total)`;
+    }
+    function sunburstTooltip(){
+        const sum = (this.node && this.node.childrenTotal) || this.value;
+        const total = this.series.points[0].node.childrenTotal;
+        const pct = total ? (sum / total * 100) : 0;
+        return `<b>${this.point.name}</b><br/>£${Highcharts.numberFormat(sum, 2)} (${Highcharts.numberFormat(pct, 1)}%)`;
+    }
     // Format totals with currency and colour
     function totalFormatter(cell){
         const value = cell.getValue();
@@ -107,7 +118,7 @@
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+            tooltip: { pointFormatter: columnTooltip },
             series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
@@ -152,9 +163,7 @@
                     cursor: 'pointer',
                     dataLabels: { format: '{point.name}: £{point.value:.2f}' }
                 }],
-                tooltip: {
-                    pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); }
-                }
+                tooltip: { pointFormatter: sunburstTooltip }
             });
         }
 

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -57,6 +57,15 @@
 <script>
 // Format a number as currency with a pound symbol
 function formatCurrency(value){return '£'+parseFloat(value).toFixed(2);}
+function budgetTooltip(){
+    const category = this.category;
+    if(this.series.name==='Spent'){
+        const budget = this.series.chart.series[0].data[this.point.index].y;
+        const pct = budget ? (this.y / budget * 100) : 0;
+        return `<b>${category}</b><br/>Spent: £${Highcharts.numberFormat(this.y,2)} (${Highcharts.numberFormat(pct,1)}% of budget)`;
+    }
+    return `<b>${category}</b><br/>Budget: £${Highcharts.numberFormat(this.y,2)}`;
+}
 let budgetTable;
 const monthInput=document.getElementById('month');
 monthInput.value=new Date().toISOString().slice(0,7);
@@ -106,6 +115,7 @@ async function loadBudgets(){
         title:{text:''},
         xAxis:{categories:data.map(b=>b.category)},
         yAxis:{title:{text:'£'}},
+        tooltip:{ pointFormatter: budgetTooltip },
         series:[
             {name:'Budget',data:data.map(b=>parseFloat(b.amount))},
             {name:'Spent',data:data.map(b=>parseFloat(b.spent))}

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -49,6 +49,23 @@
     // Retrieve data for the chosen year and draw charts with 3D bars where applicable
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
 
+    function columnTooltip(){
+        const total = this.series.yData.reduce((sum, v) => sum + v, 0);
+        const pct = total ? (this.y / total * 100) : 0;
+        return `<b>${this.series.name}</b><br/>${this.category}: £${Highcharts.numberFormat(this.y, 2)} (${Highcharts.numberFormat(pct, 1)}% of total)`;
+    }
+
+    function pieTooltip(){
+        return `<b>${this.point.name}</b><br/>£${Highcharts.numberFormat(this.y, 2)} (${Highcharts.numberFormat(this.percentage, 1)}%)`;
+    }
+
+    function sunburstTooltip(){
+        const sum = (this.node && this.node.childrenTotal) || this.value;
+        const total = this.series.points[0].node.childrenTotal;
+        const pct = total ? (sum / total * 100) : 0;
+        return `<b>${this.point.name}</b><br/>£${Highcharts.numberFormat(sum, 2)} (${Highcharts.numberFormat(pct, 1)}%)`;
+    }
+
     function loadYear(year){
         Promise.all([
             fetch('../php_backend/public/dashboard.php?year=' + year).then(r => r.json()),
@@ -75,7 +92,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: columnTooltip },
                 plotOptions: { column: { stacking: 'normal', depth: 40 } },
                 series: categorySeries
             });
@@ -106,7 +123,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: columnTooltip },
                 plotOptions: { column: { stacking: 'normal', depth: 40 } },
                 series: categoryCumulative
             });
@@ -119,7 +136,7 @@
 
                 },
                 title: { text: 'Category Breakdown' },
-                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: pieTooltip },
                 plotOptions: { pie: { depth: 35 } },
                 series: [{ name: 'Categories', data: catData }]
             });
@@ -139,7 +156,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: columnTooltip },
                 plotOptions: { bar: { depth: 40 } },
                 series: [{ name: 'Total', data: incomeTags.map(t => parseFloat(t.total)), colorByPoint: true }]
             });
@@ -156,7 +173,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: columnTooltip },
                 plotOptions: { bar: { depth: 40 } },
                 series: [{ name: 'Total', data: outgoingTags.map(t => Math.abs(parseFloat(t.total))), colorByPoint: true }]
             });
@@ -174,7 +191,7 @@
                     title: { text: 'Amount (£)' },
                     labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } }
                 },
-                tooltip: { pointFormatter: function(){ return this.series.name + ' - ' + this.category + ': £' + Highcharts.numberFormat(this.y, 2); } },
+                tooltip: { pointFormatter: columnTooltip },
 
                 series: [{ name: 'Spending', data: totals.map((v, i) => [i, v]), colorByPoint: true }]
 
@@ -304,12 +321,7 @@
                 ]
             }],
             title: { text: chartTitle },
-            tooltip: {
-                pointFormatter: function(){
-                    const sum = (this.node && this.node.childrenTotal) || this.value;
-                    return this.series.name + ': £' + Highcharts.numberFormat(sum, 2);
-                }
-            }
+            tooltip: { pointFormatter: sunburstTooltip }
         });
 
         return Object.entries(segmentTotals).map(([name, total]) => ({ name, total }));
@@ -339,7 +351,7 @@
             title: { text: 'Segment Totals' },
             xAxis: { categories: segments.map(s => s.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+            tooltip: { pointFormatter: columnTooltip },
             series: [{ name: 'Total', data: segments.map(s => parseFloat(s.total)), colorByPoint: true }]
         });
     }

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -43,6 +43,11 @@
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    function columnTooltip(){
+        const total = this.series.yData.reduce((sum, v) => sum + v, 0);
+        const pct = total ? (this.y / total * 100) : 0;
+        return `<b>${this.series.name}</b><br/>${this.category}: £${Highcharts.numberFormat(this.y, 2)} (${Highcharts.numberFormat(pct, 1)}% of total)`;
+    }
     // Format totals with currency and highlight positive/negative values
     function totalFormatter(cell){
         const value = cell.getValue();
@@ -126,7 +131,7 @@
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value,2); } } },
-            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+            tooltip: { pointFormatter: columnTooltip },
             series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -72,6 +72,17 @@
     <script src="https://code.highcharts.com/modules/sunburst.js"></script>
     <script>
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    function columnTooltip(){
+        const total = this.series.yData.reduce((sum, v) => sum + v, 0);
+        const pct = total ? (this.y / total * 100) : 0;
+        return `<b>${this.series.name}</b><br/>${this.category}: £${Highcharts.numberFormat(this.y, 2)} (${Highcharts.numberFormat(pct, 1)}% of total)`;
+    }
+    function sunburstTooltip(){
+        const sum = (this.node && this.node.childrenTotal) || this.value;
+        const total = this.series.points[0].node.childrenTotal;
+        const pct = total ? (sum / total * 100) : 0;
+        return `<b>${this.point.name}</b><br/>£${Highcharts.numberFormat(sum, 2)} (${Highcharts.numberFormat(pct, 1)}%)`;
+    }
     // Format totals with currency and sign-based colouring
     function totalFormatter(cell){
         const value = cell.getValue();
@@ -129,7 +140,7 @@
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+            tooltip: { pointFormatter: columnTooltip },
             series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
@@ -174,9 +185,7 @@
                     cursor: 'pointer',
                     dataLabels: { format: '{point.name}: £{point.value:.2f}' }
                 }],
-                tooltip: {
-                    pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); }
-                }
+                tooltip: { pointFormatter: sunburstTooltip }
             });
         }
 

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -429,7 +429,8 @@ function buildDonutChart(spendings, prevSpendings){
             pointFormatter: function(){
                 const change = this.change;
                 const sign = change >= 0 ? '+' : '-';
-                return `<b>${this.series.name}: ${this.name}</b><br/>Spend: £${Highcharts.numberFormat(this.y, 2)}<br/>Change: ${sign}£${Highcharts.numberFormat(Math.abs(change), 2)}`;
+                const share = Highcharts.numberFormat(this.percentage, 1);
+                return `<b>${this.series.name}: ${this.name}</b><br/>Spend: £${Highcharts.numberFormat(this.y, 2)}<br/>Change: ${sign}£${Highcharts.numberFormat(Math.abs(change), 2)}<br/>Share: ${share}%`;
             }
         },
         series: [{ data }]

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -47,6 +47,11 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script>
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    function columnTooltip(){
+        const total = this.series.yData.reduce((sum, v) => sum + v, 0);
+        const pct = total ? (this.y / total * 100) : 0;
+        return `${this.category}: £${Highcharts.numberFormat(this.y, 2)} (${Highcharts.numberFormat(pct, 1)}%)`;
+    }
 
     // Load filter options for categories, tags and groups
     async function loadOptions() {
@@ -154,6 +159,7 @@
                         title: { text: 'Transaction Amounts' },
                         xAxis: { categories: categories, title: { text: 'Date' } },
                         yAxis: { title: { text: 'Amount' } },
+                        tooltip: { pointFormatter: columnTooltip },
                         series: [{ name: 'Amount', data: amounts, colorByPoint: true }]
                     });
                 } else {

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -38,6 +38,11 @@
     <script src="https://code.highcharts.com/highcharts-3d.js"></script>
     <script>
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    function columnTooltip(){
+        const total = this.series.yData.reduce((sum, v) => sum + v, 0);
+        const pct = total ? (this.y / total * 100) : 0;
+        return `${this.category}: £${Highcharts.numberFormat(this.y, 2)} (${Highcharts.numberFormat(pct, 1)}%)`;
+    }
     // Format a numeric value as pounds and pence
     function formatCurrency(value) {
         return '£' + parseFloat(value).toFixed(2);
@@ -172,7 +177,7 @@
                             yAxis: { title: { text: 'Amount (£)' } },
                             plotOptions: { column: { depth: 25 } },
                             series: [{ name: 'Spend', data: points, colorByPoint: true }],
-                            tooltip: { valuePrefix: '£', valueDecimals: 2 }
+                            tooltip: { pointFormatter: columnTooltip }
                         });
                     } else {
                         chartEl.innerHTML = '';

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -54,6 +54,17 @@
     <script src="https://code.highcharts.com/modules/sunburst.js"></script>
     <script>
     const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    function columnTooltip(){
+        const total = this.series.yData.reduce((sum, v) => sum + v, 0);
+        const pct = total ? (this.y / total * 100) : 0;
+        return `<b>${this.series.name}</b><br/>${this.category}: £${Highcharts.numberFormat(this.y, 2)} (${Highcharts.numberFormat(pct, 1)}% of total)`;
+    }
+    function sunburstTooltip(){
+        const sum = (this.node && this.node.childrenTotal) || this.value;
+        const total = this.series.points[0].node.childrenTotal;
+        const pct = total ? (sum / total * 100) : 0;
+        return `<b>${this.point.name}</b><br/>£${Highcharts.numberFormat(sum, 2)} (${Highcharts.numberFormat(pct, 1)}%)`;
+    }
     // Format totals with currency and colour coding
     function totalFormatter(cell){
         const value = cell.getValue();
@@ -111,7 +122,7 @@
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
-            tooltip: { pointFormatter: function(){ return this.series.name + ': £' + Highcharts.numberFormat(this.y, 2); } },
+            tooltip: { pointFormatter: columnTooltip },
             series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
         });
     }
@@ -156,9 +167,7 @@
                     cursor: 'pointer',
                     dataLabels: { format: '{point.name}: £{point.value:.2f}' }
                 }],
-                tooltip: {
-                    pointFormatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); }
-                }
+                tooltip: { pointFormatter: sunburstTooltip }
             });
         }
 


### PR DESCRIPTION
## Summary
- enhance Highcharts column, pie, sunburst, and waterfall charts with category, currency, and percentage details in tooltips
- add balance change tooltips on account history and budget progress tooltips with percent of budget
- show category share percentages on monthly statement donut chart

## Testing
- `composer install` *(fails: CONNECT tunnel failed 403)*
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68a86033fd70832e8912b548dcaa5823