### PR TITLE
Fix tag deletion targeting

### DIFF
--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -53,13 +53,13 @@ async function loadTags(){
             { title: 'Keyword', field: 'keyword' },
             { title: 'Description', field: 'description' },
             { title: 'Actions', formatter: function(cell){
-                const t = cell.getRow().getData();
                 const container = document.createElement('div');
                 const edit = document.createElement('button');
                 edit.innerHTML = '<i class="fas fa-edit w-4 h-4"></i>';
                 edit.setAttribute('aria-label','Edit');
                 edit.className = 'bg-indigo-600 text-white px-2 py-1 rounded mr-2';
                 edit.addEventListener('click', async () => {
+                    const t = cell.getRow().getData();
                     const name = prompt('Tag Name', t.name);
                     if (name === null) return;
                     const keyword = prompt('Keyword (for auto tagging)', t.keyword || '');
@@ -80,6 +80,7 @@ async function loadTags(){
                 del.className = 'bg-red-600 text-white px-2 py-1 rounded';
                 del.addEventListener('click', async () => {
                     if (!confirm('Delete this tag?')) return;
+                    const t = cell.getRow().getData();
                     await fetch('../php_backend/public/tags.php', {
                         method: 'DELETE',
                         headers: {'Content-Type':'application/json'},

--- a/tests/TagDeletionTest.php
+++ b/tests/TagDeletionTest.php
@@ -1,0 +1,39 @@
+<?php
+require_once __DIR__ . '/../php_backend/Database.php';
+require_once __DIR__ . '/../php_backend/models/Tag.php';
+
+putenv('DB_DSN=sqlite::memory:');
+$db = Database::getConnection();
+
+function check($condition, $message) {
+    if (!$condition) {
+        throw new Exception($message);
+    }
+}
+
+// minimal schema for tag deletion
+$db->exec('CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, keyword TEXT, description TEXT)');
+$db->exec('CREATE TABLE category_tags (category_id INTEGER, tag_id INTEGER)');
+$db->exec('CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTOINCREMENT, tag_id INTEGER)');
+
+// seed two tags with linked transactions and category assignment
+$db->exec("INSERT INTO tags (name) VALUES ('A'), ('B')");
+$db->exec("INSERT INTO category_tags (category_id, tag_id) VALUES (1,1), (2,2)");
+$db->exec("INSERT INTO transactions (tag_id) VALUES (1), (2), (2)");
+
+// delete second tag
+Tag::delete(2);
+
+$tags = $db->query('SELECT id FROM tags')->fetchAll(PDO::FETCH_COLUMN);
+$tags = array_map('intval', $tags);
+check($tags === [1], 'Only tag 1 should remain');
+
+$txTags = $db->query('SELECT tag_id FROM transactions ORDER BY id')->fetchAll(PDO::FETCH_COLUMN);
+$txTags = array_map(fn($v) => $v === null ? null : (int)$v, $txTags);
+check($txTags === [1, null, null], 'Transactions with deleted tag should be cleared');
+
+$catTags = $db->query('SELECT tag_id FROM category_tags ORDER BY category_id')->fetchAll(PDO::FETCH_COLUMN);
+$catTags = array_map('intval', $catTags);
+check($catTags === [1], 'Category tag link for deleted tag should be removed');
+
+echo "Tag deletion test passed\n";


### PR DESCRIPTION
## Summary
- Ensure Manage Tags actions use current row data so the correct tag is edited or removed
- Add regression test confirming only the specified tag is deleted

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php tests/TagDeletionTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68a9d7c2cf88832ea880b9e56c238e02