### PR TITLE
Fix OpenAI response format for JSON output

### DIFF
--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -71,7 +71,7 @@ class NaturalLanguageReportParser {
                 ['role' => 'user', 'content' => $prompt],
             ],
             'temperature' => 0,
-            'text' => ['format' => 'json_object'],
+            'response_format' => ['type' => 'json_object'],
         ];
 
         $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -91,11 +91,11 @@ try {
         'model' => 'gpt-5-nano',
         'input' => [
             ['role' => 'system', 'content' => 'You create budgets and explanations in JSON.'],
-            ['role' => 'user', 'content' => $prompt]
-        ],
-        'temperature' => 1,
-        'text' => ['format' => 'json_object'],
-    ];
+        ['role' => 'user', 'content' => $prompt]
+    ],
+    'temperature' => 1,
+    'response_format' => ['type' => 'json_object'],
+];
 
     $ch = curl_init('https://api.openai.com/v1/responses');
     curl_setopt_array($ch, [

--- a/php_backend/public/ai_feedback.php
+++ b/php_backend/public/ai_feedback.php
@@ -63,11 +63,11 @@ try {
         'model' => 'gpt-5-mini',
         'input' => [
             ['role' => 'system', 'content' => 'You are a financial analyst that writes long, clear summaries without asking questions.'],
-            ['role' => 'user', 'content' => $prompt]
-        ],
-        'temperature' => 1,
-        'text' => ['format' => 'json_object'],
-    ];
+        ['role' => 'user', 'content' => $prompt]
+    ],
+    'temperature' => 1,
+    'response_format' => ['type' => 'json_object'],
+];
 
     $ch = curl_init('https://api.openai.com/v1/responses');
     curl_setopt_array($ch, [

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -52,7 +52,7 @@ $payload = [
         ['role' => 'user', 'content' => $prompt]
     ],
     'temperature' => 1,
-    'text' => ['format' => 'json_object'],
+    'response_format' => ['type' => 'json_object'],
 ];
 
 $ch = curl_init('https://api.openai.com/v1/responses');


### PR DESCRIPTION
## Summary
- use `response_format` with `json_object` for OpenAI requests
- prevents `Invalid type for 'text.format'` errors during AI-assisted reports

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8bf58cd84832e82b85c5ea5698b7d