### PR TITLE
Switch budget progress to bullet chart

### DIFF
--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -43,7 +43,7 @@
             <h2 class="text-xl font-semibold mb-4">Current Budgets</h2>
             <div id="budget-table"></div>
         </section>
-        <section>
+        <section class="bg-white p-6 rounded shadow">
             <h2 class="text-xl font-semibold mb-4">Budget Progress</h2>
             <div id="budget-chart" style="height:400px"></div>
         </section>
@@ -54,17 +54,16 @@
 <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
 <script src="js/tabulator-tailwind.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
+<script src="https://code.highcharts.com/modules/bullet.js"></script>
 <script>
 // Format a number as currency with a pound symbol
 function formatCurrency(value){return '£'+parseFloat(value).toFixed(2);}
 function budgetTooltip(){
-    const category = this.category;
-    if(this.series.name==='Spent'){
-        const budget = this.series.chart.series[0].data[this.point.index].y;
-        const pct = budget ? (this.y / budget * 100) : 0;
-        return `<b>${category}</b><br/>Spent: £${Highcharts.numberFormat(this.y,2)} (${Highcharts.numberFormat(pct,1)}% of budget)`;
-    }
-    return `<b>${category}</b><br/>Budget: £${Highcharts.numberFormat(this.y,2)}`;
+    const category=this.category;
+    const budget=this.point.target;
+    const spent=this.y;
+    const pct=budget?(spent/budget*100):0;
+    return `<b>${category}</b><br/>Spent: £${Highcharts.numberFormat(spent,2)} (${Highcharts.numberFormat(pct,1)}% of budget)<br/>Budget: £${Highcharts.numberFormat(budget,2)}`;
 }
 let budgetTable;
 const monthInput=document.getElementById('month');
@@ -111,15 +110,15 @@ async function loadBudgets(){
         });
     }
     Highcharts.chart('budget-chart',{
-        chart:{type:'column'},
+        chart:{type:'bullet',inverted:true},
         title:{text:''},
         xAxis:{categories:data.map(b=>b.category)},
         yAxis:{title:{text:'£'}},
         tooltip:{ pointFormatter: budgetTooltip },
-        series:[
-            {name:'Budget',data:data.map(b=>parseFloat(b.amount))},
-            {name:'Spent',data:data.map(b=>parseFloat(b.spent))}
-        ]
+        series:[{
+            name:'Spent',
+            data:data.map(b=>({y:parseFloat(b.spent),target:parseFloat(b.amount)}))
+        }]
     });
 }
 


### PR DESCRIPTION
## Summary
- Replace column chart with Highcharts bullet chart to show budget vs spending
- Style budget progress section as Tailwind card

## Testing
- `php -l frontend/budgets.html`


------
https://chatgpt.com/codex/tasks/task_e_68a9bf799fb0832eb82cf8de1e2aaf26