### PR TITLE
Allow site name and theme color configuration

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="w-64 flex-shrink-0 bg-white/80 backdrop-blur border-r p-6 shadow"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
-            <h1 class="text-3xl font-semibold mb-4 text-indigo-700">Welcome to Finance Manager</h1>
+            <h1 class="text-3xl font-semibold mb-4 text-indigo-700">Welcome to <span id="landing-site-name">Finance Manager</span></h1>
             <p class="text-gray-700">Select an option from the menu to get started exploring your finances. Each section opens tools and dashboards that help you understand where your money goes.</p>
             <p id="version" class="text-gray-500">Version: loading...</p>
 

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -5,7 +5,7 @@
       <img src="/favicon.svg" alt="Finance Manager logo" class="h-8 w-8" />
       <button id="menu-toggle" class="md:hidden bg-indigo-700 text-white p-2 rounded"><i class="fas fa-bars h-4 w-4"></i></button>
       <div class="font-bold text-lg flex items-center">
-        <span>Personal Finance Manager</span>
+        <span id="site-title">Personal Finance Manager</span>
         <span id="release-number" class="ml-2 bg-indigo-700 text-white text-[0.675rem] px-2 py-0.5 rounded">v0.0.0</span>
       </div>
     </div>

--- a/index.php
+++ b/index.php
@@ -7,8 +7,24 @@ require_once __DIR__ . '/php_backend/models/User.php';
 require_once __DIR__ . '/php_backend/models/Log.php';
 require_once __DIR__ . '/php_backend/Totp.php';
 require_once __DIR__ . '/php_backend/Database.php';
+require_once __DIR__ . '/php_backend/models/Setting.php';
 
 $db = Database::getConnection();
+$brand = Setting::getBrand();
+$siteName = $brand['site_name'];
+$colorScheme = $brand['color_scheme'];
+$colorMap = [
+    'indigo' => ['600' => '#4f46e5', '700' => '#4338ca'],
+    'blue'   => ['600' => '#2563eb', '700' => '#1d4ed8'],
+    'green'  => ['600' => '#059669', '700' => '#047857'],
+    'red'    => ['600' => '#dc2626', '700' => '#b91c1c'],
+    'purple' => ['600' => '#9333ea', '700' => '#7e22ce'],
+];
+$text600 = "text-{$colorScheme}-600";
+$text700 = "text-{$colorScheme}-700";
+$bg600 = "bg-{$colorScheme}-600";
+$hoverHex = $colorMap[$colorScheme]['600'] ?? '#4f46e5';
+$headerHex = $colorMap[$colorScheme]['700'] ?? '#4338ca';
 $error = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -70,8 +86,8 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <meta name="application-name" content="Finance Manager">
-    <title>Finance Manager Login</title>
+    <meta name="application-name" content="<?= htmlspecialchars($siteName) ?>">
+    <title><?= htmlspecialchars($siteName) ?> Login</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
@@ -81,18 +97,18 @@ $needsToken = isset($_SESSION['pending_user_id']);
         h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
         a { transition: color 0.2s ease; }
