### PR TITLE
Add deployment script for easy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This repository now provides a simple PHP implementation for managing accounts and transactions.
 
+## Quick Deployment
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/your-org/Accounts/main/deploy.sh | bash
+```
+
+The script clones the repository, sets up the database, and creates an initial user.
+
 ## Authentication
 
 A basic login page is available at the project root (`index.php`). Users are stored in a `users` table. After logging in, visit `users.php` to add new users or change your password.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="https://github.com/your-org/Accounts.git"
+
+for cmd in git php mysql; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Error: $cmd is required but not installed." >&2
+    exit 1
+  fi
+done
+
+default_dir="$PWD/accounts"
+read -p "Installation directory [$default_dir]: " INSTALL_DIR
+INSTALL_DIR="${INSTALL_DIR:-$default_dir}"
+
+if [ -d "$INSTALL_DIR/.git" ]; then
+  echo "Directory already contains a git repository." >&2
+  exit 1
+fi
+
+echo "Cloning repository..."
+git clone "$REPO_URL" "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+echo "Database configuration"
+read -p "MySQL host [localhost]: " DB_HOST
+DB_HOST=${DB_HOST:-localhost}
+read -p "Database name [accounts]: " DB_NAME
+DB_NAME=${DB_NAME:-accounts}
+read -p "Database user [accounts]: " DB_USER
+DB_USER=${DB_USER:-accounts}
+read -s -p "Database password: " DB_PASS; echo
+
+read -p "MySQL root user [root]: " MYSQL_ROOT
+MYSQL_ROOT=${MYSQL_ROOT:-root}
+read -s -p "MySQL root password: " MYSQL_ROOT_PASS; echo
+
+echo "Creating database and user..."
+mysql -h "$DB_HOST" -u "$MYSQL_ROOT" -p"$MYSQL_ROOT_PASS" <<MYSQL
+CREATE DATABASE IF NOT EXISTS \`$DB_NAME\`;
+CREATE USER IF NOT EXISTS '$DB_USER'@'%' IDENTIFIED BY '$DB_PASS';
+GRANT ALL PRIVILEGES ON \`$DB_NAME\`.* TO '$DB_USER'@'%';
+FLUSH PRIVILEGES;
+MYSQL
+
+cat > .env <<ENV
+DB_HOST=$DB_HOST
+DB_NAME=$DB_NAME
+DB_USER=$DB_USER
+DB_PASS=$DB_PASS
+ENV
+
+export DB_HOST DB_NAME DB_USER DB_PASS
+
+echo "Creating database tables..."
+php php_backend/create_tables.php
+
+read -p "Initial application username: " ADMIN_USER
+read -s -p "Initial password: " ADMIN_PASS; echo
+
+export ADMIN_USER ADMIN_PASS
+php <<'PHP'
+<?php
+require 'php_backend/models/User.php';
+$id = User::create(getenv('ADMIN_USER'), getenv('ADMIN_PASS'));
+// Use stderr? but simply echo
+echo "Created user with ID: $id\n";
+?>
+PHP
+
+echo "Deployment complete."
+echo "To start the server, run:"
+echo "  cd '$INSTALL_DIR' && source .env && php -S localhost:8000"


### PR DESCRIPTION
## Summary
- add `deploy.sh` to clone repo, configure MySQL, create tables, and seed first user
- document one-line quick deployment command in README

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9c61580b0832eb16f8503814c737b