### PR TITLE
Remove segment table row shading

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -484,8 +484,7 @@
             data: segments,
             layout: 'fitDataStretch',
             rowFormatter: row => {
-                const color = getSegmentColor(row.getData().name);
-                row.getElement().style.backgroundColor = Highcharts.color(color).brighten(0.5).get();
+                row.getElement().style.backgroundColor = '#fff';
             },
             columns: [
                 { title: 'Name', field: 'name', formatter: function(cell){


### PR DESCRIPTION
## Summary
- remove segment-based row shading on graphs page

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68aac958fa44832eaa8a9326c039b1d3