### PR TITLE
Switch Responses API parameter to text.format

### DIFF
--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -71,7 +71,7 @@ class NaturalLanguageReportParser {
                 ['role' => 'user', 'content' => $prompt],
             ],
             'temperature' => 0,
-            'response_format' => ['type' => 'json_object'],
+            'text' => ['format' => 'json_object'],
         ];
 
         $ch = curl_init('https://api.openai.com/v1/responses');


### PR DESCRIPTION
## Summary
- update OpenAI request to use `text.format` for JSON responses

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b858638e70832ea7ae2cdbc409bc63