### PR TITLE
Add natural language report parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ sequenceDiagram
 - Analyse recurring expenses and break down spending by segments and categories.
 - Secure access with two-factor authentication.
 - Search and report on transactions in detail.
+- Generate reports using natural-language queries.
 - Back up and restore your data and export it to OFX, CSV, or XLSX.
 - Manage user accounts, processes, and logs.
 
 - Share links to the site with rich previews via Open Graph metadata.
+ 
+## Natural-language Reports
 
+The reporting page now accepts plain English queries. Enter phrases such as "costs for cars in the last 12 months" in the Ask in plain English field on `frontend/report.html`. The backend parser translates the query into category, tag, segment and date filters and returns results using the existing report API. Leaving the field empty uses the manual selectors instead.
 
 ## Quick Deployment
 

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -21,6 +21,9 @@
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Reports</h1>
             <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>
             <form id="report-form" class="bg-white p-4 rounded shadow grid grid-cols-1 md:grid-cols-3 gap-4">
+                <label class="block md:col-span-3">Ask in plain English:
+                    <input type="text" id="nl-query" class="border p-2 rounded w-full" placeholder="e.g., costs for cars in the last 12 months" data-help="Describe the report you want in plain English">
+                </label>
                 <label class="block">Category: <select id="category" multiple class="border p-2 rounded w-full" data-help="Filter by category"></select></label>
                 <label class="block">Tag: <select id="tag" multiple class="border p-2 rounded w-full" data-help="Filter by tag"></select></label>
                 <label class="block">Group: <select id="group" multiple class="border p-2 rounded w-full" data-help="Filter by group"></select></label>
