### PR TITLE
Tidy report chart styling

### DIFF
--- a/frontend/js/color_map.js
+++ b/frontend/js/color_map.js
@@ -1,8 +1,20 @@
-const chartColors = Highcharts.getOptions().colors;
+const chartColors = [
+    '#4F46E5', // indigo-600
+    '#4338CA', // indigo-700
+    '#3730A3', // indigo-800
+    '#6366F1', // indigo-500
+    '#818CF8', // indigo-400
+    '#A5B4FC', // indigo-300
+    '#C7D2FE', // indigo-200
+    '#E0E7FF'  // indigo-100
+];
 const segmentColorMap = {};
 let nextSegmentIndex = 0;
 
 Highcharts.setOptions({
+    colors: chartColors,
+    chart: { style: { fontFamily: 'Inter, sans-serif' } },
+    credits: { enabled: false },
     legend: { enabled: true, itemStyle: { fontSize: '10px' } },
     plotOptions: {
         series: { showInLegend: true },

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -39,7 +39,7 @@
                 <button type="button" id="delete-report" class="bg-red-600 text-white px-3 py-2 rounded" aria-label="Delete saved report"><i class="fas fa-trash inline w-4 h-4"></i></button>
             </div>
             <div id="results-grid" class="mt-4"></div>
-            <div id="chart" class="mt-6" style="height:400px;" data-chart-desc="Column chart of transaction amounts grouped by your criteria."></div>
+            <div id="chart" class="mt-6 bg-white p-6 rounded shadow" style="height:400px;" data-chart-desc="Column chart of transaction amounts grouped by your criteria."></div>
         </main>
     </div>
     <script src="js/menu.js"></script>
@@ -227,13 +227,13 @@
                     const amounts = grouped.grouped.map(g => parseFloat(g.total));
                     const label = grouped.group.charAt(0).toUpperCase() + grouped.group.slice(1);
                     Highcharts.chart('chart', {
-                        colors: chartColors,
-                        chart: { type: 'column' },
+                        chart: { type: 'column', backgroundColor: 'transparent' },
                         title: { text: 'Transaction Amounts by ' + label },
                         xAxis: { categories: cats, title: { text: label } },
                         yAxis: { title: { text: 'Amount' } },
+                        legend: { enabled: false },
                         tooltip: { pointFormatter: columnTooltip },
-                        series: [{ name: 'Amount', data: amounts, colorByPoint: true }]
+                        series: [{ name: 'Amount', data: amounts, color: chartColors[0] }]
                     });
                 } else {
                     gridEl.innerHTML = 'No transactions found.';


### PR DESCRIPTION
## Summary
- Use site indigo palette for all charts and disable credits
- Render report column chart in a card with single-tone bars

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b82a6889a4832ea6290c570c650a08