### PR TITLE
Add branding block to navigation menu

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -159,6 +159,11 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(resp => resp.text())
       .then(html => {
         menu.innerHTML = html;
+        const titleEl = menu.querySelector('#site-title');
+        if (titleEl) titleEl.textContent = siteName;
+        menu.querySelectorAll('img[alt="Finance Manager logo"]').forEach(img => {
+          img.alt = `${siteName} logo`;
+        });
         applyColorScheme(menu);
         applyIconColor(menu);
         const userEl = menu.querySelector('#current-user');
@@ -276,16 +281,20 @@ document.addEventListener('DOMContentLoaded', () => {
           .catch(err => console.error('Latest statement load failed', err));
       }
 
-      const releaseEl = document.getElementById('release-number');
-      if (releaseEl) {
+      const releaseEls = document.querySelectorAll('#release-number');
+      if (releaseEls.length > 0) {
         fetch('../php_backend/public/version.php')
           .then(r => r.json())
           .then(v => {
             const version = v.version || 'unknown';
-            releaseEl.textContent = `v${version}`;
+            releaseEls.forEach(el => {
+              el.textContent = `v${version}`;
+            });
           })
           .catch(() => {
-            releaseEl.textContent = 'v?';
+            releaseEls.forEach(el => {
+              el.textContent = 'v?';
+            });
           });
       }
     })

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -1,5 +1,9 @@
 <!-- Navigation menu shared across pages -->
-<h2 class="text-xl font-semibold text-gray-700 mb-4">Menu</h2>
+<div class="flex items-center space-x-2 mb-4">
+  <img src="/favicon.svg" alt="Finance Manager logo" class="h-8 w-8" />
+  <span id="site-title" class="text-xl font-semibold text-gray-700">Personal Finance Manager</span>
+  <span id="release-number" class="bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded">v0.0.0</span>
+</div>
 <div class="space-y-2">
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Start Here</h3>


### PR DESCRIPTION
## Summary
- Replace plain menu heading with a flex container showing the site logo, title and release number
- Update menu script to populate the branding fields and refresh all release numbers

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aac5760d68832eaa702bc2457d73ef