### PR TITLE
Show AI summary feedback on natural language reports

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -210,7 +210,7 @@
                 document.getElementById('text').value = filters.text || '';
                 document.getElementById('start').value = filters.start || '';
                 document.getElementById('end').value = filters.end || '';
-                aiStatus.textContent = 'AI suggestions applied';
+                aiStatus.textContent = filters.summary || 'AI suggestions applied';
             } catch (e) {
                 aiStatus.textContent = 'AI request failed';
             }


### PR DESCRIPTION
## Summary
- Request a short natural-language `summary` from the OpenAI report parser and generate one locally if the API omits it.
- Display the returned summary on the transaction report page so users get immediate feedback.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b847db21d0832e9d4704dd4971f761