### PR TITLE
Define text900 color class in login page

### DIFF
--- a/index.php
+++ b/index.php
@@ -24,6 +24,7 @@ $colorMap = [
 ];
 $text600 = "text-{$colorScheme}-600";
 $text700 = "text-{$colorScheme}-700";
+$text900 = "text-{$colorScheme}-900";
 $bg600 = "bg-{$colorScheme}-600";
 $bgHover = "hover:bg-{$colorScheme}-700";
 $error = '';


### PR DESCRIPTION
## Summary
- Define `$text900` based on current color scheme to fix undefined variable error on login page

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b84f8def68832ead5a809bc511d035