### PR TITLE
Allow AI report parser to select multiple tags

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -194,7 +194,11 @@
             const resp = await fetch('../php_backend/public/nl_report.php?' + new URLSearchParams({ q: nl }).toString());
             const filters = await resp.json();
             if (filters.category) window.catChoices.setChoiceByValue(String(filters.category));
-            if (filters.tag) window.tagChoices.setChoiceByValue(String(filters.tag));
+            if (filters.tag) {
+                window.tagChoices.removeActiveItems();
+                const t = Array.isArray(filters.tag) ? filters.tag : [filters.tag];
+                t.forEach(id => window.tagChoices.setChoiceByValue(String(id)));
+            }
             if (filters.group) window.groupChoices.setChoiceByValue(String(filters.group));
             if (filters.segment) window.segmentChoices.setChoiceByValue(String(filters.segment));
             document.getElementById('text').value = filters.text || '';

--- a/tests/NaturalLanguageReportParserTest.php
+++ b/tests/NaturalLanguageReportParserTest.php
@@ -30,5 +30,15 @@ class NaturalLanguageReportParserTest extends TestCase
         $this->assertSame(date('Y-m-d', strtotime('-12 months')), $filters['start']);
         $this->assertSame(date('Y-m-d'), $filters['end']);
     }
+
+    public function testParseMultipleTags(): void
+    {
+        $db = Database::getConnection();
+        $db->exec("INSERT INTO tags (name, keyword, description) VALUES ('car', '', ''), ('auto', '', '')");
+        $filters = NaturalLanguageReportParser::parse('car auto');
+        $this->assertIsArray($filters['tag']);
+        sort($filters['tag']);
+        $this->assertSame([1,2], $filters['tag']);
+    }
 }
 ?>

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -258,6 +258,13 @@ $parsed = NaturalLanguageReportParser::parse('costs for cars in the last 12 mont
 assertEqual($carId, $parsed['category'], 'Natural language parser finds category');
 assertEqual(date('Y-m-d', strtotime('-12 months')), $parsed['start'], 'Natural language parser sets start date');
 
+$db->exec('DELETE FROM tags');
+$db->exec('DELETE FROM sqlite_sequence WHERE name="tags"');
+$db->exec("INSERT INTO tags (name, keyword, description) VALUES ('car','', ''), ('auto','', '')");
+$parsedTags = NaturalLanguageReportParser::parse('car auto');
+sort($parsedTags['tag']);
+assertEqual([1,2], $parsedTags['tag'], 'Natural language parser finds multiple tags');
+
 
 // Output results and set exit code
 $failed = false;


### PR DESCRIPTION
## Summary
- Extend natural language report parsing to request an array of tags from the AI and map each to tag IDs
- Support multi-tag fallback parsing and add tests for multiple tag selection
- Update report page to apply multiple AI-suggested tags to the tag filter

## Testing
- `php tests/run_tests.php`
- `vendor/bin/phpunit --colors=always` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b83d3fc520832eafcf3bab45bee8b6