### PR TITLE
Ensure session timeout redirects to login

### DIFF
--- a/frontend/js/auto_logout.js
+++ b/frontend/js/auto_logout.js
@@ -1,26 +1,30 @@
 // Logs out the user after a period of inactivity based on server settings.
-document.addEventListener('DOMContentLoaded', () => {
-  fetch('../php_backend/public/session_timeout.php')
-    .then(r => (r.ok ? r.json() : Promise.reject()))
-    .then(data => {
-      const minutes = parseInt(data.minutes, 10);
-      if (minutes > 0) {
-        const meta = document.createElement('meta');
-        meta.httpEquiv = 'refresh';
-        document.head.appendChild(meta);
-        let timer;
-        const reset = () => {
-          clearTimeout(timer);
-          meta.content = `${minutes * 60};url=../logout.php?timeout=1`;
-          timer = setTimeout(() => {
-            window.location.href = '../logout.php?timeout=1';
-          }, minutes * 60 * 1000);
-        };
-        ['click', 'mousemove', 'keydown', 'scroll', 'touchstart'].forEach(evt =>
-          document.addEventListener(evt, reset, true)
-        );
-        reset();
-      }
-    })
-    .catch(err => console.error('Session timeout check failed', err));
-});
+fetch('../php_backend/public/session_timeout.php')
+  .then(r => {
+    if (r.status === 401) {
+      window.location.href = '../logout.php?timeout=1';
+      return Promise.reject('Not logged in');
+    }
+    return r.ok ? r.json() : Promise.reject('Session timeout fetch failed');
+  })
+  .then(data => {
+    const minutes = parseInt(data.minutes, 10);
+    if (minutes > 0) {
+      const meta = document.createElement('meta');
+      meta.httpEquiv = 'refresh';
+      document.head.appendChild(meta);
+      let timer;
+      const reset = () => {
+        clearTimeout(timer);
+        meta.content = `${minutes * 60};url=../logout.php?timeout=1`;
+        timer = setTimeout(() => {
+          window.location.href = '../logout.php?timeout=1';
+        }, minutes * 60 * 1000);
+      };
+      ['click', 'mousemove', 'keydown', 'scroll', 'touchstart'].forEach(evt =>
+        document.addEventListener(evt, reset, true)
+      );
+      reset();
+    }
+  })
+  .catch(err => console.error('Session timeout check failed', err));


### PR DESCRIPTION
## Summary
- Initialize auto logout immediately so inactivity timer starts
- Redirect to login if session timeout check fails

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68aae27bb64c832e8739c21ecc2c7fec