### PR TITLE
Add hover shadow to top-right search bar

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -268,10 +268,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const utility = document.createElement('div');
   utility.id = 'utility-bar';
-  utility.className = 'fixed top-4 right-4 bg-white rounded-full shadow border border-indigo-600 p-3 flex items-center space-x-4 z-50';
+  utility.className = 'fixed top-4 right-4 bg-white rounded-full border border-indigo-600 p-3 flex items-center space-x-4 z-50 transition-shadow hover:shadow-lg';
   utility.innerHTML = `
     <form id="topbar-search" action="search.html" method="get" class="flex">
-      <input type="text" name="value" placeholder="Search transactions" class="p-1 rounded text-black" />
+      <input type="text" name="value" placeholder="Search transactions" class="p-1 rounded text-black bg-white transition-shadow hover:shadow focus:shadow" />
       <button type="submit" class="ml-2"><i class="fas fa-search h-4 w-4"></i></button>
     </form>
     <a id="latest-statement-link" href="monthly_statement.html" class="hidden md:flex items-center">


### PR DESCRIPTION
## Summary
- Add drop-shadow styling to the top-right search bar so it casts a shadow on hover and focus
- Style the search bar input and container with Tailwind classes

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68aad332d954832ea1c2a0cdcef980e1