### PR TITLE
Add customizable font settings

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -73,20 +73,40 @@ document.addEventListener('DOMContentLoaded', () => {
     );
 
     // Load site fonts and apply them to headings, body text and accents
-    if (!document.getElementById('app-fonts')) {
-      const fontLink = document.createElement('link');
+    let fontLink = document.getElementById('app-fonts');
+    if (!fontLink) {
+      fontLink = document.createElement('link');
       fontLink.id = 'app-fonts';
       fontLink.rel = 'stylesheet';
-      fontLink.href = 'https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap';
       document.head.appendChild(fontLink);
     }
     const fontStyle = document.createElement('style');
-    fontStyle.textContent = `
-      body { font-family: 'Inter', sans-serif; font-weight: 400; }
-      h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
-      button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
-    `;
     document.head.appendChild(fontStyle);
+
+    fetch('../php_backend/public/font_settings.php')
+      .then(r => r.json())
+      .then(f => {
+        const families = [
+          `family=${encodeURIComponent(f.heading)}:wght@700`,
+          `family=${encodeURIComponent(f.body)}:wght@400`,
+          `family=${encodeURIComponent(f.accent)}:wght@300`
+        ];
+        fontLink.href = `https://fonts.googleapis.com/css2?${families.join('&')}&display=swap`;
+        fontStyle.textContent = `
+          body { font-family: '${f.body}', sans-serif; font-weight: 400; }
+          h1, h2, h3, h4, h5, h6 { font-family: '${f.heading}', sans-serif; font-weight: 700; }
+          button, .accent { font-family: '${f.accent}', sans-serif; font-weight: 300; }
+        `;
+      })
+      .catch(err => {
+        console.error('Font load failed', err);
+        fontLink.href = 'https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap';
+        fontStyle.textContent = `
+          body { font-family: 'Inter', sans-serif; font-weight: 400; }
+          h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
+          button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
+        `;
+      });
 
     fetch('menu.html')
       .then(resp => resp.text())

--- a/php_backend/models/Setting.php
+++ b/php_backend/models/Setting.php
@@ -3,6 +3,11 @@
 require_once __DIR__ . '/../Database.php';
 
 class Setting {
+    /** Default fonts used when none have been configured. */
+    private const DEFAULT_HEADING_FONT = 'Roboto';
+    private const DEFAULT_BODY_FONT = 'Inter';
+    private const DEFAULT_ACCENT_FONT = 'Source Sans Pro';
+
     /**
      * Retrieve a setting value by name.
      */
@@ -22,6 +27,19 @@ class Setting {
         $stmt = $db->prepare('INSERT INTO `settings` (`name`, `value`) VALUES (:name, :value)
             ON DUPLICATE KEY UPDATE `value` = VALUES(`value`)');
         $stmt->execute(['name' => $name, 'value' => $value]);
+    }
+
+    /**
+     * Convenience accessor for the site's configured fonts with sensible defaults.
+     *
+     * @return array{heading: string, body: string, accent: string}
+     */
+    public static function getFonts(): array {
+        return [
+            'heading' => self::get('font_heading') ?? self::DEFAULT_HEADING_FONT,
+            'body'    => self::get('font_body') ?? self::DEFAULT_BODY_FONT,
+            'accent'  => self::get('font_accent') ?? self::DEFAULT_ACCENT_FONT,
+        ];
     }
 }
 ?>

--- a/php_backend/public/font_settings.php
+++ b/php_backend/public/font_settings.php
@@ -1,0 +1,6 @@
+<?php
+require_once __DIR__ . '/../models/Setting.php';
+header('Content-Type: application/json');
+
+echo json_encode(Setting::getFonts());
+?>

--- a/settings.php
+++ b/settings.php
@@ -15,12 +15,20 @@ $openai = Setting::get('openai_api_token') ?? '';
 $batch = Setting::get('ai_tag_batch_size') ?? '20';
 $retention = Setting::get('log_retention_days') ?? '30';
 $timeout = Setting::get('session_timeout_minutes') ?? '0';
+$fontSettings = Setting::getFonts();
+$fontHeading = $fontSettings['heading'];
+$fontBody = $fontSettings['body'];
+$fontAccent = $fontSettings['accent'];
+$fontOptions = ['Roboto', 'Inter', 'Source Sans Pro', 'Montserrat', 'Open Sans', 'Lato'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $openai = trim($_POST['openai_api_token'] ?? '');
     $batch = trim($_POST['ai_tag_batch_size'] ?? '');
     $retention = trim($_POST['log_retention_days'] ?? '');
     $timeout = trim($_POST['session_timeout_minutes'] ?? '');
+    $fontHeading = trim($_POST['font_heading'] ?? '');
+    $fontBody = trim($_POST['font_body'] ?? '');
+    $fontAccent = trim($_POST['font_accent'] ?? '');
     Setting::set('openai_api_token', $openai);
     Log::write('Updated OpenAI API token');
     if ($batch !== '') {
@@ -34,6 +42,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($timeout !== '') {
         Setting::set('session_timeout_minutes', $timeout);
         Log::write('Updated session timeout minutes');
+    }
+    if ($fontHeading !== '') {
+        Setting::set('font_heading', $fontHeading);
+        Log::write('Updated heading font');
+    }
+    if ($fontBody !== '') {
+        Setting::set('font_body', $fontBody);
+        Log::write('Updated body font');
+    }
+    if ($fontAccent !== '') {
+        Setting::set('font_accent', $fontAccent);
+        Log::write('Updated accent font');
     }
     $message = 'Settings updated.';
 }
@@ -82,6 +102,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </label>
             <label class="block">Auto-Logout Minutes:
                 <input type="number" name="session_timeout_minutes" value="<?= htmlspecialchars($timeout) ?>" class="border p-2 rounded w-full" data-help="Minutes of inactivity before automatic logout">
+            </label>
+            <label class="block">Heading Font:
+                <select name="font_heading" class="border p-2 rounded w-full" data-help="Font used for headings">
+                    <?php foreach ($fontOptions as $opt): ?>
+                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontHeading ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block">Body Font:
+                <select name="font_body" class="border p-2 rounded w-full" data-help="Font used for body text">
+                    <?php foreach ($fontOptions as $opt): ?>
+                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontBody ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block">Accent Font:
+                <select name="font_accent" class="border p-2 rounded w-full" data-help="Font used for buttons and accents">
+                    <?php foreach ($fontOptions as $opt): ?>
+                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontAccent ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
+                    <?php endforeach; ?>
+                </select>
             </label>
             <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
         </form>


### PR DESCRIPTION
## Summary
- Extend Setting model with default font accessors and helper to fetch configured fonts
- Allow admins to select heading, body, and accent fonts via settings page
- Dynamically load configured fonts on every page through menu.js and new font settings endpoint

## Testing
- `php -l php_backend/models/Setting.php`
- `php -l settings.php`
- `php -l php_backend/public/font_settings.php`
- `node --check frontend/js/menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9bfadc568832e90eefc79b0832452