### PR TITLE
Show commit lag in version info

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -261,8 +261,13 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(r => r.json())
             .then(v => {
               const version = v.version || 'unknown';
+              const behind = v.behind;
               releaseEls.forEach(el => {
-                el.textContent = `v${version}`;
+                let text = `v${version}`;
+                if (typeof behind === 'number') {
+                  text += ` (${behind} behind)`;
+                }
+                el.textContent = text;
               });
             })
             .catch(() => {

--- a/frontend/js/version.js
+++ b/frontend/js/version.js
@@ -6,7 +6,12 @@ document.addEventListener('DOMContentLoaded', () => {
     .then((response) => response.json())
     .then((data) => {
       const version = data.version || 'unknown';
-      target.textContent = `Version: ${version}`;
+      const behind = data.behind;
+      let text = `Version: ${version}`;
+      if (typeof behind === 'number') {
+        text += ` (${behind} behind)`;
+      }
+      target.textContent = text;
     })
     .catch(() => {
       target.textContent = 'Version: unknown';

--- a/php_backend/public/version.php
+++ b/php_backend/public/version.php
@@ -4,12 +4,17 @@ require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');
 $rootDir = dirname(__DIR__, 2);
+
+// Determine the current commit hash and branch name.
 $commitHash = '';
+$branch = null;
 $headPath = $rootDir . '/.git/HEAD';
 if (is_readable($headPath)) {
     $ref = trim(file_get_contents($headPath));
     if (strpos($ref, 'ref: ') === 0) {
-        $refPath = $rootDir . '/.git/' . substr($ref, 5);
+        $branchRef = substr($ref, 5);
+        $branch = basename($branchRef);
+        $refPath = $rootDir . '/.git/' . $branchRef;
         if (is_readable($refPath)) {
             $commitHash = trim(file_get_contents($refPath));
         }
@@ -19,5 +24,22 @@ if (is_readable($headPath)) {
 } else {
     Log::write('Version check failed: HEAD not readable', 'ERROR');
 }
+
+// Attempt to determine how many commits behind the remote the current branch is.
+$behind = null;
+if ($branch) {
+    // Fetch latest refs but ignore errors if git or the remote are unavailable.
+    @exec(sprintf('git -C %s fetch origin 2>&1', escapeshellarg($rootDir)));
+    if (preg_match('/^[A-Za-z0-9._\/-]+$/', $branch)) {
+        $cmd = sprintf('git -C %s rev-list --count HEAD..origin/%s 2>&1', escapeshellarg($rootDir), $branch);
+        $output = [];
+        $exitCode = null;
+        @exec($cmd, $output, $exitCode);
+        if ($exitCode === 0 && isset($output[0]) && ctype_digit($output[0])) {
+            $behind = (int)$output[0];
+        }
+    }
+}
+
 $commitHash = $commitHash ? substr($commitHash, 0, 7) : null;
-echo json_encode(['version' => $commitHash]);
+echo json_encode(['version' => $commitHash, 'behind' => $behind]);


### PR DESCRIPTION
## Summary
- Report current branch commit hash and number of commits behind origin via version API
- Display commit lag alongside version number in the dashboard header
- Surface commit lag on the menu release badge for quick status checks

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b850cc78ec832e8926ad3685234a60