### PR TITLE
Offset mobile content to avoid topbar overlap

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -252,7 +252,7 @@ document.addEventListener('DOMContentLoaded', () => {
     content.classList.add('h-screen', 'overflow-hidden');
     const main = content.querySelector('main');
     if (main) {
-      main.classList.add('h-full', 'overflow-y-auto', 'md:ml-64');
+      main.classList.add('h-full', 'overflow-y-auto', 'md:ml-64', 'pt-16', 'md:pt-0');
     }
   }
 


### PR DESCRIPTION
## Summary
- add mobile-only top padding to main content so fixed menu toggle and search bar no longer cover page top

## Testing
- `node --check frontend/js/menu.js`


------
https://chatgpt.com/codex/tasks/task_e_68aacec87f1c832ebab670f6b1436e30