### PR TITLE
Fix group active toggle

### DIFF
--- a/php_backend/models/TransactionGroup.php
+++ b/php_backend/models/TransactionGroup.php
@@ -62,6 +62,9 @@ class TransactionGroup {
         $stmt = $db->prepare('SELECT id, name, description, active FROM transaction_groups WHERE id = :id');
         $stmt->execute(['id' => $id]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row) {
+            $row['active'] = (int)$row['active'];
+        }
         return $row ?: null;
     }
 
@@ -71,7 +74,11 @@ class TransactionGroup {
     public static function all(): array {
         $db = Database::getConnection();
         $stmt = $db->query('SELECT id, name, description, active FROM transaction_groups ORDER BY id');
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($rows as &$row) {
+            $row['active'] = (int)$row['active'];
+        }
+        return $rows;
     }
 }
 ?>

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/../php_backend/models/Tag.php';
 require_once __DIR__ . '/../php_backend/models/Category.php';
 require_once __DIR__ . '/../php_backend/models/Transaction.php';
 require_once __DIR__ . '/../php_backend/models/Segment.php';
+require_once __DIR__ . '/../php_backend/models/TransactionGroup.php';
 require_once __DIR__ . '/../php_backend/OfxParser.php';
 
 // Use an in-memory SQLite database for tests.
@@ -148,6 +149,12 @@ $txCat = $db->query('SELECT category_id FROM transactions WHERE id = 1')->fetchC
 assertEqual(null, $txCat, 'Transaction category cleared');
 $budCount = $db->query('SELECT COUNT(*) FROM budgets')->fetchColumn();
 assertEqual(0, (int)$budCount, 'Budgets removed with category');
+
+// --- Group active flag ---
+$groupId = TransactionGroup::create('Temp', 'desc', true);
+TransactionGroup::update($groupId, 'Temp', 'desc', false);
+$groups = TransactionGroup::all();
+assertEqual(0, $groups[0]['active'], 'Group updated to inactive returns 0');
 
 // --- Segment tests ---
 $db->exec('DELETE FROM segments');


### PR DESCRIPTION
## Summary
- Cast group `active` flags to integers when fetching so inactive groups stay disabled
- Add regression test for deactivating a group

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68b6d1bf1dd8832e85114e313519e1ad