### PR TITLE
Use Responses API with structured text format for AI endpoints

### DIFF
--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -89,23 +89,22 @@ try {
 
     $payload = [
         'model' => 'gpt-5-nano',
-        'messages' => [
-
+        'input' => [
             ['role' => 'system', 'content' => 'You create budgets and explanations in JSON.'],
-
             ['role' => 'user', 'content' => $prompt]
         ],
         'temperature' => 1,
+        'text' => ['format' => 'json_object'],
     ];
 
-    $ch = curl_init('https://api.openai.com/v1/chat/completions');
+    $ch = curl_init('https://api.openai.com/v1/responses');
     curl_setopt_array($ch, [
         CURLOPT_HTTPHEADER => [
             'Content-Type: application/json',
-            'Authorization: Bearer ' . $apiKey
+            'Authorization: Bearer ' . $apiKey,
         ],
         CURLOPT_POSTFIELDS => json_encode($payload),
-        CURLOPT_RETURNTRANSFER => true
+        CURLOPT_RETURNTRANSFER => true,
     ]);
     $response = curl_exec($ch);
     $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -116,7 +115,7 @@ try {
         exit;
     }
     $data = json_decode($response, true);
-    $content = $data['choices'][0]['message']['content'] ?? '';
+    $content = $data['output'][0]['content'][0]['text'] ?? '';
     $usage = $data['usage']['total_tokens'] ?? 0;
 
     $content = trim($content);

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -47,21 +47,22 @@ foreach ($txns as $t) {
 
 $payload = [
     'model' => 'gpt-5-nano',
-    'messages' => [
+    'input' => [
         ['role' => 'system', 'content' => 'You label bank transactions. Use JSON.'],
         ['role' => 'user', 'content' => $prompt]
     ],
     'temperature' => 1,
+    'text' => ['format' => 'json_object'],
 ];
 
-$ch = curl_init('https://api.openai.com/v1/chat/completions');
+$ch = curl_init('https://api.openai.com/v1/responses');
 curl_setopt_array($ch, [
     CURLOPT_HTTPHEADER => [
         'Content-Type: application/json',
-        'Authorization: Bearer ' . $apiKey
+        'Authorization: Bearer ' . $apiKey,
     ],
     CURLOPT_POSTFIELDS => json_encode($payload),
-    CURLOPT_RETURNTRANSFER => true
+    CURLOPT_RETURNTRANSFER => true,
 ]);
 $response = curl_exec($ch);
 $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
@@ -72,7 +73,7 @@ if ($response === false || $code !== 200) {
     exit;
 }
 $data = json_decode($response, true);
-$content = $data['choices'][0]['message']['content'] ?? '';
+$content = $data['output'][0]['content'][0]['text'] ?? '';
 $usage = $data['usage']['total_tokens'] ?? 0;
 
 


### PR DESCRIPTION
## Summary
- Switch budgeting, tagging, and feedback endpoints to the OpenAI Responses API
- Supply structured `text` format objects for JSON outputs
- Parse responses from new API and handle errors consistently

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b87e88da28832ea7876fe57f91e6a5