-        a:hover { color: #4f46e5; }
+        a:hover { color: <?= $hoverHex ?>; }
         button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
         button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
     </style>
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gray-50">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow">
-        <img src="favicon.svg" alt="Finance Manager logo" class="h-24 w-24 mb-4 block mx-auto" />
-        <div class="uppercase text-indigo-900 text-[0.6rem] mb-1 text-center">AUTHENTICATION / <?= $needsToken ? 'TWO-FACTOR' : 'LOGIN' ?></div>
-        <h1 class="text-2xl font-semibold mb-4 text-center text-indigo-700"><?= $needsToken ? 'Enter Code' : 'Login' ?></h1>
+        <img src="favicon.svg" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 block mx-auto" />
+        <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1 text-center">AUTHENTICATION / <?= $needsToken ? 'TWO-FACTOR' : 'LOGIN' ?></div>
+        <h1 class="text-2xl font-semibold mb-4 text-center <?= $text700 ?>"><?= $needsToken ? 'Enter Code' : 'Login' ?></h1>
         <p class="mb-4 text-center">
-            <?= $needsToken ? 'Enter the 6-digit code from your authenticator.' : 'Use your account credentials to sign in and access the finance manager. Enter your username and password in the boxes below and press the login button to continue.' ?>
+            <?= $needsToken ? 'Enter the 6-digit code from your authenticator.' : 'Use your account credentials to sign in and access the ' . htmlspecialchars($siteName) . '. Enter your username and password in the boxes below and press the login button to continue.' ?>
         </p>
         <?php if ($error): ?>
             <p class="mb-4 text-red-500 text-center"><?= htmlspecialchars($error) ?></p>
@@ -102,7 +118,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
                 <label class="block">Code:
                     <input type="text" name="token" autocomplete="one-time-code" class="mt-1 w-full border p-2 rounded" data-help="Enter your 6-digit code">
                 </label>
-                <button type="submit" class="w-full bg-indigo-600 text-white py-2 rounded">Verify</button>
+                <button type="submit" class="w-full <?= $bg600 ?> text-white py-2 rounded">Verify</button>
             </form>
         <?php else: ?>
             <form method="post" id="login-form" name="login-form" autocomplete="on" class="space-y-4">
@@ -112,7 +128,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
                 <label class="block">Password:
                     <input type="password" name="password" autocomplete="current-password" class="mt-1 w-full border p-2 rounded" data-help="Enter your password">
                 </label>
-                <button type="submit" class="w-full bg-indigo-600 text-white py-2 rounded">Login</button>
+                <button type="submit" class="w-full <?= $bg600 ?> text-white py-2 rounded">Login</button>
             </form>
         <?php endif; ?>
     </div>

--- a/logout.php
+++ b/logout.php
@@ -4,6 +4,7 @@ ini_set('session.cookie_secure', '1');
 session_start();
 require_once __DIR__ . '/php_backend/nocache.php';
 require_once __DIR__ . '/php_backend/models/Log.php';
+require_once __DIR__ . '/php_backend/models/Setting.php';
 
 if (isset($_SESSION['user_id'])) {
     $reason = isset($_GET['timeout']) ? ' (timeout)' : '';
@@ -16,6 +17,19 @@ if (isset($_GET['timeout'])) {
     header('Location: index.php');
     exit;
 }
+$brand = Setting::getBrand();
+$siteName = $brand['site_name'];
+$colorScheme = $brand['color_scheme'];
+$colorMap = [
+    'indigo' => ['600' => '#4f46e5', '700' => '#4338ca'],
+    'blue'   => ['600' => '#2563eb', '700' => '#1d4ed8'],
+    'green'  => ['600' => '#059669', '700' => '#047857'],
+    'red'    => ['600' => '#dc2626', '700' => '#b91c1c'],
+    'purple' => ['600' => '#9333ea', '700' => '#7e22ce'],
+];
+$text700 = "text-{$colorScheme}-700";
+$bg600 = "bg-{$colorScheme}-600";
+$hoverHex = $colorMap[$colorScheme]['600'] ?? '#4f46e5';
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -34,17 +48,17 @@ if (isset($_GET['timeout'])) {
         h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
         a { transition: color 0.2s ease; }
-        a:hover { color: #4f46e5; }
+        a:hover { color: <?= $hoverHex ?>; }
         button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
         button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
     </style>
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gray-50">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow text-center">
-        <img src="favicon.svg" alt="Finance Manager logo" class="h-24 w-24 mb-4 mx-auto" />
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Logged Out</h1>
-        <p class="mb-4">You have been safely logged out of the finance manager.</p>
-        <a href="index.php" class="bg-indigo-600 text-white px-4 py-2 rounded">Return to Login</a>
+        <img src="favicon.svg" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 mx-auto" />
+        <h1 class="text-2xl font-semibold mb-4 <?= $text700 ?>">Logged Out</h1>
+        <p class="mb-4">You have been safely logged out of the <?= htmlspecialchars($siteName) ?>.</p>
+        <a href="index.php" class="<?= $bg600 ?> text-white px-4 py-2 rounded">Return to Login</a>
     </div>
     <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>

--- a/php_backend/models/Setting.php
+++ b/php_backend/models/Setting.php
@@ -7,6 +7,8 @@ class Setting {
     private const DEFAULT_HEADING_FONT = 'Roboto';
     private const DEFAULT_BODY_FONT = 'Inter';
     private const DEFAULT_ACCENT_FONT = 'Source Sans Pro';
+    private const DEFAULT_SITE_NAME = 'Finance Manager';
+    private const DEFAULT_COLOR_SCHEME = 'indigo';
 
     /**
      * Retrieve a setting value by name.
@@ -39,6 +41,18 @@ class Setting {
             'heading' => self::get('font_heading') ?? self::DEFAULT_HEADING_FONT,
             'body'    => self::get('font_body') ?? self::DEFAULT_BODY_FONT,
             'accent'  => self::get('font_accent') ?? self::DEFAULT_ACCENT_FONT,
+        ];
+    }
+
+    /**
+     * Retrieve branding settings such as site name and color scheme.
+     *
+     * @return array{site_name: string, color_scheme: string}
+     */
+    public static function getBrand(): array {
+        return [
+            'site_name'    => self::get('site_name') ?? self::DEFAULT_SITE_NAME,
+            'color_scheme' => self::get('color_scheme') ?? self::DEFAULT_COLOR_SCHEME,
         ];
     }
 }

--- a/php_backend/public/font_settings.php
+++ b/php_backend/public/font_settings.php
@@ -2,5 +2,5 @@
 require_once __DIR__ . '/../models/Setting.php';
 header('Content-Type: application/json');
 
-echo json_encode(Setting::getFonts());
+echo json_encode(array_merge(Setting::getFonts(), Setting::getBrand()));
 ?>

--- a/settings.php
+++ b/settings.php
@@ -19,9 +19,20 @@ $fontSettings = Setting::getFonts();
 $fontHeading = $fontSettings['heading'];
 $fontBody = $fontSettings['body'];
 $fontAccent = $fontSettings['accent'];
+$brand = Setting::getBrand();
+$siteName = $brand['site_name'];
+$colorScheme = $brand['color_scheme'];
 $fontOptions = [
     'Roboto', 'Inter', 'Source Sans Pro', 'Montserrat', 'Open Sans', 'Lato',
     'Nunito', 'Poppins', 'Raleway', 'Work Sans', 'Quicksand'
+];
+$colorOptions = ['indigo', 'blue', 'green', 'red', 'purple'];
+$colorMap = [
+    'indigo' => '#4f46e5',
+    'blue'   => '#2563eb',
+    'green'  => '#059669',
+    'red'    => '#dc2626',
+    'purple' => '#9333ea',
 ];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -32,6 +43,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $fontHeading = trim($_POST['font_heading'] ?? '');
     $fontBody = trim($_POST['font_body'] ?? '');
     $fontAccent = trim($_POST['font_accent'] ?? '');
+    $siteName = trim($_POST['site_name'] ?? '');
+    $colorScheme = trim($_POST['color_scheme'] ?? '');
     Setting::set('openai_api_token', $openai);
     Log::write('Updated OpenAI API token');
     if ($batch !== '') {
@@ -58,8 +71,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         Setting::set('font_accent', $fontAccent);
         Log::write('Updated accent font');
     }
+    if ($siteName !== '') {
+        Setting::set('site_name', $siteName);
+        Log::write('Updated site name');
+    }
+    if ($colorScheme !== '') {
+        Setting::set('color_scheme', $colorScheme);
+        Log::write('Updated color scheme');
+    }
     $message = 'Settings updated.';
 }
+
+$colorHex = $colorMap[$colorScheme] ?? '#4f46e5';
+$text600 = "text-{$colorScheme}-600";
+$text700 = "text-{$colorScheme}-700";
+$text900 = "text-{$colorScheme}-900";
+$bg600 = "bg-{$colorScheme}-600";
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -78,18 +105,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
         a { transition: color 0.2s ease; }
-        a:hover { color: #4f46e5; }
+        a:hover { color: <?= $colorHex ?>; }
         button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
         button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
     </style>
 </head>
 <body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
     <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow">
-        <i class="fas fa-cogs text-indigo-600 text-6xl mb-4 block mx-auto"></i>
-        <div class="uppercase text-indigo-900 text-[0.6rem] mb-1">ADMIN TOOLS / SYSTEM SETTINGS</div>
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">System Settings</h1>
+        <i class="fas fa-cogs <?= $text600 ?> text-6xl mb-4 block mx-auto"></i>
+        <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1">ADMIN TOOLS / SYSTEM SETTINGS</div>
+        <h1 class="text-2xl font-semibold mb-4 <?= $text700 ?>">System Settings</h1>
         <p class="mb-4">Adjust application configuration values.</p>
-        <p class="mb-4"><a href="logout.php" class="text-indigo-600 hover:underline">Logout</a> | <a href="frontend/index.html" class="text-indigo-600 hover:underline">Home</a></p>
+        <p class="mb-4"><a href="logout.php" class="<?= $text600 ?> hover:underline">Logout</a> | <a href="frontend/index.html" class="<?= $text600 ?> hover:underline">Home</a></p>
         <?php if ($message): ?>
             <p class="mb-4 text-green-600"><?= htmlspecialchars($message) ?></p>
         <?php endif; ?>
@@ -105,6 +132,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </label>
             <label class="block">Auto-Logout Minutes:
                 <input type="number" name="session_timeout_minutes" value="<?= htmlspecialchars($timeout) ?>" class="border p-2 rounded w-full" data-help="Minutes of inactivity before automatic logout">
+            </label>
+            <label class="block">Site Name:
+                <input type="text" name="site_name" value="<?= htmlspecialchars($siteName) ?>" class="border p-2 rounded w-full" data-help="Displayed name of the website">
+            </label>
+            <label class="block">Color Scheme:
+                <select name="color_scheme" class="border p-2 rounded w-full" data-help="Primary Tailwind color">
+                    <?php foreach ($colorOptions as $opt): ?>
+                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $colorScheme ? 'selected' : '' ?>><?= ucfirst($opt) ?></option>
+                    <?php endforeach; ?>
+                </select>
             </label>
             <label class="block">Heading Font:
                 <select name="font_heading" class="border p-2 rounded w-full" data-help="Font used for headings">
@@ -127,7 +164,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <?php endforeach; ?>
                 </select>
             </label>
-            <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
+            <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
         </form>
     </div>
     <script src="frontend/js/input_help.js"></script>


### PR DESCRIPTION
## Summary
- Add default site name and color scheme settings with helper accessor
- Save and edit site name and theme color in system settings
- Apply configurable branding across login, logout and frontend via updated menu.js

## Testing
- `php -l php_backend/models/Setting.php`
- `php -l php_backend/public/font_settings.php`
- `php -l settings.php`
- `php -l index.php`
- `php -l logout.php`
- `node --check frontend/js/menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9cee7c478832e968b9c4f1e6bc730