### PR TITLE
Use timestamped names for PDF reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@
 - Backups and restores can include project data.
 - Secure accounts with two-factor authentication and offer detailed search and reporting.
 - Transaction groups include an `active` flag. Inactive groups are hidden from selection and projects set to archived automatically deactivate their associated group.
+- PDF reports are named using a timestamped `transactions_report_YYYYMMDD_HHMMSS.pdf` format to ensure uniqueness and clarity.
 
 ## Testing
 - Run `php tests/run_tests.php` to execute the test suite.

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -325,10 +325,16 @@
         });
 
         const blob = doc.output('blob');
-        doc.save('report.pdf');
+
+        const now = new Date();
+        const pad = n => String(n).padStart(2, '0');
+        const timestamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+        const filename = `transactions_report_${timestamp}.pdf`;
+
+        doc.save(filename);
 
         const formData = new FormData();
-        formData.append('report', blob, 'report.pdf');
+        formData.append('report', blob, filename);
         fetch('../php_backend/public/send_pdf.php', { method: 'POST', body: formData });
 
     });

--- a/php_backend/public/send_pdf.php
+++ b/php_backend/public/send_pdf.php
@@ -23,7 +23,10 @@ try {
     if (!is_dir($uploadDir)) {
         mkdir($uploadDir, 0777, true);
     }
-    $filename = 'report_' . date('Ymd_His') . '.pdf';
+
+    $uploadedName = isset($file['name']) ? basename($file['name']) : '';
+    $sanitized = preg_replace('/[^A-Za-z0-9_.-]/', '_', $uploadedName);
+    $filename = $sanitized ?: 'report_' . date('Ymd_His') . '.pdf';
     $path = $uploadDir . '/' . $filename;
     move_uploaded_file($file['tmp_name'], $path);
 


### PR DESCRIPTION
## Summary
- Give downloaded transaction reports a timestamped filename and send the same name to the backend.
- Ensure `send_pdf.php` uses the uploaded filename, sanitising it for safe storage and email attachment.
- Document the timestamped PDF naming convention in AGENTS instructions.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b815e1555c832ea181e8d77ad9fc38