### PR TITLE
Include projects in backups

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - Automatically tag transactions and suggest budgets using AI.
 - Analyse recurring expenses and break down spending by segments and categories.
 - Support backups, restores, and exporting transactions to OFX, CSV, or XLSX.
+- Backups and restores can include project data.
 - Secure accounts with two-factor authentication and offer detailed search and reporting.
 - Transaction groups include an `active` flag. Inactive groups are hidden from selection and projects set to archived automatically deactivate their associated group.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Back up and restore your data through the web interface. From the navigation
 menu open **Backup & Restore** under *Administration*. User accounts and
 account information are always included in backups. You can additionally choose
 which other parts of the database to download—transactions, categories, tags,
-groups, or budgets. The downloaded file contains gzipped JSON and is named after
+groups, segments, projects, or budgets. The downloaded file contains gzipped JSON and is named after
 your site's hostname, the current date, and the selected sections (for example,
 `example.com-2024-05-15-transactions-categories.json.gz`). To restore a backup,
 choose the compressed file on the same page and click **Restore**; any included

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -29,6 +29,7 @@
                     <label class="block"><input type="checkbox" name="parts" value="tags" class="mr-2">Tags</label>
                     <label class="block"><input type="checkbox" name="parts" value="groups" class="mr-2">Groups</label>
                     <label class="block"><input type="checkbox" name="parts" value="segments" class="mr-2">Segments</label>
+                    <label class="block"><input type="checkbox" name="parts" value="projects" class="mr-2">Projects</label>
                     <label class="block"><input type="checkbox" name="parts" value="budgets" class="mr-2">Budgets</label>
 
                 </div>
@@ -38,7 +39,7 @@
             </section>
             <section class="bg-white p-6 rounded shadow space-y-4">
                 <h2 class="text-xl font-semibold">Restore Backup</h2>
-                <p>Select a gzipped JSON backup file to restore any included transactions, categories, tags, groups, segments, or budgets.</p>
+                <p>Select a gzipped JSON backup file to restore any included transactions, categories, tags, groups, segments, projects, or budgets.</p>
                 <form id="restore-form" action="../php_backend/public/restore.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                     <input type="file" id="backup-file" name="backup_file" accept="application/gzip,application/json" required data-help="Choose a previously downloaded compressed backup file">
                     <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-upload inline w-4 h-4 mr-2"></i>Restore</button>

