### PR TITLE
Add branding block to navigation menu

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -159,6 +159,11 @@ document.addEventListener('DOMContentLoaded', () => {
       .then(resp => resp.text())
       .then(html => {
         menu.innerHTML = html;
+        const titleEl = menu.querySelector('#site-title');
+        if (titleEl) titleEl.textContent = siteName;
+        menu.querySelectorAll('img[alt="Finance Manager logo"]').forEach(img => {
+          img.alt = `${siteName} logo`;
+        });
         applyColorScheme(menu);
         applyIconColor(menu);
         const userEl = menu.querySelector('#current-user');
@@ -276,16 +281,20 @@ document.addEventListener('DOMContentLoaded', () => {
           .catch(err => console.error('Latest statement load failed', err));
       }
 
-      const releaseEl = document.getElementById('release-number');
-      if (releaseEl) {
+      const releaseEls = document.querySelectorAll('#release-number');
+      if (releaseEls.length > 0) {
         fetch('../php_backend/public/version.php')
           .then(r => r.json())
           .then(v => {
             const version = v.version || 'unknown';
-            releaseEl.textContent = `v${version}`;
+            releaseEls.forEach(el => {
+              el.textContent = `v${version}`;
+            });
           })
           .catch(() => {
-            releaseEl.textContent = 'v?';
+            releaseEls.forEach(el => {
+              el.textContent = 'v?';
+            });
           });
       }
     })

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -1,5 +1,11 @@
 <!-- Navigation menu shared across pages -->
-<h2 class="text-xl font-semibold text-gray-700 mb-4">Menu</h2>
+<div class="flex items-center mb-4 space-x-2">
+  <img src="/favicon.svg" alt="Finance Manager logo" class="h-8 w-8" />
+  <div class="flex flex-col">
+    <span id="site-title" class="text-xl font-semibold text-gray-700">Personal Finance Manager</span>
+    <span id="release-number" class="bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded mt-1 w-max">v0.0.0</span>
+  </div>
+</div>
 <div class="space-y-2">
   <div class="group">
     <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Start Here</h3>

--- a/frontend/topbar.html
+++ b/frontend/topbar.html
@@ -4,9 +4,9 @@
     <div class="flex items-center space-x-4">
       <img src="/favicon.svg" alt="Finance Manager logo" class="h-8 w-8" />
       <button id="menu-toggle" class="md:hidden bg-indigo-700 text-white p-2 rounded"><i class="fas fa-bars h-4 w-4"></i></button>
-      <div class="font-bold text-lg hidden md:flex items-center">
-        <span id="site-title">Personal Finance Manager</span>
-        <span id="release-number" class="ml-2 bg-indigo-700 text-white text-[0.675rem] px-2 py-0.5 rounded">v0.0.0</span>
+      <div class="hidden md:flex flex-col">
+        <span id="site-title" class="font-bold text-lg">Personal Finance Manager</span>
+        <span id="release-number" class="bg-indigo-700 text-white text-[0.675rem] px-2 py-0.5 rounded mt-1 w-max">v0.0.0</span>
       </div>
     </div>
     <div id="topbar-right" class="flex items-center space-x-4 transition-transform duration-300">


### PR DESCRIPTION
## Summary
- Replace plain menu heading with a flex container showing the site logo and title with the release number stacked beneath
- Update header bar to place the release number under the site title

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aac5760d68832eaa702bc2457d73ef