### PR TITLE
Remove height limit on segment tree chart

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -46,7 +46,7 @@
             <div id="scatter-chart-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="scatter-chart" class="h-[80vh]" data-chart-desc="Scatter chart comparing income and expenses."></div></div>
             <div id="network-graph-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="network-graph" class="h-[80vh]" data-chart-desc="Network graph linking segments and categories."></div></div>
 
-            <div id="treegraph-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="treegraph-chart" class="h-[80vh]" data-chart-desc="Tree graph of segments and categories."></div></div>
+            <div id="treegraph-container" class="tab-content bg-white p-6 rounded shadow hidden"><div id="treegraph-chart" data-chart-desc="Tree graph of segments and categories."></div></div>
 
             <div id="segment-section" class="tab-content bg-white p-6 rounded shadow hidden space-y-4">
                 <h2 class="text-xl font-semibold">Segment Totals</h2>


### PR DESCRIPTION
## Summary
- Allow segment tree graph container to expand by removing fixed 80vh height

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6bfa83a18832eb2bdec9028218969