### PR TITLE
Add natural-language report parsing with AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ sequenceDiagram
 - Analyse recurring expenses and break down spending by segments and categories.
 - Secure access with two-factor authentication.
 - Search and report on transactions in detail.
+- Generate reports using natural-language queries.
 - Back up and restore your data and export it to OFX, CSV, or XLSX.
 - Manage user accounts, processes, and logs.
 
 - Share links to the site with rich previews via Open Graph metadata.
+ 
+## Natural-language Reports
 
+The reporting page now accepts plain English queries. Enter phrases such as "costs for cars in the last 12 months" in the Ask in plain English field on `frontend/report.html`. When an OpenAI API token is configured the backend sends the query to the AI service which returns category, tag, segment and date filters that populate the normal selectors before running the report. Without a token a simple rule-based parser is used. Leaving the field empty falls back to manual selection.
 
 ## Quick Deployment
 

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -21,6 +21,9 @@
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Reports</h1>
             <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>
             <form id="report-form" class="bg-white p-4 rounded shadow grid grid-cols-1 md:grid-cols-3 gap-4">
+                <label class="block md:col-span-3">Ask in plain English:
+                    <input type="text" id="nl-query" class="border p-2 rounded w-full" placeholder="e.g., costs for cars in the last 12 months" data-help="Describe the report you want in plain English">
+                </label>
                 <label class="block">Category: <select id="category" multiple class="border p-2 rounded w-full" data-help="Filter by category"></select></label>
                 <label class="block">Tag: <select id="tag" multiple class="border p-2 rounded w-full" data-help="Filter by tag"></select></label>
                 <label class="block">Group: <select id="group" multiple class="border p-2 rounded w-full" data-help="Filter by group"></select></label>
@@ -184,7 +187,21 @@
     }
 
     // Execute the report query and render results and chart