--- a/frontend/js/backup.js
+++ b/frontend/js/backup.js
@@ -6,7 +6,7 @@ function initBackup() {
     if (dlBtn) {
         dlBtn.addEventListener('click', () => {
             const parts = Array.from(document.querySelectorAll('input[name="parts"]:checked')).map(cb => cb.value);
-            const allParts = ['categories','tags','groups','transactions','budgets','segments'];
+            const allParts = ['categories','tags','groups','transactions','budgets','segments','projects'];
             const selected = parts.length ? parts : allParts;
             const qs = parts.length ? `?parts=${parts.join(',')}` : '';
             fetch(`../php_backend/public/backup.php${qs}`)

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -1,14 +1,15 @@
 <?php
 // Exports selected data as JSON. Allows selecting categories, tags, groups,
-// segments, transactions, and budgets via the `parts` query parameter. User
-// and account information is always included so a full backup can be restored.
+// segments, transactions, budgets, and projects via the `parts` query parameter.
+// User and account information is always included so a full backup can be restored.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Log.php';
 
 // Determine which parts are being backed up so the filename can reflect them
 // Include segments so they can be exported and restored
-$allParts = ['categories','tags','groups','transactions','budgets','segments'];
+// Allow optionally including projects in the backup
+$allParts = ['categories','tags','groups','transactions','budgets','segments','projects'];
 $parts = isset($_GET['parts']) && $_GET['parts'] !== ''
     ? array_intersect($allParts, explode(',', $_GET['parts']))
     : $allParts;
@@ -54,6 +55,9 @@ try {
     }
     if (in_array('budgets', $parts)) {
         $data['budgets'] = $getAll('SELECT category_id, month, year, amount FROM budgets ORDER BY category_id, year, month');
+    }
+    if (in_array('projects', $parts)) {
+        $data['projects'] = $getAll('SELECT id, name, description, rationale, cost_low, cost_medium, cost_high, funding_source, recurring_cost, estimated_time, expected_lifespan, benefit_financial, benefit_quality, benefit_risk, benefit_sustainability, weight_financial, weight_quality, weight_risk, weight_sustainability, dependencies, risks, archived, group_id, created_at FROM projects ORDER BY id');
     }
 
     // Compress the JSON payload

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -1,7 +1,7 @@
 <?php
 
 // Restores users, accounts, segments, categories, tags, groups,
-// transactions, and budgets from an uploaded gzipped JSON backup.
+// transactions, budgets, and projects from an uploaded gzipped JSON backup.
 
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
@@ -83,6 +83,7 @@ try {
     if (isset($data['categories'])) $db->exec('TRUNCATE TABLE categories');
     if (isset($data['segments'])) $db->exec('TRUNCATE TABLE segments');
     if (isset($data['groups'])) $db->exec('TRUNCATE TABLE transaction_groups');
+    if (isset($data['projects'])) $db->exec('TRUNCATE TABLE projects');
     if (isset($data['budgets'])) $db->exec('TRUNCATE TABLE budgets');
     if (isset($data['accounts'])) $db->exec('TRUNCATE TABLE accounts');
     if (isset($data['users'])) $db->exec('TRUNCATE TABLE users');
@@ -151,6 +152,38 @@ try {
                 'name' => $row['name'],
                 'description' => $row['description'] ?? null,
                 'active' => isset($row['active']) ? (int)$row['active'] : 1
+            ]);
+        }
+    }
+
+    if (isset($data['projects'])) {
+        $stmtProj = $db->prepare('INSERT INTO projects (id, name, description, rationale, cost_low, cost_medium, cost_high, funding_source, recurring_cost, estimated_time, expected_lifespan, benefit_financial, benefit_quality, benefit_risk, benefit_sustainability, weight_financial, weight_quality, weight_risk, weight_sustainability, dependencies, risks, archived, group_id, created_at) VALUES (:id, :name, :description, :rationale, :cost_low, :cost_medium, :cost_high, :funding_source, :recurring_cost, :estimated_time, :expected_lifespan, :benefit_financial, :benefit_quality, :benefit_risk, :benefit_sustainability, :weight_financial, :weight_quality, :weight_risk, :weight_sustainability, :dependencies, :risks, :archived, :group_id, :created_at)');
+        foreach ($data['projects'] as $row) {
+            $stmtProj->execute([
+                'id' => $row['id'],
+                'name' => $row['name'],
+                'description' => $row['description'] ?? null,
+                'rationale' => $row['rationale'] ?? null,
+                'cost_low' => $row['cost_low'] ?? null,
+                'cost_medium' => $row['cost_medium'] ?? null,
+                'cost_high' => $row['cost_high'] ?? null,
+                'funding_source' => $row['funding_source'] ?? null,
+                'recurring_cost' => $row['recurring_cost'] ?? null,
+                'estimated_time' => $row['estimated_time'] ?? null,
+                'expected_lifespan' => $row['expected_lifespan'] ?? null,
+                'benefit_financial' => $row['benefit_financial'] ?? null,
+                'benefit_quality' => $row['benefit_quality'] ?? null,
+                'benefit_risk' => $row['benefit_risk'] ?? null,
+                'benefit_sustainability' => $row['benefit_sustainability'] ?? null,
+                'weight_financial' => $row['weight_financial'] ?? null,
+                'weight_quality' => $row['weight_quality'] ?? null,
+                'weight_risk' => $row['weight_risk'] ?? null,
+                'weight_sustainability' => $row['weight_sustainability'] ?? null,
+                'dependencies' => $row['dependencies'] ?? null,
+                'risks' => $row['risks'] ?? null,
+                'archived' => $row['archived'] ?? 0,
+                'group_id' => $row['group_id'] ?? null,
+                'created_at' => $row['created_at'] ?? null,
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- allow backups to include projects and restore them
- expose projects as an optional part on the backup page
- document project backups

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1c96756c8832eb7ad83fb4698815e