### PR TITLE
Add PDF export and email endpoint for reports

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -30,6 +30,7 @@
                 <div class="md:col-span-3 space-x-2">
                     <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Run Report</button>
                     <button type="button" id="save-report" class="bg-gray-600 text-white px-4 py-2 rounded">Save Report</button>
+                    <button type="button" id="download-pdf" class="bg-green-600 text-white px-4 py-2 rounded" aria-label="Download report as PDF"><i class="fas fa-file-download inline w-4 h-4 mr-1"></i>Download PDF</button>
                 </div>
             </form>
             <div class="mt-4 flex items-center space-x-2">
@@ -46,6 +47,9 @@
     <script src="js/color_map.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.29/dist/jspdf.plugin.autotable.min.js"></script>
     <script>
     function columnTooltip(){
         const total = this.series.yData.reduce((sum, v) => sum + v, 0);
@@ -167,7 +171,7 @@
         if (text) params.append('text', text);
         if (start) params.append('start', start);
         if (end) params.append('end', end);
-        fetch('../php_backend/public/report.php?' + params.toString())
+        return fetch('../php_backend/public/report.php?' + params.toString())
             .then(resp => resp.json())
             .then(data => {
                 const gridEl = document.getElementById('results-grid');
@@ -255,6 +259,24 @@
         localStorage.setItem('reports', JSON.stringify(saved));
         loadSavedReports();
         select.value = '';
+    });
+
+    document.getElementById('download-pdf').addEventListener('click', async function() {
+        await runReport();
+        const gridEl = document.getElementById('results-grid');
+        const canvas = await html2canvas(gridEl);
+        const imgData = canvas.toDataURL('image/png');
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF();
+        const pdfWidth = doc.internal.pageSize.getWidth();
+        const pdfHeight = canvas.height * pdfWidth / canvas.width;
+        doc.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+        const blob = doc.output('blob');
+        doc.save('report.pdf');
+
+        const formData = new FormData();
+        formData.append('report', blob, 'report.pdf');
+        fetch('../php_backend/public/send_pdf.php', { method: 'POST', body: formData });
     });
 
     loadOptions();

--- a/php_backend/public/send_pdf.php
+++ b/php_backend/public/send_pdf.php
@@ -1,0 +1,56 @@
+<?php
+// Receives a PDF report upload and emails it to a configured address.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+try {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST' || !isset($_FILES['report'])) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'No PDF uploaded']);
+        exit;
+    }
+
+    $file = $_FILES['report'];
+    if ($file['error'] !== UPLOAD_ERR_OK) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'message' => 'Upload failed']);
+        exit;
+    }
+
+    $uploadDir = __DIR__ . '/../uploads';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0777, true);
+    }
+    $filename = 'report_' . date('Ymd_His') . '.pdf';
+    $path = $uploadDir . '/' . $filename;
+    move_uploaded_file($file['tmp_name'], $path);
+
+    // Build a basic email with the PDF attached. Adjust address as needed.
+    $to = getenv('REPORT_EMAIL') ?: 'admin@example.com';
+    $subject = 'Transaction Report PDF';
+    $message = 'Attached is the generated report.';
+    $boundary = md5(uniqid());
+    $headers = "MIME-Version: 1.0\r\n";
+    $headers .= "Content-Type: multipart/mixed; boundary=\"$boundary\"\r\n";
+
+    $body = "--$boundary\r\n";
+    $body .= "Content-Type: text/plain; charset=\"UTF-8\"\r\n\r\n";
+    $body .= $message . "\r\n";
+    $body .= "--$boundary\r\n";
+    $body .= "Content-Type: application/pdf; name=\"$filename\"\r\n";
+    $body .= "Content-Transfer-Encoding: base64\r\n";
+    $body .= "Content-Disposition: attachment; filename=\"$filename\"\r\n\r\n";
+    $body .= chunk_split(base64_encode(file_get_contents($path))) . "\r\n";
+    $body .= "--$boundary--";
+
+    @mail($to, $subject, $body, $headers);
+    Log::write("PDF report received: $filename");
+
+    echo json_encode(['status' => 'ok']);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('send_pdf error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['status' => 'error', 'message' => 'Server error']);
+}


### PR DESCRIPTION
## Summary
- Add jsPDF/html2canvas integration and a PDF download button for transaction reports
- Support server-side PDF uploads and email dispatch through new endpoint

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68b80b8f4ef4832eb99a9f42a71f8ede