### PR TITLE
Fetch only untagged count for menu badge

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -241,10 +241,10 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         }
         // Display counter for untagged transactions in menu
-        fetch('../php_backend/public/untagged_transactions.php')
+        fetch('../php_backend/public/untagged_count.php')
           .then(r => r.json())
-          .then(rows => {
-            const total = rows.reduce((sum, row) => sum + Number(row.count || 0), 0);
+          .then(data => {
+            const total = Number(data.count || 0);
             if (total > 10) {
               const counter = menu.querySelector('#missing-tags-count');
               if (counter) {

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -1089,6 +1089,15 @@ class Transaction {
     }
 
     /**
+     * Return the total number of untagged transactions.
+     */
+    public static function getUntaggedTotal(): int {
+        $db = Database::getConnection();
+        $stmt = $db->query('SELECT COUNT(*) FROM `transactions` WHERE `tag_id` IS NULL');
+        return (int)$stmt->fetchColumn();
+    }
+
+    /**
      * Analyse the last 12 months to find regularly occurring spend items.
      * Transactions marked as transfers are ignored.
      *

--- a/php_backend/public/untagged_count.php
+++ b/php_backend/public/untagged_count.php
@@ -1,0 +1,17 @@
+<?php
+// API endpoint returning the total number of untagged transactions.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+try {
+    $count = Transaction::getUntaggedTotal();
+    echo json_encode(['count' => $count]);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Untagged count error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['count' => 0]);
+}
+?>


### PR DESCRIPTION
## Summary
- add endpoint to return total untagged transactions
- expose helper to query count of untagged transactions
- update menu script to call lightweight count endpoint

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b84f346208832e9f01f6d7ae8af37c