### PR TITLE
Wrap long log messages in logs view

### DIFF
--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -43,11 +43,17 @@
             .then(data => {
                 tailwindTabulator(gridEl, {
                     data: data,
-                    layout: 'fitDataStretch',
+                    layout: 'fitColumns',
+                    variableHeight: true,
                     columns: [
                         { title: 'Time', field: 'created_at' },
                         { title: 'Level', field: 'level' },
-                        { title: 'Message', field: 'message' }
+                        { title: 'Message', field: 'message', formatter: function(cell) {
+                            const el = cell.getElement();
+                            el.style.whiteSpace = 'pre-wrap';
+                            el.style.wordBreak = 'break-word';
+                            return cell.getValue();
+                        } }
                     ]
                 });
             });


### PR DESCRIPTION
## Summary
- prevent log message text from overflowing table

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b85cc8d5f4832e8c807d5e1826e847