### PR TITLE
Add generic fallback for ambiguous AI tagging

### DIFF
--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -32,7 +32,7 @@ if (!$txns) {
 $categories = $db->query('SELECT id, name FROM categories')->fetchAll(PDO::FETCH_ASSOC);
 
 $txnMap = [];
-$prompt = "You are a financial assistant. For each transaction provide a short tag, a brief description for the tag and one of the provided categories. Return JSON array with objects {\"id\":<id>,\"tag\":\"tag name\",\"description\":\"tag description\",\"category\":\"category name\"}.\n\n";
+$prompt = "You are a financial assistant. For each transaction provide a short tag, a brief description for the tag and one of the provided categories. If the transaction details are ambiguous, use a generic tag name. Return JSON array with objects {\"id\":<id>,\"tag\":\"tag name\",\"description\":\"tag description\",\"category\":\"category name\"}.\n\n";
 
 $prompt .= "Categories:\n";
 foreach ($categories as $c) {


### PR DESCRIPTION
## Summary
- ensure AI tagging instructions mention using a generic tag when transaction details are ambiguous

## Testing
- `php -l php_backend/public/ai_tags.php`
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a865597750832ea713d673710a346e