### PR TITLE
Ensure group edits trigger backend updates

### DIFF
--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -44,14 +44,14 @@ async function loadGroups() {
         groupTable.setData(groups);
         return;
     }
-    groupTable = tailwindTabulator('#group-table', {
-        data: groups,
-        layout: 'fitDataStretch',
-        columns: [
-            { title: 'Name', field: 'name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
-            { title: 'Description', field: 'description', editor: 'input' },
-            { title: 'Active', field: 'active', formatter: 'tickCross', editor: true },
-            { title: 'Actions', formatter: function(cell){
+        groupTable = tailwindTabulator('#group-table', {
+            data: groups,
+            layout: 'fitDataStretch',
+            columns: [
+                { title: 'Name', field: 'name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
+                { title: 'Description', field: 'description', editor: 'input' },
+                { title: 'Active', field: 'active', formatter: 'tickCross', editor: true },
+                { title: 'Actions', formatter: function(cell){
                 const g = cell.getRow().getData();
                 const container = document.createElement('div');
                 const edit = document.createElement('button');
@@ -89,18 +89,18 @@ async function loadGroups() {
                 container.appendChild(del);
                 return container;
             }}
-        ],
-        cellEdited: async function(cell){
-            const field = cell.getField();
-            if (field !== 'description' && field !== 'active') return;
-            const g = cell.getRow().getData();
-            await fetch('../php_backend/public/groups.php', {
-                method: 'PUT',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({id: g.id, name: g.name, description: g.description, active: g.active})
-            });
-            showMessage('Group updated');
-        }
+        ]
+    });
+    groupTable.on('cellEdited', async function(cell){
+        const field = cell.getField();
+        if (field !== 'description' && field !== 'active') return;
+        const g = cell.getRow().getData();
+        await fetch('../php_backend/public/groups.php', {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({id: g.id, name: g.name, description: g.description, active: g.active})
+        });
+        showMessage('Group updated');
     });
 }
 


### PR DESCRIPTION
## Summary
- Fix Manage Groups table so cell edits send PUT requests to update group data

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5c1dee018832ea0a41a078f19b9b3