### PR TITLE
Ensure application logging across endpoints

### DIFF
--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -2,6 +2,7 @@
 // Resets and creates all database tables used by the application.
 require_once __DIR__ . '/Database.php';
 require_once __DIR__ . '/models/Transaction.php';
+require_once __DIR__ . '/models/Log.php';
 
 $db = Database::getConnection();
 

--- a/php_backend/public/account_balance.php
+++ b/php_backend/public/account_balance.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Account.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../Database.php';
+require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
 
@@ -40,6 +41,7 @@ try {
     ]);
 } catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['error' => $e->getMessage()]);
+    Log::write('Account balance error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
 }
 ?>

--- a/php_backend/public/account_dashboard.php
+++ b/php_backend/public/account_dashboard.php
@@ -2,6 +2,7 @@
 // API endpoint returning account summaries.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Account.php';
+require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
 
@@ -10,6 +11,7 @@ try {
     echo json_encode($accounts);
 } catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['error' => $e->getMessage()]);
+    Log::write('Account dashboard error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
 }
 ?>

--- a/php_backend/public/account_statement.php
+++ b/php_backend/public/account_statement.php
@@ -2,6 +2,7 @@
 // Returns a list of transactions for a single account.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
 
@@ -14,6 +15,7 @@ try {
     echo json_encode($transactions);
 } catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['error' => $e->getMessage()]);
+    Log::write('Account statement error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
 }
 ?>

--- a/php_backend/public/current_user.php
+++ b/php_backend/public/current_user.php
@@ -2,6 +2,7 @@
 // Returns the username of the currently logged-in user.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
+require_once __DIR__ . '/../models/Log.php';
 ini_set('session.cookie_secure', '1');
 session_start();
 
@@ -17,5 +18,6 @@ if (isset($_SESSION['username'])) {
     echo json_encode(['username' => $username, 'has2fa' => $has2fa]);
 } else {
     http_response_code(401);
+    Log::write('Unauthorized current_user request', 'WARN');
     echo json_encode(['error' => 'Not logged in']);
 }

--- a/php_backend/public/export_data.php
+++ b/php_backend/public/export_data.php
@@ -2,6 +2,7 @@
 // Returns transactions within a date range as JSON for client-side export
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
 
@@ -13,5 +14,6 @@ try {
     echo json_encode($txns);
 } catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['error' => $e->getMessage()]);
+    Log::write('Export data error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
 }

--- a/php_backend/public/export_ofx.php
+++ b/php_backend/public/export_ofx.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/x-ofx');
 $host = $_SERVER['HTTP_HOST'] ?? 'backup';
@@ -79,5 +80,6 @@ try {
     echo "</OFX>\n";
 } catch (Exception $e) {
     http_response_code(500);
-    echo $e->getMessage();
+    Log::write('Export OFX error: ' . $e->getMessage(), 'ERROR');
+    echo 'Error generating OFX';
 }

--- a/php_backend/public/font_settings.php
+++ b/php_backend/public/font_settings.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../models/Setting.php';
+require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');
 
 echo json_encode(array_merge(Setting::getFonts(), Setting::getBrand()));

--- a/php_backend/public/ignored_transactions.php
+++ b/php_backend/public/ignored_transactions.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
 
@@ -21,6 +22,7 @@ try {
     echo json_encode($stmt->fetchAll(PDO::FETCH_ASSOC));
 } catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['error' => $e->getMessage()]);
+    Log::write('Ignored transactions error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
 }
 ?>

--- a/php_backend/public/link_preview.php
+++ b/php_backend/public/link_preview.php
@@ -1,10 +1,12 @@
 <?php
+require_once __DIR__ . '/../models/Log.php';
 $sent = headers_sent();
 if (!$sent) {
     header('Content-Type: application/json');
 }
 $url = $_GET['url'] ?? '';
 if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
+    Log::write('Invalid link preview URL: ' . $url, 'WARN');
     echo json_encode(['error' => 'Invalid URL']);
     exit;
 }
@@ -19,6 +21,7 @@ $context = stream_context_create([
 ]);
 $html = @file_get_contents($url, false, $context);
 if ($html === false) {
+    Log::write('Link preview fetch failed: ' . $url, 'ERROR');
     echo json_encode(['error' => 'Unable to fetch URL']);
     exit;
 }

--- a/php_backend/public/projects.php
+++ b/php_backend/public/projects.php
@@ -2,51 +2,58 @@
 // REST API for managing home projects.
 require_once __DIR__ . '/../models/Project.php';
 require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 
