### PR TITLE
Log SQL responses when saving budgets

### DIFF
--- a/php_backend/models/Budget.php
+++ b/php_backend/models/Budget.php
@@ -6,8 +6,9 @@ require_once __DIR__ . '/Tag.php';
 class Budget {
     /**
      * Create or update a budget for a category for a given month and year.
+     * Returns an array with rowCount and errorInfo for logging.
      */
-    public static function set(int $categoryId, int $month, int $year, float $amount): void {
+    public static function set(int $categoryId, int $month, int $year, float $amount): array {
         $db = Database::getConnection();
         $stmt = $db->prepare('INSERT INTO budgets (category_id, month, year, amount) VALUES (:cid, :month, :year, :amount) '
             . 'ON DUPLICATE KEY UPDATE amount = VALUES(amount)');
@@ -17,6 +18,7 @@ class Budget {
             'year' => $year,
             'amount' => $amount
         ]);
+        return ['rowCount' => $stmt->rowCount(), 'errorInfo' => $stmt->errorInfo()];
     }
 
     /**

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -152,7 +152,8 @@ try {
 
 } catch (Exception $e) {
     http_response_code(500);
-    Log::write('AI budgeting error: ' . $e->getMessage(), 'ERROR');
+    $info = ($e instanceof PDOException && $e->errorInfo) ? json_encode($e->errorInfo) : '';
+    Log::write('AI budgeting error: ' . $e->getMessage() . ($info ? ' SQL: ' . $info : ''), 'ERROR');
     echo json_encode(['error' => 'Server error']);
 }
 ?>

--- a/php_backend/public/budgets.php
+++ b/php_backend/public/budgets.php
@@ -32,12 +32,13 @@ if ($method === 'POST') {
         return;
     }
     try {
-        Budget::set($category, $month, $year, $amount);
-        Log::write("Set budget for category $category to $amount");
+        $res = Budget::set($category, $month, $year, $amount);
+        Log::write("Set budget for category $category to $amount SQL: " . json_encode($res));
         echo json_encode(['status' => 'ok']);
     } catch (Exception $e) {
         http_response_code(500);
-        Log::write('Budget save error: ' . $e->getMessage(), 'ERROR');
+        $info = ($e instanceof PDOException && $e->errorInfo) ? json_encode($e->errorInfo) : '';
+        Log::write('Budget save error: ' . $e->getMessage() . ($info ? ' SQL: ' . $info : ''), 'ERROR');
         echo json_encode(['error' => 'Server error']);
     }
     return;


### PR DESCRIPTION
## Summary
- Log row count and error info from SQL when budgets are saved
- Include SQL error details in logs for AI budgeting

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad866375c8832e98945d3fc9c53ecd