### PR TITLE
Add Tailwind-styled tooltips for interactive elements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 - Provide popover help for form inputs using `data-help` attributes handled by `frontend/js/input_help.js`.
 - Ensure the site remains mobile-friendly: include `<meta name="viewport" content="width=device-width, initial-scale=1.0">` on
   every page and use Tailwind's responsive utilities so navigation and layouts work on small screens.
- - Interactive icons and buttons must include meaningful `aria-label` attributes. A global script copies these to `title` attributes to provide mouse-over explanations.
+- Interactive icons and buttons must include meaningful `aria-label` attributes. A global script copies these to `data-tooltip` attributes and displays Tailwind-styled tooltips.
 
 ## Features
 - Flag transactions recognised as transfers and exclude them from income and expense totals.

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -65,24 +65,24 @@ document.addEventListener('DOMContentLoaded', () => {
   // Apply 20% opacity to all page elements
   document.documentElement.style.opacity = '0.9';
 
-  // Copy aria-labels to title attributes for tooltips
-  const applyAriaTitles = (root = document) => {
+  // Copy aria-labels to data-tooltip attributes for custom tooltips
+  const applyAriaTooltips = (root = document) => {
     root.querySelectorAll('[aria-label]').forEach(el => {
-      if (!el.getAttribute('title')) {
-        el.setAttribute('title', el.getAttribute('aria-label'));
+      if (!el.getAttribute('data-tooltip')) {
+        el.setAttribute('data-tooltip', el.getAttribute('aria-label'));
       }
     });
   };
-  applyAriaTitles();
+  applyAriaTooltips();
   const ariaObserver = new MutationObserver(mutations => {
     for (const m of mutations) {
       m.addedNodes.forEach(node => {
         if (node.nodeType === 1) {
-          if (node.hasAttribute && node.hasAttribute('aria-label') && !node.getAttribute('title')) {
-            node.setAttribute('title', node.getAttribute('aria-label'));
+          if (node.hasAttribute && node.hasAttribute('aria-label') && !node.getAttribute('data-tooltip')) {
+            node.setAttribute('data-tooltip', node.getAttribute('aria-label'));
           }
           if (node.querySelectorAll) {
-            applyAriaTitles(node);
+            applyAriaTooltips(node);
           }
         }
       });
@@ -356,4 +356,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const logoutScript = document.createElement('script');
   logoutScript.src = 'js/auto_logout.js';
   document.body.appendChild(logoutScript);
+
+  const tooltipScript = document.createElement('script');
+  tooltipScript.src = 'js/tooltips.js';
+  document.body.appendChild(tooltipScript);
 });

--- a/frontend/js/tooltips.js
+++ b/frontend/js/tooltips.js
@@ -1,0 +1,45 @@
+(() => {
+  const tooltip = document.createElement('div');
+  tooltip.className = 'absolute hidden z-50 bg-gray-800 text-white text-xs rounded py-1 px-2 pointer-events-none shadow-lg';
+  document.body.appendChild(tooltip);
+
+  const showTooltip = (e) => {
+    const text = e.currentTarget.getAttribute('data-tooltip');
+    if (!text) return;
+    tooltip.textContent = text;
+    tooltip.classList.remove('hidden');
+    const rect = e.currentTarget.getBoundingClientRect();
+    const top = rect.bottom + window.scrollY + 4;
+    const left = rect.left + window.scrollX + rect.width / 2;
+    tooltip.style.top = `${top}px`;
+    tooltip.style.left = `${left}px`;
+    tooltip.style.transform = 'translateX(-50%)';
+  };
+
+  const hideTooltip = () => {
+    tooltip.classList.add('hidden');
+  };
+
+  const attach = (el) => {
+    el.addEventListener('mouseenter', showTooltip);
+    el.addEventListener('focus', showTooltip);
+    el.addEventListener('mouseleave', hideTooltip);
+    el.addEventListener('blur', hideTooltip);
+  };
+
+  document.querySelectorAll('[data-tooltip]').forEach(attach);
+
+  const observer = new MutationObserver(mutations => {
+    mutations.forEach(m => {
+      m.addedNodes.forEach(node => {
+        if (node.nodeType === 1) {
+          if (node.matches && node.matches('[data-tooltip]')) attach(node);
+          if (node.querySelectorAll) {
+            node.querySelectorAll('[data-tooltip]').forEach(attach);
+          }
+        }
+      });
+    });
+  });
+  observer.observe(document.body, {childList: true, subtree: true});
+})();


### PR DESCRIPTION
## Summary
- replace title attributes with data-tooltip hooks and load global tooltip script
- introduce Tailwind-styled tooltip helper for consistent hover hints
- document new tooltip behaviour in AGENTS guidelines

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68ad8e6e8824832e9be166d3cf5fd41d