### PR TITLE
Fix mobile wrapping on monthly statement form

### DIFF
--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -21,14 +21,14 @@
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Statement</h1>
             <p class="mb-4">Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.</p>
             <div class="bg-white p-6 rounded shadow">
-                <form id="statement-form" class="flex items-end space-x-4">
-                    <div>
+                <form id="statement-form" class="flex flex-wrap items-end gap-4">
+                    <div class="w-full sm:w-auto">
                         <label for="year" class="block text-sm font-medium text-gray-700 mb-1">Year</label>
-                        <select id="year" name="year" class="border p-2 rounded w-32" data-help="Select year"></select>
+                        <select id="year" name="year" class="border p-2 rounded w-full sm:w-32" data-help="Select year"></select>
                     </div>
-                    <div>
+                    <div class="w-full sm:w-auto">
                         <label for="month" class="block text-sm font-medium text-gray-700 mb-1">Month</label>
-                        <select id="month" name="month" class="border p-2 rounded w-32" data-help="Select month"></select>
+                        <select id="month" name="month" class="border p-2 rounded w-full sm:w-32" data-help="Select month"></select>
                     </div>
                     <div class="flex items-center space-x-2 mb-1">
                         <input type="checkbox" id="untagged-only" class="h-4 w-4" checked data-help="Show only untagged transactions">


### PR DESCRIPTION
## Summary
- Allow statement form inputs to wrap on small screens
- Make year and month selectors full width on mobile for better responsiveness

## Testing
- `tidy -q -e frontend/monthly_statement.html` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*
- `php -l php_backend/public/recurring_spend.php`


------
https://chatgpt.com/codex/tasks/task_e_68aab8ff5410832e93a544b62dc0d56c