### PR TITLE
Add pivot analysis section using WebDataRocks

### DIFF
--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -34,7 +34,8 @@ const init = () => {
     'transfers.html': `Use Assist to search for same-day transactions with equal and opposite amounts. Review each suggested pair and mark it individually or mark all at once so confirmed transfers are ignored in reports. Undo any transfer if you mark it by mistake to keep totals accurate and prevent the same money being counted twice.`,
 
     'yearly_dashboard.html': `Analyse totals for a chosen year using charts and tables. Look through the months to see how spending and income evolved as the year progressed. This broader view helps you understand whether you are meeting your long‑term goals and where you might need to cut back.`,
-    'recurring_spend.html': `Identify expenses that recur over the past year so you are aware of ongoing commitments. The page highlights regular payments like subscriptions or rent and shows how much they cost overall. Spotting these repeated charges helps you decide which ones are essential and which could be reduced or cancelled.`
+    'recurring_spend.html': `Identify expenses that recur over the past year so you are aware of ongoing commitments. The page highlights regular payments like subscriptions or rent and shows how much they cost overall. Spotting these repeated charges helps you decide which ones are essential and which could be reduced or cancelled.`,
+    'pivot.html': `Explore transactions with a pivot table. Choose a year or view all records to break down amounts by category, month or other fields. Use the export options to save the results for further analysis.`
 
   };
 

--- a/frontend/js/pivot.js
+++ b/frontend/js/pivot.js
@@ -1,0 +1,66 @@
+// Initialise pivot table with WebDataRocks and provide year filtering
+
+document.addEventListener('DOMContentLoaded', () => {
+  const yearSelect = document.getElementById('year-select');
+  const refreshBtn = document.getElementById('refresh');
+  const monthNames = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+  let pivot; 
+
+  // Fetch available months to populate years list
+  fetch('../php_backend/public/transaction_months.php')
+    .then(r => r.json())
+    .then(months => {
+      const years = Array.from(new Set(months.map(m => m.year))).sort((a,b) => b - a);
+      years.forEach(y => {
+        const opt = document.createElement('option');
+        opt.value = y;
+        opt.textContent = y;
+        yearSelect.appendChild(opt);
+      });
+      loadData(yearSelect.value);
+    })
+    .catch(() => showMessage('Failed to load years','error'));
+
+  refreshBtn.addEventListener('click', () => loadData(yearSelect.value));
+
+  function loadData(year){
+    let url = '../php_backend/public/export_data.php';
+    if(year !== 'all'){
+      url += `?start=${year}-01-01&end=${year}-12-31`;
+    }
+    fetch(url)
+      .then(r => r.json())
+      .then(rows => {
+        const data = rows.map(r => ({
+          ...r,
+          year: r.date.substring(0,4),
+          month: monthNames[new Date(r.date).getMonth()]
+        }));
+        const report = {
+          dataSource: { data },
+          slice: {
+            rows: [{ uniqueName: 'category_name' }],
+            columns: [{ uniqueName: 'month' }],
+            measures: [{ uniqueName: 'amount', aggregation: 'sum', format: 'GBP' }]
+          },
+          formats: [{
+            name: 'GBP',
+            currencySymbol: '£',
+            thousandsSeparator: ',',
+            decimalSeparator: '.',
+            decimalPlaces: 2
+          }]
+        };
+        if(pivot){
+          pivot.setReport(report);
+        } else {
+          pivot = new WebDataRocks({
+            container: '#pivot-table',
+            toolbar: true,
+            report
+          });
+        }
+      })
+      .catch(() => showMessage('Failed to load data','error'));
+  }
+});

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -29,6 +29,7 @@
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="group_dashboard.html"><i class="fas fa-object-group mr-1"></i> Group Dashboard</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="account_dashboard.html"><i class="fas fa-wallet mr-1"></i> Account Dashboard</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="recurring_spend.html"><i class="fas fa-rotate mr-1"></i> Recurring Spend</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="pivot.html"><i class="fas fa-table mr-1"></i> Pivot Analysis</a></li>
     </ul>
   </div>
 

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!-- Interactive pivot table analysis -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pivot Analysis</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="https://cdn.webdatarocks.com/latest/webdatarocks.min.css" />
+</head>
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="w-64 flex-shrink-0 bg-white border-r p-6"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
+            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Pivot Analysis</h1>
+            <p class="mb-4">Explore transactions using a flexible pivot table. Choose a year or analyse all recorded data.</p>
+            <section class="space-y-4">
+                <div class="flex flex-col md:flex-row md:items-end md:space-x-4 space-y-4 md:space-y-0">
+                    <div class="flex flex-col">
+                        <label for="year-select" class="font-semibold">Year</label>
+                        <select id="year-select" class="border p-2 rounded" data-help="Select the year to analyse or view all years">
+                            <option value="all">All Years</option>
+                        </select>
+                    </div>
+                    <button id="refresh" class="bg-indigo-600 text-white px-4 py-2 rounded self-start md:self-auto"><i class="fas fa-rotate inline w-4 h-4 mr-2"></i>Refresh</button>
+                </div>
+                <div id="pivot-table" class="h-96"></div>
+            </section>
+        </main>
+    </div>
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="js/overlay.js"></script>
+    <script src="https://cdn.webdatarocks.com/latest/webdatarocks.toolbar.min.js"></script>
+    <script src="https://cdn.webdatarocks.com/latest/webdatarocks.js"></script>
+    <script src="js/pivot.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Pivot Analysis page with year filter and WebDataRocks pivot table
- enable built-in export toolbar and link page from navigation menu
- document purpose in page help overlay

## Testing
- `node --check frontend/js/pivot.js`


------
https://chatgpt.com/codex/tasks/task_e_68a979181b70832e8f291989608ce497