### PR TITLE
Add meta refresh redirect for inactivity logout

### DIFF
--- a/frontend/js/auto_logout.js
+++ b/frontend/js/auto_logout.js
@@ -5,9 +5,13 @@ document.addEventListener('DOMContentLoaded', () => {
     .then(data => {
       const minutes = parseInt(data.minutes, 10);
       if (minutes > 0) {
+        const meta = document.createElement('meta');
+        meta.httpEquiv = 'refresh';
+        document.head.appendChild(meta);
         let timer;
         const reset = () => {
           clearTimeout(timer);
+          meta.content = `${minutes * 60};url=../logout.php?timeout=1`;
           timer = setTimeout(() => {
             window.location.href = '../logout.php?timeout=1';
           }, minutes * 60 * 1000);


### PR DESCRIPTION
## Summary
- Add meta refresh tag via auto_logout.js so inactive sessions automatically redirect to login

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68aad3807320832e8593b0afd8c487b1