### PR TITLE
fix: match names with surrounding symbols

### DIFF
--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -196,7 +196,7 @@ class NaturalLanguageReportParser {
         $db = Database::getConnection();
         $stmt = $db->query("SELECT id, name FROM $table");
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $pattern = '/\\b' . preg_quote($row['name'], '/') . '\\b/i';
+            $pattern = '/(?<!\\w)' . preg_quote($row['name'], '/') . '(?!\\w)/i';
             if (preg_match($pattern, $query)) {
                 return (int)$row['id'];
             }
@@ -212,7 +212,7 @@ class NaturalLanguageReportParser {
         $stmt = $db->query("SELECT id, name FROM $table");
         $ids = [];
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $pattern = '/\\b' . preg_quote($row['name'], '/') . '\\b/i';
+            $pattern = '/(?<!\\w)' . preg_quote($row['name'], '/') . '(?!\\w)/i';
             if (preg_match($pattern, $query)) {
                 $ids[] = (int)$row['id'];
             }

--- a/tests/NaturalLanguageReportParserTest.php
+++ b/tests/NaturalLanguageReportParserTest.php
@@ -40,5 +40,23 @@ class NaturalLanguageReportParserTest extends TestCase
         sort($filters['tag']);
         $this->assertSame([1,2], $filters['tag']);
     }
+
+    public function testCategoryNameWithLeadingSymbol(): void
+    {
+        $db = Database::getConnection();
+        $db->exec("INSERT INTO categories (name) VALUES ('#groceries')");
+        $filters = NaturalLanguageReportParser::parse('#groceries');
+        $this->assertSame(2, $filters['category']);
+    }
+
+    public function testTagNamesWithNonWordCharacters(): void
+    {
+        $db = Database::getConnection();
+        $db->exec("INSERT INTO tags (name, keyword, description) VALUES ('#fun', '', ''), ('bills!', '', '')");
+        $filters = NaturalLanguageReportParser::parse('#fun bills!');
+        $this->assertIsArray($filters['tag']);
+        sort($filters['tag']);
+        $this->assertSame([1,2], $filters['tag']);
+    }
 }
 ?>

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -265,6 +265,20 @@ $parsedTags = NaturalLanguageReportParser::parse('car auto');
 sort($parsedTags['tag']);
 assertEqual([1,2], $parsedTags['tag'], 'Natural language parser finds multiple tags');
 
+$db->exec('DELETE FROM categories');
+$db->exec('DELETE FROM sqlite_sequence WHERE name="categories"');
+$db->exec("INSERT INTO categories (name) VALUES ('#groceries')");
+$catSymbolId = (int)$db->lastInsertId();
+$parsedPunctCat = NaturalLanguageReportParser::parse('#groceries');
+assertEqual($catSymbolId, $parsedPunctCat['category'], 'Natural language parser handles category starting with symbol');
+
+$db->exec('DELETE FROM tags');
+$db->exec('DELETE FROM sqlite_sequence WHERE name="tags"');
+$db->exec("INSERT INTO tags (name, keyword, description) VALUES ('#fun','', ''), ('bills!','', '')");
+$parsedPunctTags = NaturalLanguageReportParser::parse('#fun bills!');
+sort($parsedPunctTags['tag']);
+assertEqual([1,2], $parsedPunctTags['tag'], 'Natural language parser handles tag names with symbols');
+
 
 // Output results and set exit code
 $failed = false;


### PR DESCRIPTION
## Summary
- use lookarounds instead of word boundaries so names with punctuation are detected
- add tests covering categories and tags with leading/trailing symbols

## Testing
- `php tests/run_tests.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b84a6eb490832e80fccc693bd84df2