-    function runReport() {
+    async function runReport() {
+        const nl = document.getElementById('nl-query').value.trim();
+        if (nl) {
+            const resp = await fetch('../php_backend/public/nl_report.php?' + new URLSearchParams({ q: nl }).toString());
+            const filters = await resp.json();
+            if (filters.category) window.catChoices.setChoiceByValue(String(filters.category));
+            if (filters.tag) window.tagChoices.setChoiceByValue(String(filters.tag));
+            if (filters.group) window.groupChoices.setChoiceByValue(String(filters.group));
+            if (filters.segment) window.segmentChoices.setChoiceByValue(String(filters.segment));
+            document.getElementById('text').value = filters.text || '';
+            document.getElementById('start').value = filters.start || '';
+            document.getElementById('end').value = filters.end || '';
+            document.getElementById('nl-query').value = '';
+        }
+
         const category = getSelectedValues(window.catChoices);
         const tag = getSelectedValues(window.tagChoices);
         const group = getSelectedValues(window.groupChoices);
@@ -200,45 +217,44 @@
         if (text) params.append('text', text);
         if (start) params.append('start', start);
         if (end) params.append('end', end);
-        return fetch('../php_backend/public/report.php?' + params.toString())
-            .then(resp => resp.json())
-            .then(data => {
-                const gridEl = document.getElementById('results-grid');
-                const chartContainer = document.getElementById('chart');
-                gridEl.innerHTML = '';
-                chartContainer.innerHTML = '';
-                window.reportTable = null;
-                if (Array.isArray(data) && data.length) {
-                    window.reportTable = tailwindTabulator(gridEl, {
-                        data: data,
-                        layout: 'fitDataStretch',
-                        columns: [
-                            { title: 'Date', field: 'date' },
-                            { title: 'Description', field: 'description', bottomCalc: function() { return 'Total'; } },
-                            { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
-                            { title: 'Tag', field: 'tag_name', formatter: badgeFormatter('bg-indigo-200 text-indigo-800') },
-                            { title: 'Group', field: 'group_name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
-                            { title: 'Segment', field: 'segment_name', formatter: badgeFormatter('bg-yellow-200 text-yellow-800') },
-                            { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: function(values) { var total = 0; values.forEach(function(value) { total += parseFloat(value) || 0; }); return total; }, bottomCalcFormatter: 'money', bottomCalcFormatterParams: { symbol: '£', precision: 2 } }
-                        ]
-                    });
-                    const grouped = groupTransactions(data);
-                    const cats = grouped.grouped.map(g => g.label);
-                    const amounts = grouped.grouped.map(g => parseFloat(g.total));
-                    const label = grouped.group.charAt(0).toUpperCase() + grouped.group.slice(1);
-                    Highcharts.chart('chart', {
-                        chart: { type: 'column', backgroundColor: 'transparent' },
-                        title: { text: 'Transaction Amounts by ' + label },
-                        xAxis: { categories: cats, title: { text: label } },
-                        yAxis: { title: { text: 'Amount' } },
-                        legend: { enabled: false },
-                        tooltip: { pointFormatter: columnTooltip },
-                        series: [{ name: 'Amount', data: amounts, color: chartColors[0] }]
-                    });
-                } else {
-                    gridEl.innerHTML = 'No transactions found.';
-                }
+
+        const fetchUrl = '../php_backend/public/report.php?' + params.toString();
+        const data = await fetch(fetchUrl).then(resp => resp.json());
+        const gridEl = document.getElementById('results-grid');
+        const chartContainer = document.getElementById('chart');
+        gridEl.innerHTML = '';
+        chartContainer.innerHTML = '';
+        window.reportTable = null;
+        if (Array.isArray(data) && data.length) {
+            window.reportTable = tailwindTabulator(gridEl, {
+                data: data,
+                layout: 'fitDataStretch',
+                columns: [
+                    { title: 'Date', field: 'date' },
+                    { title: 'Description', field: 'description', bottomCalc: function() { return 'Total'; } },
+                    { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
+                    { title: 'Tag', field: 'tag_name', formatter: badgeFormatter('bg-indigo-200 text-indigo-800') },
+                    { title: 'Group', field: 'group_name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },
+                    { title: 'Segment', field: 'segment_name', formatter: badgeFormatter('bg-yellow-200 text-yellow-800') },
+                    { title: 'Amount', field: 'amount', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right', bottomCalc: function(values) { var total = 0; values.forEach(function(value) { total += parseFloat(value) || 0; }); return total; }, bottomCalcFormatter: 'money', bottomCalcFormatterParams: { symbol: '£', precision: 2 } }
+                ]
             });
+            const grouped = groupTransactions(data);
+            const cats = grouped.grouped.map(g => g.label);
+            const amounts = grouped.grouped.map(g => parseFloat(g.total));
+            const label = grouped.group.charAt(0).toUpperCase() + grouped.group.slice(1);
+            Highcharts.chart('chart', {
+                chart: { type: 'column', backgroundColor: 'transparent' },
+                title: { text: 'Transaction Amounts by ' + label },
+                xAxis: { categories: cats, title: { text: label } },
+                yAxis: { title: { text: 'Amount' } },
+                legend: { enabled: false },
+                tooltip: { pointFormatter: columnTooltip },
+                series: [{ name: 'Amount', data: amounts, color: chartColors[0] }]
+            });
+        } else {
+            gridEl.innerHTML = 'No transactions found.';
+        }
     }
 
     document.getElementById('report-form').addEventListener('submit', function(e) {

--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -1,0 +1,176 @@
+<?php
+// Parses plain-English report requests into Transaction::filter parameters.
+require_once __DIR__ . '/Database.php';
+require_once __DIR__ . '/models/Setting.php';
+
+class NaturalLanguageReportParser {
+    /**
+     * Convert a free-text query into filters for Transaction::filter().
+     * Tries the AI integration when an API token is configured and falls
+     * back to a simple rule-based parser otherwise.
+     */
+    public static function parse(string $query): array {
+        $token = Setting::get('openai_api_token');
+        if ($token) {
+            $ai = self::parseWithAI($query, $token);
+            if ($ai !== null) {
+                return $ai;
+            }
+        }
+        return self::parseFallback($query);
+    }
+
+    /**
+     * Use the OpenAI chat API to interpret the query.
+     * Returns null if the API request fails or the response is invalid.
+     */
+    private static function parseWithAI(string $query, string $token): ?array {
+        $db = Database::getConnection();
+
+        $tables = [
+            'categories' => [],
+            'tags' => [],
+            'segments' => [],
+            'transaction_groups' => [],
+        ];
+        $names = [];
+        foreach ($tables as $table => $_) {
+            $rows = $db->query("SELECT id, name FROM $table")->fetchAll(PDO::FETCH_ASSOC);
+            $map = [];
+            $list = [];
+            foreach ($rows as $r) {
+                $map[strtolower($r['name'])] = (int)$r['id'];
+                $list[] = $r['name'];
+            }
+            $tables[$table] = $map;
+            $names[$table] = $list;
+        }
+
+        $prompt = "Convert the following query into JSON {\"category\",\"tag\",\"segment\",\"group\",\"start\",\"end\",\"text\"}. " .
+            "Use ISO dates and only the names listed.\n\n" .
+            "Categories:\n- " . implode("\n- ", $names['categories']) . "\n\n" .
+            "Tags:\n- " . implode("\n- ", $names['tags']) . "\n\n" .
+            "Segments:\n- " . implode("\n- ", $names['segments']) . "\n\n" .
+            "Groups:\n- " . implode("\n- ", $names['transaction_groups']) . "\n\n" .
+            "Query: $query";
+
+        $payload = [
+            'model' => 'gpt-5-nano',
+            'messages' => [
+                ['role' => 'system', 'content' => 'You convert report requests into JSON filters.'],
+                ['role' => 'user', 'content' => $prompt],
+            ],
+            'temperature' => 0,
+        ];
+
+        $ch = curl_init('https://api.openai.com/v1/chat/completions');
+        curl_setopt_array($ch, [
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'Authorization: Bearer ' . $token,
+            ],
+            CURLOPT_POSTFIELDS => json_encode($payload),
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+        $response = curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($response === false || $code !== 200) {
+            return null;
+        }
+        $data = json_decode($response, true);
+        $content = $data['choices'][0]['message']['content'] ?? '';
+
+        $content = trim($content);
+        if (substr($content, 0, 3) === '```') {
+            $content = preg_replace('/^```(?:json)?\s*/i', '', $content);
+            $content = preg_replace('/```\s*$/', '', $content);
+            $content = trim($content);
+        }
+
+        $parsed = json_decode($content, true);
+        if (!is_array($parsed)) {
+            return null;
+        }
+
+        $filters = [
+            'category' => null,
+            'tag' => null,
+            'group' => null,
+            'segment' => null,
+            'start' => $parsed['start'] ?? null,
+            'end' => $parsed['end'] ?? null,
+            'text' => $parsed['text'] ?? null,
+        ];
+
+        foreach ([
+            'category' => 'categories',
+            'tag' => 'tags',
+            'group' => 'transaction_groups',
+            'segment' => 'segments',
+        ] as $field => $table) {
+            $name = $parsed[$field] ?? null;
+            if ($name) {
+                $id = $tables[$table][strtolower($name)] ?? null;
+                if ($id !== null) {
+                    $filters[$field] = $id;
+                }
+            }
+        }
+
+        return $filters;
+    }
+
+    /**
+     * Simple regex-based fallback parser used when AI is unavailable.
+     */
+    private static function parseFallback(string $query): array {
+        $filters = [
+            'category' => null,
+            'tag' => null,
+            'group' => null,
+            'segment' => null,
+            'start' => null,
+            'end' => null,
+            'text' => null,
+        ];
+
+        $q = strtolower($query);
+        $filters['category'] = self::matchName($q, 'categories');
+        $filters['tag'] = self::matchName($q, 'tags');
+        $filters['group'] = self::matchName($q, 'transaction_groups');
+        $filters['segment'] = self::matchName($q, 'segments');
+
+        if (preg_match('/last\s+(\d+)\s+months?/', $q, $m)) {
+            $months = (int)$m[1];
+            $filters['start'] = date('Y-m-d', strtotime("-$months months"));
+            $filters['end'] = date('Y-m-d');
+        } elseif (preg_match('/last\s+(\d+)\s+years?/', $q, $m)) {
+            $years = (int)$m[1];
+            $filters['start'] = date('Y-m-d', strtotime("-$years years"));
+            $filters['end'] = date('Y-m-d');
+        } elseif (strpos($q, 'last year') !== false) {
+            $filters['start'] = date('Y-m-d', strtotime('-1 year'));
+            $filters['end'] = date('Y-m-d');
+        } elseif (strpos($q, 'last month') !== false) {
+            $filters['start'] = date('Y-m-d', strtotime('-1 month'));
+            $filters['end'] = date('Y-m-d');
+        }
+
+        return $filters;
+    }
+
+    /**
+     * Find the id of an entity in a table whose name appears in the query.
+     */
+    private static function matchName(string $query, string $table): ?int {
+        $db = Database::getConnection();
+        $stmt = $db->query("SELECT id, name FROM $table");
+        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            if (stripos($query, strtolower($row['name'])) !== false) {
+                return (int)$row['id'];
+            }
+        }
+        return null;
+    }
+}
+?>

--- a/php_backend/public/nl_report.php
+++ b/php_backend/public/nl_report.php
@@ -1,0 +1,15 @@
+<?php
+// API endpoint that accepts a natural language query and returns the derived filters.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../NaturalLanguageReportParser.php';
+
+header('Content-Type: application/json');
+
+$q = isset($_GET['q']) ? trim($_GET['q']) : '';
+if ($q === '') {
+    echo json_encode([]);
+    exit;
+}
+
+echo json_encode(NaturalLanguageReportParser::parse($q));
+?>

--- a/tests/NaturalLanguageReportParserTest.php
+++ b/tests/NaturalLanguageReportParserTest.php
@@ -1,0 +1,33 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../php_backend/NaturalLanguageReportParser.php';
+require_once __DIR__ . '/../php_backend/Database.php';
+
+class NaturalLanguageReportParserTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv('DB_DSN=sqlite::memory:');
+        $ref = new ReflectionClass(Database::class);
+        $prop = $ref->getProperty('instance');
+        $prop->setAccessible(true);
+        $prop->setValue(null);
+        $db = Database::getConnection();
+        $db->exec('CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);');
+        $db->exec('CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, keyword TEXT, description TEXT);');
+        $db->exec('CREATE TABLE segments (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT);');
+        $db->exec('CREATE TABLE transaction_groups (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, active INTEGER);');
+        $db->exec('CREATE TABLE settings (name TEXT PRIMARY KEY, value TEXT);');
+        $db->exec('INSERT INTO categories (name) VALUES ("cars");');
+    }
+
+    public function testParseCategoryAndDateRange(): void
+    {
+        $filters = NaturalLanguageReportParser::parse('costs for cars in the last 12 months');
+        $this->assertSame(1, $filters['category']);
+        $this->assertSame(date('Y-m-d', strtotime('-12 months')), $filters['start']);
+        $this->assertSame(date('Y-m-d'), $filters['end']);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- Run natural-language report queries through OpenAI when a token is configured, falling back to rule-based parsing otherwise
- Populate standard report selectors with AI-derived filters before querying transactions
- Document AI-backed natural-language reports

## Testing
- `php tests/run_tests.php`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b82b820140832e9a0ed0802d5aadea