### PR TITLE
Fix OpenAI text.format usage for AI features

### DIFF
--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -71,7 +71,7 @@ class NaturalLanguageReportParser {
                 ['role' => 'user', 'content' => $prompt],
             ],
             'temperature' => 0,
-            'text' => ['format' => 'json'],
+            'text' => ['format' => ['type' => 'json']],
         ];
 
         $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -94,7 +94,7 @@ try {
         ['role' => 'user', 'content' => $prompt]
     ],
     'temperature' => 1,
-    'text' => ['format' => 'json'],
+    'text' => ['format' => ['type' => 'json']],
 ];
 
     $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_feedback.php
+++ b/php_backend/public/ai_feedback.php
@@ -66,7 +66,7 @@ try {
         ['role' => 'user', 'content' => $prompt]
     ],
     'temperature' => 1,
-    'text' => ['format' => 'json'],
+    'text' => ['format' => ['type' => 'json']],
 ];
 
     $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -52,7 +52,7 @@ $payload = [
         ['role' => 'user', 'content' => $prompt]
     ],
     'temperature' => 1,
-    'text' => ['format' => 'json'],
+    'text' => ['format' => ['type' => 'json']],
 ];
 
 $ch = curl_init('https://api.openai.com/v1/responses');


### PR DESCRIPTION
## Summary
- Use structured `text.format` object when requesting JSON output from OpenAI Responses API

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9702a4060832eb357e7928beddf91