### PR TITLE
Use Tailwind utilities instead of custom selectors

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -14,29 +14,23 @@
 
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
     <!-- Icons provided by Font Awesome loaded via menu.js -->
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-
-        h1, h2, h3, h4, h5, h6 { font-family: 'Montserrat', sans-serif; font-weight: 700; }
-
-        button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
-    </style>
+    <!-- Custom fonts handled via Tailwind utility classes -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white" data-api-base="../php_backend/public">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter']" data-api-base="../php_backend/public">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <div class="flex items-center mb-4">
-                <h1 class="text-2xl font-semibold flex-1 text-indigo-700"><i class="fas fa-shield-halved inline w-6 h-6 mr-2"></i>Two-Factor Authentication</h1>
-                <button id="help-btn" class="text-indigo-600 accent"><i class="fas fa-question-circle inline w-5 h-5"></i></button>
+                <h1 class="font-['Montserrat'] text-2xl font-semibold flex-1 text-indigo-700"><i class="fas fa-shield-halved inline w-6 h-6 mr-2"></i>Two-Factor Authentication</h1>
+                <button id="help-btn" class="text-indigo-600 font-['Source_Sans_Pro'] font-light"><i class="fas fa-question-circle inline w-5 h-5"></i></button>
             </div>
             <p class="mb-4">Set up TOTP-based authentication and verify your one-time codes.</p>
 
             <div class="bg-white p-6 rounded shadow mb-6">
-                <h2 class="text-xl mb-4">Setup</h2>
+                <h2 class="font-['Montserrat'] text-xl mb-4">Setup</h2>
                 <form id="generate-form" class="space-y-4">
                     <input id="gen-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">
-                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-qrcode inline w-4 h-4 mr-2"></i>Generate QR</button>
+                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light"><i class="fas fa-qrcode inline w-4 h-4 mr-2"></i>Generate QR</button>
                 </form>
 
                 <div id="qr" class="mt-4 mx-auto"></div>
@@ -44,11 +38,11 @@
             </div>
 
             <div class="bg-white p-6 rounded shadow">
-                <h2 class="text-xl mb-4">Verify</h2>
+                <h2 class="font-['Montserrat'] text-xl mb-4">Verify</h2>
                 <form id="verify-form" class="space-y-4">
                     <input id="ver-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">
                     <input id="token" type="text" placeholder="TOTP Code" class="border p-2 rounded w-full" data-help="Enter the 6-digit code from your authenticator">
-                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-check inline w-4 h-4 mr-2"></i>Verify</button>
+                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light"><i class="fas fa-check inline w-4 h-4 mr-2"></i>Verify</button>
                 </form>
             </div>
         </main>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,20 +15,15 @@
     <meta property="og:description" content="Manage your finances with budgets, reports and more.">
     <meta property="og:image" content="/favicon.svg">
     <!-- Font Awesome icons loaded via menu.js -->
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
-        button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
-    </style>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter']">
     <div class="flex flex-col md:flex-row min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto shadow"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <section class="bg-white p-8 rounded shadow text-center mb-8">
-                <h1 class="text-4xl font-semibold mb-4 text-indigo-700">Welcome to <span id="landing-site-name">Finance Manager</span></h1>
+                <h1 class="font-['Roboto'] text-4xl font-semibold mb-4 text-indigo-700">Welcome to <span id="landing-site-name">Finance Manager</span></h1>
                 <p class="text-gray-700 mb-4">Select an option from the menu to get started exploring your finances. Each section opens tools and dashboards that help you understand where your money goes.</p>
-                <a href="upload.html" class="accent inline-block bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">Get Started</a>
+                <a href="upload.html" class="inline-block bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 font-['Source_Sans_Pro'] font-light">Get Started</a>
                 <p id="version" class="text-gray-500 mt-2">Version: loading...</p>
             </section>
 
@@ -48,7 +43,7 @@
             </section>
 
             <section class="mt-8 bg-white p-8 rounded-lg shadow-lg">
-                <h2 class="text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
+                <h2 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div class="flex items-start space-x-3">
                         <i class="fas fa-file-upload text-indigo-600 fa-2x"></i>

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -14,29 +14,24 @@
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/highcharts-more.js"></script>
     <!-- Font Awesome icons loaded via menu.js -->
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
-        button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
-    </style>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter']">
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Projects</h1>
+        <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">Projects</h1>
         <p class="mb-4">Review your planned projects, explore costs and compare their priorities.</p>
 
         <section class="bg-white p-6 rounded shadow space-y-6">
             <div>
-                <h2 class="text-xl font-semibold mb-4">Budget Planning</h2>
+                <h2 class="font-['Roboto'] text-xl font-semibold mb-4">Budget Planning</h2>
                 <div class="flex items-end space-x-4">
                     <label class="block">Annual Budget (£)<br><input type="number" id="annual-budget" class="border p-2 rounded" data-help="Total funds available"></label>
-                    <button id="apply-budget" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-filter mr-1"></i>Apply Budget</button>
+                    <button id="apply-budget" class="bg-indigo-600 text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light"><i class="fas fa-filter mr-1"></i>Apply Budget</button>
                 </div>
             </div>
             <div>
