### PR TITLE
Add drilldown for pivot table cells

### DIFF
--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -34,6 +34,14 @@
                 <div id="pivot-table" class="h-[80vh]"></div>
 
             </section>
+
+            <section id="detail-card" class="hidden bg-white p-6 rounded shadow space-y-4">
+                <div class="flex justify-between items-center">
+                    <h2 id="detail-title" class="text-xl font-semibold text-indigo-700"></h2>
+                    <button id="detail-close" class="text-gray-500 hover:text-gray-700"><i class="fas fa-times"></i></button>
+                </div>
+                <div id="detail-table" class="h-96"></div>
+            </section>
         </main>
     </div>
     <script src="js/menu.js"></script>


### PR DESCRIPTION
## Summary
- make pivot table cells clickable to reveal the transactions behind them
- add detail section on Pivot Analysis page to display these transactions
- ensure detail card scrolls into view and is styled as a card

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9ad4e2d70832eadea747330c94509