-switch ($method) {
-    case 'GET':
-        $archived = isset($_GET['archived']) ? (bool)$_GET['archived'] : false;
-        echo json_encode(Project::all($archived));
-        break;
-    case 'POST':
-        $data = json_decode(file_get_contents('php://input'), true) ?? [];
-        $id = Project::create($data);
-        echo json_encode(['status' => 'ok', 'id' => $id]);
-        break;
-    case 'PUT':
-        $data = json_decode(file_get_contents('php://input'), true) ?? [];
-        if (isset($data['id'])) {
-            $ok = Project::update((int)$data['id'], $data);
-            echo json_encode(['status' => $ok ? 'ok' : 'error']);
-        } else {
-            echo json_encode(['status' => 'error', 'error' => 'Missing id']);
-        }
-        break;
-    case 'PATCH':
-        $data = json_decode(file_get_contents('php://input'), true) ?? [];
-        if (isset($data['id']) && isset($data['archived'])) {
-            $ok = Project::setArchived((int)$data['id'], (bool)$data['archived']);
-            echo json_encode(['status' => $ok ? 'ok' : 'error']);
-        } else {
-            echo json_encode(['status' => 'error', 'error' => 'Missing id or archived']);
-        }
-        break;
-    case 'DELETE':
-        $data = json_decode(file_get_contents('php://input'), true) ?? [];
-        if (isset($data['id'])) {
-            $ok = Project::delete((int)$data['id']);
-            echo json_encode(['status' => $ok ? 'ok' : 'error']);
-        } else {
-            echo json_encode(['status' => 'error', 'error' => 'Missing id']);
-        }
-        break;
-    default:
-        http_response_code(405);
-        echo json_encode(['status' => 'error', 'error' => 'Method not allowed']);
+try {
+    switch ($method) {
+        case 'GET':
+            $archived = isset($_GET['archived']) ? (bool)$_GET['archived'] : false;
+            echo json_encode(Project::all($archived));
+            break;
+        case 'POST':
+            $data = json_decode(file_get_contents('php://input'), true) ?? [];
+            $id = Project::create($data);
+            echo json_encode(['status' => 'ok', 'id' => $id]);
+            break;
+        case 'PUT':
+            $data = json_decode(file_get_contents('php://input'), true) ?? [];
+            if (isset($data['id'])) {
+                $ok = Project::update((int)$data['id'], $data);
+                echo json_encode(['status' => $ok ? 'ok' : 'error']);
+            } else {
+                echo json_encode(['status' => 'error', 'error' => 'Missing id']);
+            }
+            break;
+        case 'PATCH':
+            $data = json_decode(file_get_contents('php://input'), true) ?? [];
+            if (isset($data['id']) && isset($data['archived'])) {
+                $ok = Project::setArchived((int)$data['id'], (bool)$data['archived']);
+                echo json_encode(['status' => $ok ? 'ok' : 'error']);
+            } else {
+                echo json_encode(['status' => 'error', 'error' => 'Missing id or archived']);
+            }
+            break;
+        case 'DELETE':
+            $data = json_decode(file_get_contents('php://input'), true) ?? [];
+            if (isset($data['id'])) {
+                $ok = Project::delete((int)$data['id']);
+                echo json_encode(['status' => $ok ? 'ok' : 'error']);
+            } else {
+                echo json_encode(['status' => 'error', 'error' => 'Missing id']);
+            }
+            break;
+        default:
+            http_response_code(405);
+            echo json_encode(['status' => 'error', 'error' => 'Method not allowed']);
+    }
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Projects API error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['status' => 'error', 'error' => 'Server error']);
 }
 
 ?>

--- a/php_backend/public/recurring_spend.php
+++ b/php_backend/public/recurring_spend.php
@@ -2,6 +2,7 @@
 // API endpoint to analyse recurring spending over the past year.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
 
@@ -14,6 +15,7 @@ try {
     echo json_encode(['results' => $results, 'total' => $total]);
 } catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['error' => $e->getMessage()]);
+    Log::write('Recurring spend error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
 }
 ?>

--- a/php_backend/public/session_timeout.php
+++ b/php_backend/public/session_timeout.php
@@ -2,11 +2,13 @@
 // Returns inactivity timeout in minutes for the current user.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Setting.php';
+require_once __DIR__ . '/../models/Log.php';
 ini_set('session.cookie_secure', '1');
 session_start();
 header('Content-Type: application/json');
 if (!isset($_SESSION['user_id'])) {
     http_response_code(401);
+    Log::write('Session timeout check without login', 'WARN');
     echo json_encode(['error' => 'Not logged in']);
     exit;
 }

--- a/php_backend/public/transaction.php
+++ b/php_backend/public/transaction.php
@@ -2,6 +2,7 @@
 // API endpoint returning a single transaction's details.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
 
@@ -22,6 +23,7 @@ try {
     }
 } catch (Exception $e) {
     http_response_code(500);
-    echo json_encode(['error' => $e->getMessage()]);
+    Log::write('Transaction fetch error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
 }
 ?>

--- a/php_backend/public/version.php
+++ b/php_backend/public/version.php
@@ -1,6 +1,7 @@
 <?php
 // Outputs the current git commit hash for version display without relying on shell_exec.
 require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');
 $rootDir = dirname(__DIR__, 2);
 $commitHash = '';
@@ -15,6 +16,8 @@ if (is_readable($headPath)) {
     } else {
         $commitHash = $ref;
     }
+} else {
+    Log::write('Version check failed: HEAD not readable', 'ERROR');
 }
 $commitHash = $commitHash ? substr($commitHash, 0, 7) : null;
 echo json_encode(['version' => $commitHash]);

--- a/users.php
+++ b/users.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/php_backend/models/User.php';
 require_once __DIR__ . '/php_backend/nocache.php';
 require_once __DIR__ . '/php_backend/Totp.php';
 require_once __DIR__ . '/php_backend/Database.php';
+require_once __DIR__ . '/php_backend/models/Log.php';
 
 if (!isset($_SESSION['user_id'])) {
     header('Location: index.php');
@@ -33,6 +34,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $message = 'User added.';
             } catch (Exception $e) {
                 $message = 'Error adding user.';
+                Log::write('User add error: ' . $e->getMessage(), 'ERROR');
             }
         } else {
             $message = 'Username and password required.';


### PR DESCRIPTION
## Summary
- require application logger in all public and utility scripts
- log errors and warnings for API endpoints and user management actions
- add catch blocks to handle and report project API failures

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad88850398832e8a9de513498a3eeb