### PR TITLE
Add aria-label tooltips for action icons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - Provide popover help for form inputs using `data-help` attributes handled by `frontend/js/input_help.js`.
 - Ensure the site remains mobile-friendly: include `<meta name="viewport" content="width=device-width, initial-scale=1.0">` on
   every page and use Tailwind's responsive utilities so navigation and layouts work on small screens.
+ - Interactive icons and buttons must include meaningful `aria-label` attributes. A global script copies these to `title` attributes to provide mouse-over explanations.
 
 ## Features
 - Flag transactions recognised as transfers and exclude them from income and expense totals.

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -107,7 +107,7 @@ async function loadBudgets(){
                 {title:'Budget',field:'amount',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
                 {title:'Spent',field:'spent',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
                 {title:'Left',field:'left',formatter:'money',formatterParams:{symbol:'£',precision:2},hozAlign:'right'},
-                {formatter:()=>'<i class="fas fa-trash w-4 h-4"></i>',width:40,hozAlign:'center',cellClick:async(e,cell)=>{
+                {formatter:()=>'<i class="fas fa-trash w-4 h-4" aria-label="Delete"></i>',width:40,hozAlign:'center',cellClick:async(e,cell)=>{
                     if(!confirm('Delete this budget?')) return;
                     const id=cell.getRow().getData().id;
                     await fetch('../php_backend/public/budgets.php',{

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -78,7 +78,7 @@
                         { title: 'Description', field: 'description' },
                         { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
                         { title: 'Count', field: 'count', hozAlign: 'right' },
-                        { title: 'Remove', formatter: function(){ return '<button class="bg-red-600 text-white px-2 py-1 rounded text-sm"><i class="fas fa-trash w-4 h-4"></i></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); dedupe(r.ids); } }
+                        { title: 'Remove', formatter: function(){ return '<button class="bg-red-600 text-white px-2 py-1 rounded text-sm" aria-label="Delete"><i class="fas fa-trash w-4 h-4"></i></button>'; }, width: 90, hozAlign: 'center', cellClick: function(e, cell){ const r = cell.getRow().getData(); dedupe(r.ids); } }
                     ]
                 });
             }

--- a/frontend/js/category_drag.js
+++ b/frontend/js/category_drag.js
@@ -78,6 +78,7 @@
     const editBtn = document.createElement('button');
     editBtn.className = 'text-indigo-600';
     editBtn.innerHTML = '<i class="fas fa-edit"></i>';
+    editBtn.setAttribute('aria-label','Edit');
     editBtn.addEventListener('click', async () => {
       const name = prompt('Category Name', cat.name);
       if (name === null) return;
@@ -98,6 +99,7 @@
     const delBtn = document.createElement('button');
     delBtn.className = 'text-red-600';
     delBtn.innerHTML = '<i class="fas fa-trash"></i>';
+    delBtn.setAttribute('aria-label','Delete');
     delBtn.addEventListener('click', async () => {
       if (!confirm('Delete this category?')) return;
       await fetch('../php_backend/public/categories.php', {

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -65,6 +65,31 @@ document.addEventListener('DOMContentLoaded', () => {
   // Apply 20% opacity to all page elements
   document.documentElement.style.opacity = '0.9';
 
+  // Copy aria-labels to title attributes for tooltips
+  const applyAriaTitles = (root = document) => {
+    root.querySelectorAll('[aria-label]').forEach(el => {
+      if (!el.getAttribute('title')) {
+        el.setAttribute('title', el.getAttribute('aria-label'));
+      }
+    });
+  };
+  applyAriaTitles();
+  const ariaObserver = new MutationObserver(mutations => {
+    for (const m of mutations) {
+      m.addedNodes.forEach(node => {
+        if (node.nodeType === 1) {
+          if (node.hasAttribute && node.hasAttribute('aria-label') && !node.getAttribute('title')) {
+            node.setAttribute('title', node.getAttribute('aria-label'));
+          }
+          if (node.querySelectorAll) {
+            applyAriaTitles(node);
+          }
+        }
+      });
+    }
+  });
+  ariaObserver.observe(document.body, {childList: true, subtree: true});
+
   // Prepare font links
   let fontLink = document.getElementById('app-fonts');
   if (!fontLink) {

--- a/frontend/js/segment_drag.js
+++ b/frontend/js/segment_drag.js
@@ -68,6 +68,7 @@
     const editBtn = document.createElement('button');
     editBtn.className = 'text-indigo-600';
     editBtn.innerHTML = '<i class="fas fa-edit"></i>';
+    editBtn.setAttribute('aria-label','Edit');
     editBtn.addEventListener('click', async () => {
       const name = prompt('Segment Name', seg.name);
       if (name === null) return;
@@ -88,6 +89,7 @@
     const delBtn = document.createElement('button');
     delBtn.className = 'text-red-600';
     delBtn.innerHTML = '<i class="fas fa-trash"></i>';
+    delBtn.setAttribute('aria-label','Delete');
     delBtn.addEventListener('click', async () => {
       if (!confirm('Delete this segment?')) return;
       await fetch('../php_backend/public/segments.php', {

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -74,7 +74,7 @@ async function loadProjects(){
             data:data,
             layout:'fitDataStretch',
             columns:[
-                {formatter:()=>'<i class="fas fa-edit w-4 h-4"></i>', width:40, hozAlign:'center', cellClick:(e,cell)=>{
+                {formatter:()=>'<i class="fas fa-edit w-4 h-4" aria-label="Edit"></i>', width:40, hozAlign:'center', cellClick:(e,cell)=>{
                     const id = cell.getRow().getData().id;
                     window.location.href = `project_add.html?id=${id}`;
                 }},
@@ -87,7 +87,7 @@ async function loadProjects(){
                 {title:'Sustainability', field:'benefit_sustainability', hozAlign:'right'},
                 {title:'Funding', field:'funding_source'},
                 {title:'Score', field:'score', hozAlign:'right'},
-                {formatter:()=>'<i class="fas fa-box-archive w-4 h-4"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
+                {formatter:()=>'<i class="fas fa-box-archive w-4 h-4" aria-label="Archive"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
                     const id = cell.getRow().getData().id;
                     await fetch('../php_backend/public/projects.php',{
                         method:'PATCH',
@@ -97,7 +97,7 @@ async function loadProjects(){
                     loadProjects();
                     showMessage('Project archived');
                 }},
-                {formatter:()=>'<i class="fas fa-trash w-4 h-4"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
+                {formatter:()=>'<i class="fas fa-trash w-4 h-4" aria-label="Delete"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
                     if(!confirm('Delete this project?')) return;
                     const id = cell.getRow().getData().id;
                     await fetch('../php_backend/public/projects.php',{


### PR DESCRIPTION
## Summary
- copy `aria-label` values to `title` attributes site-wide to show helpful tooltips
- add `aria-label` text to edit/archive/delete icons and buttons
- document tooltip convention in AGENTS instructions

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad8bc1cf9c832eaa389bc2977f775e