### PR TITLE
Log natural language report queries

### DIFF
--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/Database.php';
 
 require_once __DIR__ . '/models/Setting.php';
+require_once __DIR__ . '/models/Log.php';
 
 class NaturalLanguageReportParser {
     /**
@@ -27,6 +28,7 @@ class NaturalLanguageReportParser {
      * Returns null if the API request fails or the response is invalid.
      */
     private static function parseWithAI(string $query, string $token): ?array {
+        Log::write('NL report AI query: ' . $query);
         $db = Database::getConnection();
 
         $tables = [


### PR DESCRIPTION
## Summary
- log each natural-language report query sent to the AI

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68b84f804b04832e80de0812bc4755ac