### PR TITLE
feat: add light font options

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -19,7 +19,10 @@ $fontSettings = Setting::getFonts();
 $fontHeading = $fontSettings['heading'];
 $fontBody = $fontSettings['body'];
 $fontAccent = $fontSettings['accent'];
-$fontOptions = ['Roboto', 'Inter', 'Source Sans Pro', 'Montserrat', 'Open Sans', 'Lato'];
+$fontOptions = [
+    'Roboto', 'Inter', 'Source Sans Pro', 'Montserrat', 'Open Sans', 'Lato',
+    'Nunito', 'Poppins', 'Raleway', 'Work Sans', 'Quicksand'
+];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $openai = trim($_POST['openai_api_token'] ?? '');


### PR DESCRIPTION
## Summary
- allow choosing extra light-weight fonts including Nunito, Poppins, Raleway, Work Sans, and Quicksand

## Testing
- `php -l settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9c1e6a930832ebfd1e0b73f8ef976