### PR TITLE
Expand graph containers to viewport height

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -36,22 +36,22 @@
                 </nav>
             </div>
 
-            <div id="income-sunburst" class="tab-content bg-white p-6 rounded shadow"><div id="income-sunburst-chart" style="height:600px" data-chart-desc="Sunburst chart of income by segment, category and tag."></div></div>
-            <div id="outgoing-sunburst" class="tab-content bg-white p-6 rounded shadow hidden"><div id="outgoing-sunburst-chart" style="height:600px" data-chart-desc="Sunburst chart of outgoings by segment, category and tag."></div></div>
-            <div id="monthly-chart-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="monthly-chart" style="height:400px" data-chart-desc="Column chart of monthly spending totals."></div></div>
-            <div id="cumulative-chart-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="cumulative-chart" style="height:400px" data-chart-desc="Line chart of cumulative spending through the year."></div></div>
-            <div id="pie-chart-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="pie-chart" style="height:400px" data-chart-desc="Pie chart of spending by category."></div></div>
-            <div id="income-tag-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="income-tag-chart" style="height:400px" data-chart-desc="Column chart of income totals by tag."></div></div>
-            <div id="outgoing-tag-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="outgoing-tag-chart" style="height:400px" data-chart-desc="Column chart of outgoing totals by tag."></div></div>
-            <div id="scatter-chart-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="scatter-chart" style="height:400px" data-chart-desc="Scatter chart comparing income and expenses."></div></div>
-            <div id="network-graph-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="network-graph" style="height:600px" data-chart-desc="Network graph linking segments and categories."></div></div>
+            <div id="income-sunburst" class="tab-content bg-white p-6 rounded shadow"><div id="income-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of income by segment, category and tag."></div></div>
+            <div id="outgoing-sunburst" class="tab-content bg-white p-6 rounded shadow hidden"><div id="outgoing-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of outgoings by segment, category and tag."></div></div>
+            <div id="monthly-chart-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="monthly-chart" class="h-[80vh]" data-chart-desc="Column chart of monthly spending totals."></div></div>
+            <div id="cumulative-chart-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="cumulative-chart" class="h-[80vh]" data-chart-desc="Line chart of cumulative spending through the year."></div></div>
+            <div id="pie-chart-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="pie-chart" class="h-[80vh]" data-chart-desc="Pie chart of spending by category."></div></div>
+            <div id="income-tag-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="income-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of income totals by tag."></div></div>
+            <div id="outgoing-tag-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="outgoing-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of outgoing totals by tag."></div></div>
+            <div id="scatter-chart-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="scatter-chart" class="h-[80vh]" data-chart-desc="Scatter chart comparing income and expenses."></div></div>
+            <div id="network-graph-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="network-graph" class="h-[80vh]" data-chart-desc="Network graph linking segments and categories."></div></div>
 
-            <div id="treegraph-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="treegraph-chart" style="height:1200px" data-chart-desc="Tree graph of segments and categories."></div></div>
+            <div id="treegraph-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="treegraph-chart" class="h-[80vh]" data-chart-desc="Tree graph of segments and categories."></div></div>
 
             <div id="segment-section" class="tab-content bg-white p-6 rounded shadow hidden space-y-4">
                 <h2 class="text-xl font-semibold">Segment Totals</h2>
                 <div id="segment-table"></div>
-                <div id="segment-chart" style="height:400px" data-chart-desc="Column chart of segment totals."></div>
+                <div id="segment-chart" class="h-[80vh]" data-chart-desc="Column chart of segment totals."></div>
             </div>
         </main>
     </div>


### PR DESCRIPTION
## Summary
- Replace fixed pixel heights with responsive viewport-based classes so graphs occupy most of the browser window

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1d15b9a20832ebe5afbfe1833d200