@@ -185,22 +188,29 @@
 
     // Execute the report query and render results and chart
     function runReport() {
-        const category = getSelectedValues(window.catChoices);
-        const tag = getSelectedValues(window.tagChoices);
-        const group = getSelectedValues(window.groupChoices);
-        const segment = getSelectedValues(window.segmentChoices);
-        const text = document.getElementById('text').value;
-        const start = document.getElementById('start').value;
-        const end = document.getElementById('end').value;
-        const params = new URLSearchParams();
-        if (category.length) params.append('category', category.join(','));
-        if (tag.length) params.append('tag', tag.join(','));
-        if (group.length) params.append('group', group.join(','));
-        if (segment.length) params.append('segment', segment.join(','));
-        if (text) params.append('text', text);
-        if (start) params.append('start', start);
-        if (end) params.append('end', end);
-        return fetch('../php_backend/public/report.php?' + params.toString())
+        const nl = document.getElementById('nl-query').value.trim();
+        let fetchUrl;
+        if (nl) {
+            fetchUrl = '../php_backend/public/nl_report.php?' + new URLSearchParams({ q: nl }).toString();
+        } else {
+            const category = getSelectedValues(window.catChoices);
+            const tag = getSelectedValues(window.tagChoices);
+            const group = getSelectedValues(window.groupChoices);
+            const segment = getSelectedValues(window.segmentChoices);
+            const text = document.getElementById('text').value;
+            const start = document.getElementById('start').value;
+            const end = document.getElementById('end').value;
+            const params = new URLSearchParams();
+            if (category.length) params.append('category', category.join(','));
+            if (tag.length) params.append('tag', tag.join(','));
+            if (group.length) params.append('group', group.join(','));
+            if (segment.length) params.append('segment', segment.join(','));
+            if (text) params.append('text', text);
+            if (start) params.append('start', start);
+            if (end) params.append('end', end);
+            fetchUrl = '../php_backend/public/report.php?' + params.toString();
+        }
+        return fetch(fetchUrl)
             .then(resp => resp.json())
             .then(data => {
                 const gridEl = document.getElementById('results-grid');

--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -1,0 +1,61 @@
+<?php
+// Parses plain-English report requests into Transaction::filter parameters.
+require_once __DIR__ . '/Database.php';
+
+class NaturalLanguageReportParser {
+    /**
+     * Convert a free-text query into filters for Transaction::filter().
+     * Recognises category, tag, segment, group names and simple date ranges.
+     */
+    public static function parse(string $query): array {
+        $filters = [
+            'category' => null,
+            'tag' => null,
+            'group' => null,
+            'segment' => null,
+            'start' => null,
+            'end' => null,
+            'text' => null,
+        ];
+
+        $q = strtolower($query);
+        $filters['category'] = self::matchName($q, 'categories');
+        $filters['tag'] = self::matchName($q, 'tags');
+        $filters['group'] = self::matchName($q, 'transaction_groups');
+        $filters['segment'] = self::matchName($q, 'segments');
+
+        // Basic date range parsing ("last N months" or "last N years").
+        if (preg_match('/last\s+(\d+)\s+months?/', $q, $m)) {
+            $months = (int)$m[1];
+            $filters['start'] = date('Y-m-d', strtotime("-$months months"));
+            $filters['end'] = date('Y-m-d');
+        } elseif (preg_match('/last\s+(\d+)\s+years?/', $q, $m)) {
+            $years = (int)$m[1];
+            $filters['start'] = date('Y-m-d', strtotime("-$years years"));
+            $filters['end'] = date('Y-m-d');
+        } elseif (strpos($q, 'last year') !== false) {
+            $filters['start'] = date('Y-m-d', strtotime('-1 year'));
+            $filters['end'] = date('Y-m-d');
+        } elseif (strpos($q, 'last month') !== false) {
+            $filters['start'] = date('Y-m-d', strtotime('-1 month'));
+            $filters['end'] = date('Y-m-d');
+        }
+
+        return $filters;
+    }
+
+    /**
+     * Find the id of an entity in a table whose name appears in the query.
+     */
+    private static function matchName(string $query, string $table): ?int {
+        $db = Database::getConnection();
+        $stmt = $db->query("SELECT id, name FROM $table");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            if (stripos($query, strtolower($row['name'])) !== false) {
+                return (int)$row['id'];
+            }
+        }
+        return null;
+    }
+}
+?>

--- a/php_backend/public/nl_report.php
+++ b/php_backend/public/nl_report.php
@@ -1,0 +1,26 @@
+<?php
+// API endpoint that accepts a natural language query and returns filtered transactions.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../NaturalLanguageReportParser.php';
+
+header('Content-Type: application/json');
+
+$q = isset($_GET['q']) ? trim($_GET['q']) : '';
+if ($q === '') {
+    echo json_encode([]);
+    exit;
+}
+
+$filters = NaturalLanguageReportParser::parse($q);
+
+echo json_encode(Transaction::filter(
+    $filters['category'] ?? null,
+    $filters['tag'] ?? null,
+    $filters['group'] ?? null,
+    $filters['segment'] ?? null,
+    $filters['text'] ?? null,
+    $filters['start'] ?? null,
+    $filters['end'] ?? null
+));
+?>

--- a/tests/NaturalLanguageReportParserTest.php
+++ b/tests/NaturalLanguageReportParserTest.php
@@ -1,0 +1,32 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../php_backend/NaturalLanguageReportParser.php';
+require_once __DIR__ . '/../php_backend/Database.php';
+
+class NaturalLanguageReportParserTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv('DB_DSN=sqlite::memory:');
+        $ref = new ReflectionClass(Database::class);
+        $prop = $ref->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null);
+        $db = Database::getConnection();
+        $db->exec('CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);');
+        $db->exec('CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, keyword TEXT, description TEXT);');
+        $db->exec('CREATE TABLE segments (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT);');
+        $db->exec('CREATE TABLE transaction_groups (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, active INTEGER);');
+        $db->exec('INSERT INTO categories (name) VALUES ("cars");');
+    }
+
+    public function testParseCategoryAndDateRange(): void
+    {
+        $filters = NaturalLanguageReportParser::parse('costs for cars in the last 12 months');
+        $this->assertSame(1, $filters['category']);
+        $this->assertSame(date('Y-m-d', strtotime('-12 months')), $filters['start']);
+        $this->assertSame(date('Y-m-d'), $filters['end']);
+    }
+}
+?>

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../php_backend/models/Transaction.php';
 require_once __DIR__ . '/../php_backend/models/Segment.php';
 require_once __DIR__ . '/../php_backend/models/TransactionGroup.php';
 require_once __DIR__ . '/../php_backend/OfxParser.php';
+require_once __DIR__ . '/../php_backend/NaturalLanguageReportParser.php';
 
 // Use an in-memory SQLite database for tests.
 putenv('DB_DSN=sqlite::memory:');
@@ -246,6 +247,15 @@ $previewJson = ob_get_clean();
 $previewData = json_decode($previewJson, true);
 assertEqual('OG Sample Title', $previewData['title'] ?? null, 'Link preview returns og:title');
 assertEqual('OG Sample Description', $previewData['description'] ?? null, 'Link preview returns og:description');
+
+
+// --- Natural language report parser ---
+$db->exec('DELETE FROM categories');
+$db->exec("INSERT INTO categories (name) VALUES ('cars')");
+$carId = (int)$db->lastInsertId();
+$parsed = NaturalLanguageReportParser::parse('costs for cars in the last 12 months');
+assertEqual($carId, $parsed['category'], 'Natural language parser finds category');
+assertEqual(date('Y-m-d', strtotime('-12 months')), $parsed['start'], 'Natural language parser sets start date');
 
 
 // Output results and set exit code


### PR DESCRIPTION
## Summary
- Parse plain English queries into Transaction::filter parameters
- Expose `/php_backend/public/nl_report.php` API for natural-language reports
- Support natural-language reports from the reporting UI
- Document natural-language workflow and add tests

## Testing
- `php tests/run_tests.php`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b82b820140832e9a0ed0802d5aadea