### PR TITLE
Add archiving functionality for projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS Instructions
 
 - Record any additional project decisions or conventions in this file.
+- Projects support archiving via an `archived` flag and can be restored from the Archived Projects page.
 
 ## Environment
 - Target PHP version: 7.0 and above.

--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -16,6 +16,7 @@ const init = () => {
     'export.html': `Download transactions within a chosen date range. Pick the start and end dates then select a format such as OFX, CSV or XLSX to save the data for use elsewhere.`,
     'budgets.html': `Set monthly spending limits for each category and track how you are doing. Enter a target amount and watch the progress bars show whether you are under or over budget. You can adjust the numbers as your priorities change. Checking this page often helps avoid surprise bills.`,
     'projects.html': `Plan and compare home improvement projects. Record costs, score benefits and see how each project fits your available budget.`,
+    'projects_archived.html': `Browse archived projects and restore any that you wish to revisit.`,
     'categories.html': `Maintain the list of categories and link them to tags so transactions are grouped sensibly. Add new categories when you start tracking a different type of expense and remove ones you no longer use. Keeping this list tidy ensures reports are easy to read and understand.`,
     'dedupe.html': `Review duplicate transactions and remove unwanted copies. Click Refresh to scan for duplicates and use Dedupe All to clear them quickly.`,
     'graphs.html': `Explore interactive charts that analyse your finances from different angles. Switch between graph types or time ranges to highlight trends and unusual activity. Hover over a point to see exact amounts and compare periods. These visuals make it easier to spot patterns than looking at raw numbers.`,

--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -53,6 +53,7 @@
     <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="project_add.html"><i class="fas fa-plus mr-1"></i> Add Project</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="projects.html"><i class="fas fa-screwdriver-wrench mr-1"></i> View Projects</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="projects_archived.html"><i class="fas fa-box-archive mr-1"></i> Archived Projects</a></li>
     </ul>
   </div>
 

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -87,6 +87,16 @@ async function loadProjects(){
                 {title:'Sustainability', field:'benefit_sustainability', hozAlign:'right'},
                 {title:'Funding', field:'funding_source'},
                 {title:'Score', field:'score', hozAlign:'right'},
+                {formatter:()=>'<i class="fas fa-box-archive w-4 h-4"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
+                    const id = cell.getRow().getData().id;
+                    await fetch('../php_backend/public/projects.php',{
+                        method:'PATCH',
+                        headers:{'Content-Type':'application/json'},
+                        body:JSON.stringify({id, archived:1})
+                    });
+                    loadProjects();
+                    showMessage('Project archived');
+                }},
                 {formatter:()=>'<i class="fas fa-trash w-4 h-4"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
                     if(!confirm('Delete this project?')) return;
                     const id = cell.getRow().getData().id;

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<!-- Page for viewing archived home projects -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
+    <title>Archived Projects</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+    <!-- Font Awesome icons loaded via menu.js -->
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
+        button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
+    </style>
+</head>
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<div class="flex min-h-screen">
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
+        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Archived Projects</h1>
+        <p class="mb-4">Review projects that have been archived. Restore any project to make it active again.</p>
+        <section class="bg-white p-6 rounded shadow">
+            <div id="archived-projects-table"></div>
+        </section>
+    </main>
+</div>
+
+<script src="js/menu.js"></script>
+<script src="js/input_help.js"></script>
+<script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
+<script src="js/tabulator-tailwind.js"></script>
+<script>
+let archivedTable;
+async function loadArchived(){
+    const res = await fetch('../php_backend/public/projects.php?archived=1');
+    const data = await res.json();
+    if(archivedTable){
+        archivedTable.setData(data);
+    }else{
+        archivedTable = tailwindTabulator('#archived-projects-table',{
+            data:data,
+            layout:'fitDataStretch',
+            columns:[
+                {title:'Project', field:'name'},
+                {title:'Cost (mid)', field:'cost_medium', formatter:'money', formatterParams:{symbol:'£',precision:2}, hozAlign:'right'},
+                {title:'Spent', field:'spent', formatter:'money', formatterParams:{symbol:'£',precision:2}, hozAlign:'right'},
+                {title:'Score', field:'score', hozAlign:'right'},
+                {formatter:()=>'<i class="fas fa-box-open w-4 h-4"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
+                    const id = cell.getRow().getData().id;
+                    await fetch('../php_backend/public/projects.php',{
+                        method:'PATCH',
+                        headers:{'Content-Type':'application/json'},
+                        body:JSON.stringify({id, archived:0})
+                    });
+                    loadArchived();
+                    showMessage('Project restored');
+                }}
+            ]
+        });
+    }
+}
+loadArchived();
+</script>
+<script src="js/overlay.js"></script>
+<script src="js/page_help.js"></script>
+</body>
+</html>

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -99,6 +99,7 @@ CREATE TABLE IF NOT EXISTS projects (
     weight_sustainability TINYINT DEFAULT 1,
     dependencies TEXT DEFAULT NULL,
     risks TEXT DEFAULT NULL,
+    archived TINYINT DEFAULT 0,
     group_id INT DEFAULT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/php_backend/public/projects.php
+++ b/php_backend/public/projects.php
@@ -9,7 +9,8 @@ $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 
 switch ($method) {
     case 'GET':
-        echo json_encode(Project::all());
+        $archived = isset($_GET['archived']) ? (bool)$_GET['archived'] : false;
+        echo json_encode(Project::all($archived));
         break;
     case 'POST':
         $data = json_decode(file_get_contents('php://input'), true) ?? [];
@@ -23,6 +24,15 @@ switch ($method) {
             echo json_encode(['status' => $ok ? 'ok' : 'error']);
         } else {
             echo json_encode(['status' => 'error', 'error' => 'Missing id']);
+        }
+        break;
+    case 'PATCH':
+        $data = json_decode(file_get_contents('php://input'), true) ?? [];
+        if (isset($data['id']) && isset($data['archived'])) {
+            $ok = Project::setArchived((int)$data['id'], (bool)$data['archived']);
+            echo json_encode(['status' => $ok ? 'ok' : 'error']);
+        } else {
+            echo json_encode(['status' => 'error', 'error' => 'Missing id or archived']);
         }
         break;
     case 'DELETE':


### PR DESCRIPTION
## Summary
- Allow projects to be archived and restored via new archived flag
- Add API and UI to archive projects and view archived items
- Use project descriptions for related transaction group descriptions

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad718c9464832ea69e208580ee5f6f