### PR TITLE
Fix tag badge height in manage categories

### DIFF
--- a/frontend/js/category_drag.js
+++ b/frontend/js/category_drag.js
@@ -120,7 +120,7 @@
 
     const tagWrap = document.createElement('div');
 
-    tagWrap.className = 'flex-1 min-h-[3rem] flex flex-row flex-wrap gap-2';
+    tagWrap.className = 'flex-1 min-h-[3rem] flex flex-row flex-wrap items-start gap-2';
 
     tagWrap.dataset.categoryId = cat.id;
     (cat.tags || []).forEach(t => tagWrap.appendChild(createTagBadge(t)));
@@ -138,7 +138,7 @@
     title.textContent = 'Unassigned Tags';
     card.appendChild(title);
     const tagWrap = document.createElement('div');
-    tagWrap.className = 'min-h-[3rem] flex flex-row flex-wrap gap-2';
+    tagWrap.className = 'min-h-[3rem] flex flex-row flex-wrap items-start gap-2';
     tags.forEach(t => tagWrap.appendChild(createTagBadge(t)));
     card.appendChild(tagWrap);
     addDropHandlers(tagWrap);


### PR DESCRIPTION
## Summary
- Prevent tag badges from stretching vertically on Manage Categories by aligning flex items to the start

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68aad51de0e0832eb5a087827c65b9ad