### PR TITLE
Redirect to login after inactivity timeout

### DIFF
--- a/frontend/js/auto_logout.js
+++ b/frontend/js/auto_logout.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const reset = () => {
           clearTimeout(timer);
           timer = setTimeout(() => {
-            window.location.href = '../logout.php';
+            window.location.href = '../logout.php?timeout=1';
           }, minutes * 60 * 1000);
         };
         ['click', 'mousemove', 'keydown', 'scroll', 'touchstart'].forEach(evt =>

--- a/logout.php
+++ b/logout.php
@@ -6,10 +6,16 @@ require_once __DIR__ . '/php_backend/nocache.php';
 require_once __DIR__ . '/php_backend/models/Log.php';
 
 if (isset($_SESSION['user_id'])) {
-    Log::write('User ' . $_SESSION['user_id'] . ' logged out');
+    $reason = isset($_GET['timeout']) ? ' (timeout)' : '';
+    Log::write('User ' . $_SESSION['user_id'] . ' logged out' . $reason);
 }
 
 session_destroy();
+
+if (isset($_GET['timeout'])) {
+    header('Location: index.php');
+    exit;
+}
 ?>
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- Ensure auto logout sends users straight to the login page
- Log timeout reason and redirect from server when inactivity triggers logout

## Testing
- `php -l logout.php`
- `node --check frontend/js/auto_logout.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9a9ee49c4832e9e6048f0e96660b3