### PR TITLE
Use text.format for OpenAI JSON responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS Instructions
 
 - Record any additional project decisions or conventions in this file.
-- AI integrations use the OpenAI Responses API with `json_object` responses.
+- AI integrations use the OpenAI Responses API with JSON text via `text.format` responses.
 - Projects support archiving via an `archived` flag and can be restored from the Archived Projects page.
 
 - Projects view visualises benefits using a bubble chart plotting cost vs quality with bubble size representing score, displaying each project as its own series for distinct colours.

--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -71,7 +71,7 @@ class NaturalLanguageReportParser {
                 ['role' => 'user', 'content' => $prompt],
             ],
             'temperature' => 0,
-            'response_format' => ['type' => 'json_object'],
+            'text' => ['format' => 'json'],
         ];
 
         $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -94,7 +94,7 @@ try {
         ['role' => 'user', 'content' => $prompt]
     ],
     'temperature' => 1,
-    'response_format' => ['type' => 'json_object'],
+    'text' => ['format' => 'json'],
 ];
 
     $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_feedback.php
+++ b/php_backend/public/ai_feedback.php
@@ -66,7 +66,7 @@ try {
         ['role' => 'user', 'content' => $prompt]
     ],
     'temperature' => 1,
-    'response_format' => ['type' => 'json_object'],
+    'text' => ['format' => 'json'],
 ];
 
     $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -52,7 +52,7 @@ $payload = [
         ['role' => 'user', 'content' => $prompt]
     ],
     'temperature' => 1,
-    'response_format' => ['type' => 'json_object'],
+    'text' => ['format' => 'json'],
 ];
 
 $ch = curl_init('https://api.openai.com/v1/responses');


### PR DESCRIPTION
## Summary
- Replace deprecated `response_format` with `text.format` in all OpenAI Requests
- Document new JSON text output format in AGENTS instructions

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8c5f6dd74832e860ca6015d78c7b7