### PR TITLE
fix: avoid substring matches in natural-language filters

### DIFF
--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -187,7 +187,8 @@ class NaturalLanguageReportParser {
         $db = Database::getConnection();
         $stmt = $db->query("SELECT id, name FROM $table");
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            if (stripos($query, strtolower($row['name'])) !== false) {
+            $pattern = '/\\b' . preg_quote($row['name'], '/') . '\\b/i';
+            if (preg_match($pattern, $query)) {
                 return (int)$row['id'];
             }
         }
@@ -202,7 +203,8 @@ class NaturalLanguageReportParser {
         $stmt = $db->query("SELECT id, name FROM $table");
         $ids = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            if (stripos($query, strtolower($row['name'])) !== false) {
+            $pattern = '/\\b' . preg_quote($row['name'], '/') . '\\b/i';
+            if (preg_match($pattern, $query)) {
                 $ids[] = (int)$row['id'];
             }
         }


### PR DESCRIPTION
## Summary
- match category, tag, group, and segment names using word boundaries

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b84630e394832ea9e24093c08d2b49