### PR TITLE
Apply segment tree palette across all graphs

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -37,7 +37,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
-    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    const chartColors = Highcharts.getOptions().colors;
     function balanceTooltip(){
         const prev = this.point.index > 0 ? this.series.yData[this.point.index - 1] : null;
         let text = `Date: ${this.category}<br/>Balance: £${Highcharts.numberFormat(this.y, 2)}`;
@@ -73,7 +73,7 @@
                 const dates = data.history.map(h => h.date);
                 const balances = data.history.map(h => parseFloat(h.balance));
                 Highcharts.chart('balance-chart', {
-                    colors: gradientColors,
+                    colors: chartColors,
                     title: { text: 'Balance Over Time' },
                     xAxis: { categories: dates },
                     yAxis: { title: { text: 'Balance (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -34,7 +34,7 @@
     <script src="https://code.highcharts.com/highcharts-more.js"></script>
 
     <script>
-    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    const chartColors = Highcharts.getOptions().colors;
     function waterfallTooltip(){
         const name = this.point.name || this.category;
         const change = this.y;
@@ -102,7 +102,7 @@
             });
 
             Highcharts.chart('accounts-chart', {
-                colors: gradientColors,
+                colors: chartColors,
                 chart: { type: 'waterfall' },
                 title: { text: 'Account Balances' },
                 xAxis: { type: 'category' },

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -49,7 +49,7 @@
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/modules/sunburst.js"></script>
     <script>
-    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    const chartColors = Highcharts.getOptions().colors;
     function columnTooltip(){
         const total = this.series.yData.reduce((sum, v) => sum + v, 0);
         const pct = total ? (this.y / total * 100) : 0;
@@ -113,7 +113,7 @@
     // Draw a column chart summarising totals
     function buildChart(id, title, data){
         Highcharts.chart(id, {
-            colors: gradientColors,
+            colors: chartColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -70,7 +70,7 @@
     <script>
 
     // Retrieve data for the chosen year and draw charts with 3D bars where applicable
-    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    const chartColors = Highcharts.getOptions().colors;
     let segmentTable;
 
     function columnTooltip(){
@@ -191,6 +191,7 @@
             }));
 
             Highcharts.chart('monthly-chart', {
+                colors: chartColors,
                 chart: {
                     type: 'column',
 
@@ -222,6 +223,7 @@
                 }, [])
             }));
             Highcharts.chart('cumulative-chart', {
+                colors: chartColors,
                 chart: {
                     type: 'column',
 
@@ -243,6 +245,7 @@
                 .filter(c => parseFloat(c.total) < 0)
                 .map(c => ({ name: c.name, y: Math.abs(parseFloat(c.total)) }));
             Highcharts.chart('pie-chart', {
+                colors: chartColors,
                 chart: {
 
                     type: 'pie'
@@ -258,7 +261,7 @@
             const outgoingTags = yearly.tags.filter(t => parseFloat(t.total) < 0);
 
             Highcharts.chart('income-tag-chart', {
-                colors: gradientColors,
+                colors: chartColors,
                 chart: {
                     type: 'bar',
                     options3d: { enabled: true, alpha: 0, beta: 0, depth: 50 }
@@ -275,7 +278,7 @@
             });
 
             Highcharts.chart('outgoing-tag-chart', {
-                colors: gradientColors,
+                colors: chartColors,
                 chart: {
                     type: 'bar',
                     options3d: { enabled: true, alpha: 0, beta: 0, depth: 50 }
@@ -292,7 +295,7 @@
             });
 
             Highcharts.chart('scatter-chart', {
-                colors: gradientColors,
+                colors: chartColors,
                 chart: {
 
                     type: 'scatter'
@@ -336,6 +339,7 @@
     function renderSunburst(yearly, categories, chartId, chartTitle){
         const { data, segmentTotals } = buildHierarchy(yearly, categories);
         Highcharts.chart(chartId, {
+            colors: chartColors,
             series: [{
                 type: 'sunburst',
                 data: data,
@@ -363,8 +367,9 @@
 
     function renderHierarchyCharts(data){
         const edges = data.filter(d => d.parent).map(d => [d.parent, d.id]);
-        const nodes = data.map(d => ({ id: d.id, name: d.name }));
+        const nodes = data.map((d, i) => ({ id: d.id, name: d.name, color: chartColors[i % chartColors.length] }));
         Highcharts.chart('network-graph', {
+            colors: chartColors,
             chart: { type: 'networkgraph' },
 
             title: { text: 'Segment / Category Network' },
@@ -376,7 +381,7 @@
             }]
         });
         Highcharts.chart('treegraph-chart', {
-
+            colors: chartColors,
             chart: {
                 spacingBottom: 30,
                 marginRight: 120,
@@ -459,7 +464,7 @@
             ]
         });
         Highcharts.chart('segment-chart', {
-            colors: gradientColors,
+            colors: chartColors,
             chart: { type: 'column' },
             title: { text: 'Segment Totals' },
             xAxis: { categories: segments.map(s => s.name) },

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -42,7 +42,7 @@
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script>
-    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    const chartColors = Highcharts.getOptions().colors;
     function columnTooltip(){
         const total = this.series.yData.reduce((sum, v) => sum + v, 0);
         const pct = total ? (this.y / total * 100) : 0;
@@ -126,7 +126,7 @@
     // Create a column chart for the supplied dataset
     function buildChart(id, title, data){
         Highcharts.chart(id, {
-            colors: gradientColors,
+            colors: chartColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -71,7 +71,7 @@
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/modules/sunburst.js"></script>
     <script>
-    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    const chartColors = Highcharts.getOptions().colors;
     function columnTooltip(){
         const total = this.series.yData.reduce((sum, v) => sum + v, 0);
         const pct = total ? (this.y / total * 100) : 0;
@@ -135,7 +135,7 @@
     // Draw a column chart visualising totals
     function buildChart(id, title, data){
         Highcharts.chart(id, {
-            colors: gradientColors,
+            colors: chartColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -46,7 +46,7 @@
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script>
-    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    const chartColors = Highcharts.getOptions().colors;
     function columnTooltip(){
         const total = this.series.yData.reduce((sum, v) => sum + v, 0);
         const pct = total ? (this.y / total * 100) : 0;
@@ -154,7 +154,7 @@
                     const categories = data.map(tx => tx.date);
                     const amounts = data.map(tx => parseFloat(tx.amount));
                     Highcharts.chart('chart', {
-                        colors: gradientColors,
+                        colors: chartColors,
                         chart: { type: 'column' },
                         title: { text: 'Transaction Amounts' },
                         xAxis: { categories: categories, title: { text: 'Date' } },

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -37,7 +37,7 @@
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/highcharts-3d.js"></script>
     <script>
-    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    const chartColors = Highcharts.getOptions().colors;
     function columnTooltip(){
         const total = this.series.yData.reduce((sum, v) => sum + v, 0);
         const pct = total ? (this.y / total * 100) : 0;
@@ -159,12 +159,12 @@
 
                         const points = values.map((v, i) => ({
                             y: v,
-                            color: gradientColors[i % gradientColors.length]
+                            color: chartColors[i % chartColors.length]
 
                         }));
 
                         Highcharts.chart('results-chart', {
-                            colors: gradientColors,
+                            colors: chartColors,
                             chart: {
                                 type: 'column',
 

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -53,7 +53,7 @@
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/modules/sunburst.js"></script>
     <script>
-    const gradientColors = ['#4B0082', '#40826D', '#50C878', '#AAF0D1'];
+    const chartColors = Highcharts.getOptions().colors;
     function columnTooltip(){
         const total = this.series.yData.reduce((sum, v) => sum + v, 0);
         const pct = total ? (this.y / total * 100) : 0;
@@ -117,7 +117,7 @@
     // Draw a column chart for the provided data set
     function buildChart(id, title, data){
         Highcharts.chart(id, {
-            colors: gradientColors,
+            colors: chartColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },


### PR DESCRIPTION
## Summary
- restore segment tree to original Highcharts colors
- standardize all charts to use the same default palette across the site

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68aabbbdad8c832ead5379d0f13ac105