### PR TITLE
Add mermaid diagrams to README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,6 @@
 
 ## Commit Guidelines
 - There is no specific commit message format; write concise, descriptive messages.
+
+## Documentation
+- README includes Mermaid diagrams to illustrate application architecture and request flow.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,34 @@
 
 This repository now provides a simple PHP implementation for managing accounts and transactions.
 
+## How It Works
+
+### Architecture
+```mermaid
+graph LR
+    U[User] -->|Interacts| F[Frontend]
+    F -->|Sends requests| P[PHP Backend]
+    P -->|Reads/Writes| D[(Database)]
+    P -->|Returns JSON| F
+    F -->|Updates UI| U
+```
+
+### Request Flow
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant F as Frontend
+    participant P as PHP Backend
+    participant D as Database
+
+    U->>F: Uploads OFX / Requests Data
+    F->>P: Sends request
+    P->>D: Query / Update
+    D-->>P: Results
+    P-->>F: Response
+    F-->>U: Rendered interface
+```
+
 ## Capabilities
 
 - Upload OFX files to import bank statements.


### PR DESCRIPTION
## Summary
- Illustrate architecture and request flow in README with Mermaid diagrams
- Note use of Mermaid diagrams in project documentation guidelines

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b409e469fc832e946332625ec65416