### PR TITLE
Reorganize side menu for logical workflow

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -2,7 +2,7 @@
 <h2 class="text-xl font-semibold text-gray-700 mb-4">Menu</h2>
 <div class="space-y-2">
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">General Overview</h3>
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Start Here</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
       <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="index.html"><i class="fas fa-home mr-1"></i> Home</a></li>
       <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="upload.html"><i class="fas fa-upload mr-1"></i> Upload OFX Files</a></li>
@@ -10,7 +10,7 @@
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Transaction Hub</h3>
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Statements &amp; Transactions</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_statement.html"><i class="fas fa-file-invoice mr-1"></i> Monthly Statement</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="report.html"><i class="fas fa-file-lines mr-1"></i> Transaction Reports</a></li>
@@ -21,7 +21,7 @@
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Dashboards</h3>
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Dashboards &amp; Graphs</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="yearly_dashboard.html"><i class="fas fa-calendar mr-1"></i> Yearly Dashboard</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="all_years_dashboard.html"><i class="fas fa-calendar-alt mr-1"></i> All Years Dashboard</a></li>
@@ -30,25 +30,19 @@
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="account_dashboard.html"><i class="fas fa-wallet mr-1"></i> Account Dashboard</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="recurring_spend.html"><i class="fas fa-rotate mr-1"></i> Recurring Spend</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="pivot.html"><i class="fas fa-table mr-1"></i> Pivot Analysis</a></li>
-    </ul>
-  </div>
-
-  <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Graphs</h3>
-    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="graphs.html"><i class="fas fa-chart-bar mr-1"></i> Graphs</a></li>
     </ul>
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Budget Plans</h3>
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Budgeting</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="budgets.html"><i class="fas fa-piggy-bank mr-1"></i> Budgets</a></li>
     </ul>
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Data Organisation</h3>
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Organise Data</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="tags.html"><i class="fas fa-tags mr-1"></i> Manage Tags</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ai_tags.html"><i class="fas fa-robot mr-1"></i> AI Tags</a></li>
@@ -65,7 +59,7 @@
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Exports</h3>
+    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Export</h3>
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
       <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="export.html"><i class="fas fa-file-export mr-1"></i> Export Data</a></li>
     </ul>


### PR DESCRIPTION
## Summary
- Reorder navigation into workflow-driven groups: start, statements, dashboards, budgeting, organisation, export, and admin
- Merge graphs into dashboards for streamlined insights

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a9aa5484d0832eb9c7d838b62cafff