### PR TITLE
Add link preview support for external URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository now provides a simple PHP implementation for managing accounts a
 - Search and report on transactions in detail.
 - Back up and restore your data and export it to OFX, CSV, or XLSX.
 - Manage user accounts, processes, and logs.
+- Preview external links with their titles and descriptions.
 
 ## Quick Deployment
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -94,11 +94,22 @@
                     </div>
                 </div>
             </section>
+
+            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg">
+                <h2 class="text-2xl font-semibold mb-4 text-indigo-700"><i class="fas fa-link mr-2"></i>Link Preview</h2>
+                <p class="mb-4">Enter a URL to view its title and description.</p>
+                <div class="flex flex-col space-y-2">
+                    <input id="preview-url" type="text" class="border p-2 rounded" placeholder="https://example.com" data-help="Paste a link to preview.">
+                    <div id="link-preview" class="mt-2"></div>
+                </div>
+            </section>
         </main>
     </div>
 
     <script src="js/menu.js"></script>
     <script src="js/version.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="js/link_preview.js"></script>
     <script src="js/overlay.js"></script>
   </body>
 </html>

--- a/frontend/js/link_preview.js
+++ b/frontend/js/link_preview.js
@@ -1,0 +1,42 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const input = document.getElementById('preview-url');
+    const preview = document.getElementById('link-preview');
+    if (!input || !preview) return;
+    input.addEventListener('change', () => {
+        const url = input.value.trim();
+        if (!url) return;
+        preview.textContent = 'Loading...';
+        fetch('../php_backend/public/link_preview.php?url=' + encodeURIComponent(url))
+            .then(r => r.json())
+            .then(data => {
+                if (data.error) {
+                    preview.textContent = 'No preview available.';
+                    return;
+                }
+                const card = document.createElement('div');
+                card.className = 'flex space-x-4';
+                if (data.image) {
+                    const img = document.createElement('img');
+                    img.src = data.image;
+                    img.alt = '';
+                    img.className = 'w-24 h-24 object-cover rounded';
+                    card.appendChild(img);
+                }
+                const info = document.createElement('div');
+                const title = document.createElement('h3');
+                title.className = 'font-semibold';
+                title.textContent = data.title || url;
+                const desc = document.createElement('p');
+                desc.className = 'text-sm text-gray-600';
+                desc.textContent = data.description || '';
+                info.appendChild(title);
+                info.appendChild(desc);
+                card.appendChild(info);
+                preview.innerHTML = '';
+                preview.appendChild(card);
+            })
+            .catch(() => {
+                preview.textContent = 'No preview available.';
+            });
+    });
+});

--- a/php_backend/public/link_preview.php
+++ b/php_backend/public/link_preview.php
@@ -1,0 +1,45 @@
+<?php
+$sent = headers_sent();
+if (!$sent) {
+    header('Content-Type: application/json');
+}
+$url = $_GET['url'] ?? '';
+if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
+    echo json_encode(['error' => 'Invalid URL']);
+    exit;
+}
+// Fetch the URL content
+$context = stream_context_create([
+    'http' => [
+        'user_agent' => 'Mozilla/5.0'
+    ],
+    'https' => [
+        'user_agent' => 'Mozilla/5.0'
+    ]
+]);
+$html = @file_get_contents($url, false, $context);
+if ($html === false) {
+    echo json_encode(['error' => 'Unable to fetch URL']);
+    exit;
+}
+libxml_use_internal_errors(true);
+$doc = new DOMDocument();
+$doc->loadHTML($html);
+libxml_clear_errors();
+$meta = [];
+foreach ($doc->getElementsByTagName('meta') as $m) {
+    $prop = $m->getAttribute('property');
+    if (!$prop) {
+        $prop = $m->getAttribute('name');
+    }
+    $content = $m->getAttribute('content');
+    if ($prop && $content) {
+        $meta[strtolower($prop)] = $content;
+    }
+}
+$title = $meta['og:title'] ?? ($doc->getElementsByTagName('title')->item(0)->textContent ?? '');
+$desc = $meta['og:description'] ?? ($meta['description'] ?? '');
+$image = $meta['og:image'] ?? '';
+$data = ['title' => $title, 'description' => $desc, 'image' => $image];
+echo json_encode($data);
+

--- a/sample_data/link_preview.html
+++ b/sample_data/link_preview.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Sample Title</title>
+<meta property="og:title" content="OG Sample Title">
+<meta property="og:description" content="OG Sample Description">
+<meta property="og:image" content="https://example.com/image.png">
+<meta name="description" content="Sample Description">
+</head>
+<body>
+<p>Test page</p>
+</body>
+</html>

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -225,6 +225,16 @@ assertEqual(-50.0, (float)$linked[0]['from_amount'], 'Linked from amount stored'
 $candidatesAfter = Transaction::getTransferCandidates();
 assertEqual(0, count($candidatesAfter), 'No candidates after linking');
 
+// --- Link preview test ---
+$sample = 'file://' . realpath(__DIR__ . '/../sample_data/link_preview.html');
+$_GET['url'] = $sample;
+ob_start();
+include __DIR__ . '/../php_backend/public/link_preview.php';
+$previewJson = ob_get_clean();
+$previewData = json_decode($previewJson, true);
+assertEqual('OG Sample Title', $previewData['title'] ?? null, 'Link preview returns og:title');
+assertEqual('OG Sample Description', $previewData['description'] ?? null, 'Link preview returns og:description');
+
 
 // Output results and set exit code
 $failed = false;


### PR DESCRIPTION
## Summary
- add PHP endpoint to extract Open Graph metadata for link previews
- expose a frontend card and script to show link previews on the landing page
- cover link preview service with a new automated test

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68aaf2531114832eb105f496a4708ad4