### PR TITLE
Double projects bubble chart height

### DIFF
--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -37,7 +37,7 @@
             </div>
             <div>
                 <h2 class="text-xl font-semibold mb-4">Cost vs Quality</h2>
-                <div id="project-bubble-chart" class="h-64"></div>
+                <div id="project-bubble-chart" style="height:800px"></div>
             </div>
             <div>
                 <h2 class="text-xl font-semibold mb-4">Project Priorities</h2>
@@ -66,7 +66,7 @@ function drawBubble(data){
 
     }));
     Highcharts.chart('project-bubble-chart', {
-        chart: { type: 'bubble', plotBorderWidth: 1, zoomType: 'xy' },
+        chart: { type: 'bubble', plotBorderWidth: 1, zoomType: 'xy', height: 800 },
         title: { text: 'Cost vs Quality' },
         xAxis: {
             title: { text: 'Cost (£)' },


### PR DESCRIPTION
## Summary
- Double the height of the Cost vs Quality bubble chart on the Projects page for better visibility

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1c026fde8832eb14159326f6d584a