### PR TITLE
Move user info to sidebar

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -145,7 +145,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Add responsive classes so the navigation can toggle on small screens
     menu.classList.add(
       'hidden',
-      'md:block',
+      'flex',
+      'flex-col',
       'fixed',
       'top-16',
       'bottom-0',
@@ -160,6 +161,22 @@ document.addEventListener('DOMContentLoaded', () => {
         menu.innerHTML = html;
         applyColorScheme(menu);
         applyIconColor(menu);
+        const userEl = menu.querySelector('#current-user');
+        const iconEl = menu.querySelector('#user-icon');
+        if (userEl) {
+          fetch('../php_backend/public/current_user.php')
+            .then(r => (r.ok ? r.json() : Promise.reject()))
+            .then(u => {
+              userEl.textContent = u.username || 'Guest';
+              if (u.has2fa && iconEl) {
+                iconEl.classList.remove('fa-user');
+                iconEl.classList.add('fa-user-shield');
+              }
+            })
+            .catch(() => {
+              userEl.textContent = 'Guest';
+            });
+        }
         // Enable collapsible sections with animated height transition
         menu.querySelectorAll('.group').forEach(section => {
           const header = section.querySelector('h3');
@@ -269,23 +286,6 @@ document.addEventListener('DOMContentLoaded', () => {
           })
           .catch(() => {
             releaseEl.textContent = 'v?';
-          });
-      }
-
-      const userEl = document.getElementById('current-user');
-      const iconEl = document.getElementById('user-icon');
-      if (userEl) {
-        fetch('../php_backend/public/current_user.php')
-          .then(r => (r.ok ? r.json() : Promise.reject()))
-          .then(u => {
-            userEl.textContent = u.username || 'Guest';
-            if (u.has2fa && iconEl) {
-              iconEl.classList.remove('fa-user');
-              iconEl.classList.add('fa-user-shield');
-            }
-          })
-          .catch(() => {
-            userEl.textContent = 'Guest';
           });
       }
     })

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -79,3 +79,8 @@
     </ul>
   </div>
 </div>
+
+<div id="user-info" class="flex items-center mt-auto pt-4 border-t">
+  <i id="user-icon" class="fas fa-user mr-2"></i>
+  <span id="current-user">&nbsp;</span>
+</div>

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -19,10 +19,6 @@
         <i class="fas fa-file-invoice h-4 w-4 mr-1"></i>
         <span id="latest-statement-text">Latest Statement</span>
       </a>
-      <div id="user-info" class="flex items-center">
-        <i id="user-icon" class="fas fa-user h-4 w-4 mr-1"></i>
-        <span id="current-user">&nbsp;</span>
-      </div>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- Move user icon and name to the bottom of the sidebar with spacing
- Remove user info from top bar and adjust script to load profile details
- Ensure sidebar uses flex layout for bottom placement

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68aab651d96c832ebccad9ad385b8ad5