### PR TITLE
Fix sunburst chart layout with legends

### DIFF
--- a/frontend/js/color_map.js
+++ b/frontend/js/color_map.js
@@ -33,9 +33,13 @@ window.getCategoryColor = getCategoryColor;
 
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('[data-chart-desc]').forEach(el => {
+        const wrapper = document.createElement('div');
+        el.parentNode.insertBefore(wrapper, el);
+        wrapper.appendChild(el);
+
         const p = document.createElement('p');
         p.className = 'text-xs text-gray-600 mt-2';
         p.textContent = el.dataset.chartDesc;
-        el.insertAdjacentElement('afterend', p);
+        wrapper.appendChild(p);
     });
 });


### PR DESCRIPTION
## Summary
- wrap charts with description so sunburst charts remain side by side when legends are shown

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1d1c1d214832ea953d18d05e50aa5