### PR TITLE
Hide topbar name on mobile

### DIFF
--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -4,7 +4,7 @@
     <div class="flex items-center space-x-4">
       <img src="/favicon.svg" alt="Finance Manager logo" class="h-8 w-8" />
       <button id="menu-toggle" class="md:hidden bg-indigo-700 text-white p-2 rounded"><i class="fas fa-bars h-4 w-4"></i></button>
-      <div class="font-bold text-lg flex items-center">
+      <div class="font-bold text-lg hidden md:flex items-center">
         <span id="site-title">Personal Finance Manager</span>
         <span id="release-number" class="ml-2 bg-indigo-700 text-white text-[0.675rem] px-2 py-0.5 rounded">v0.0.0</span>
       </div>
@@ -14,7 +14,7 @@
         <input type="text" name="value" placeholder="Search transactions" class="p-1 rounded text-black" />
         <button type="submit" class="ml-2"><i class="fas fa-search h-4 w-4"></i></button>
       </form>
-      <a id="latest-statement-link" href="monthly_statement.html" class="flex items-center">
+      <a id="latest-statement-link" href="monthly_statement.html" class="hidden md:flex items-center">
 
         <i class="fas fa-file-invoice h-4 w-4 mr-1"></i>
         <span id="latest-statement-text">Latest Statement</span>


### PR DESCRIPTION
## Summary
- hide topbar site title and version on small screens to declutter the mobile navbar
- hide latest statement link on small screens for cleaner mobile layout

## Testing
- `php -l frontend/topbar.html`


------
https://chatgpt.com/codex/tasks/task_e_68aab8a38aa0832e92966a78bd5f90b3