-                <h2 class="text-xl font-semibold mb-4">Project Comparison</h2>
+                <h2 class="font-['Roboto'] text-xl font-semibold mb-4">Project Comparison</h2>
                 <div class="flex items-end space-x-4 mb-4">
                     <label class="block">X Axis<br>
                         <select id="x-axis" class="border p-2 rounded" data-help="Field used for horizontal axis">
@@ -66,7 +61,7 @@
                 <div id="project-bubble-chart" style="height:800px" data-chart-desc="Bubble chart plotting chosen fields with bubble size representing score."></div>
             </div>
             <div>
-                <h2 class="text-xl font-semibold mb-4">Project Priorities</h2>
+                <h2 class="font-['Roboto'] text-xl font-semibold mb-4">Project Priorities</h2>
                 <div id="projects-table"></div>
             </div>
         </section>

--- a/index.php
+++ b/index.php
@@ -25,8 +25,7 @@ $colorMap = [
 $text600 = "text-{$colorScheme}-600";
 $text700 = "text-{$colorScheme}-700";
 $bg600 = "bg-{$colorScheme}-600";
-$hoverHex = $colorMap[$colorScheme]['600'] ?? '#4f46e5';
-$headerHex = $colorMap[$colorScheme]['700'] ?? '#4338ca';
+$bgHover = "hover:bg-{$colorScheme}-700";
 $error = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -99,21 +98,12 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
-        button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
-        a { transition: color 0.2s ease; }
-        a:hover { color: <?= $hoverHex ?>; }
-        button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
-        button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
-    </style>
 </head>
-<body class="min-h-screen flex items-center justify-center bg-gray-50">
+<body class="min-h-screen flex items-center justify-center bg-gray-50 font-['Inter']">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow">
         <img src="favicon.svg" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 block mx-auto" />
         <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1 text-center">AUTHENTICATION / <?= $needsToken ? 'TWO-FACTOR' : 'LOGIN' ?></div>
-        <h1 class="text-2xl font-semibold mb-4 text-center <?= $text700 ?>"><?= $needsToken ? 'Enter Code' : 'Login' ?></h1>
+        <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 text-center <?= $text700 ?>"><?= $needsToken ? 'Enter Code' : 'Login' ?></h1>
         <p class="mb-4 text-center">
             <?= $needsToken ? 'Enter the 6-digit code from your authenticator.' : 'Use your account credentials to sign in and access the ' . htmlspecialchars($siteName) . '. Enter your username and password in the boxes below and press the login button to continue.' ?>
         </p>
@@ -125,7 +115,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
                 <label class="block">Code:
                     <input type="text" name="token" autocomplete="one-time-code" class="mt-1 w-full border p-2 rounded" data-help="Enter your 6-digit code">
                 </label>
-                <button type="submit" class="w-full <?= $bg600 ?> text-white py-2 rounded">Verify</button>
+                <button type="submit" class="w-full <?= $bg600 ?> <?= $bgHover ?> text-white py-2 rounded font-['Source_Sans_Pro'] font-light transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Verify</button>
             </form>
         <?php else: ?>
             <form method="post" id="login-form" name="login-form" autocomplete="on" class="space-y-4">
@@ -135,7 +125,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
                 <label class="block">Password:
                     <input type="password" name="password" autocomplete="current-password" class="mt-1 w-full border p-2 rounded" data-help="Enter your password">
                 </label>
-                <button type="submit" class="w-full <?= $bg600 ?> text-white py-2 rounded">Login</button>
+                <button type="submit" class="w-full <?= $bg600 ?> <?= $bgHover ?> text-white py-2 rounded font-['Source_Sans_Pro'] font-light transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Login</button>
             </form>
         <?php endif; ?>
     </div>

--- a/logout.php
+++ b/logout.php
@@ -31,7 +31,7 @@ $colorMap = [
 ];
 $text700 = "text-{$colorScheme}-700";
 $bg600 = "bg-{$colorScheme}-600";
-$hoverHex = $colorMap[$colorScheme]['600'] ?? '#4f46e5';
+$bgHover = "hover:bg-{$colorScheme}-700";
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -45,22 +45,13 @@ $hoverHex = $colorMap[$colorScheme]['600'] ?? '#4f46e5';
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
-        button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
-        a { transition: color 0.2s ease; }
-        a:hover { color: <?= $hoverHex ?>; }
-        button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
-        button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
-    </style>
 </head>
-<body class="min-h-screen flex items-center justify-center bg-gray-50">
+<body class="min-h-screen flex items-center justify-center bg-gray-50 font-['Inter']">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow text-center">
         <img src="favicon.svg" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 mx-auto" />
-        <h1 class="text-2xl font-semibold mb-4 <?= $text700 ?>">Logged Out</h1>
+        <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 <?= $text700 ?>">Logged Out</h1>
         <p class="mb-4">You have been safely logged out of the <?= htmlspecialchars($siteName) ?>.</p>
-        <a href="index.php" class="<?= $bg600 ?> text-white px-4 py-2 rounded">Return to Login</a>
+        <a href="index.php" class="<?= $bg600 ?> <?= $bgHover ?> text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Return to Login</a>
     </div>
     <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>


### PR DESCRIPTION
## Summary
- Drop custom style blocks in landing, projects, 2FA, login, and logout pages
- Apply Tailwind font utilities and button transitions instead

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6e8d8806c832e9c200a8f415af5d1