### PR TITLE
Expose AI model and temperature as configurable settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - Record any additional project decisions or conventions in this file.
 - AI integrations use the OpenAI Responses API with JSON text via `text.format` responses.
+- AI model and temperature are configurable via `ai_model` and `ai_temperature` settings.
 - Projects support archiving via an `archived` flag and can be restored from the Archived Projects page.
 
 - Projects view visualises benefits using a bubble chart plotting cost vs quality with bubble size representing score, displaying each project as its own series for distinct colours.

--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -64,13 +64,18 @@ class NaturalLanguageReportParser {
             "Groups:\n- " . implode("\n- ", $names['transaction_groups']) . "\n\n" .
             "Query: $query";
 
+        $model = Setting::get('ai_model') ?? 'gpt-5-nano';
+        $temperature = Setting::get('ai_temperature');
+        if ($temperature === null || $temperature === '') {
+            $temperature = 0;
+        }
         $payload = [
-            'model' => 'gpt-5-nano',
+            'model' => $model,
             'input' => [
                 ['role' => 'system', 'content' => 'You convert report requests into JSON filters.'],
                 ['role' => 'user', 'content' => $prompt],
             ],
-            'temperature' => 0,
+            'temperature' => (float)$temperature,
             'text' => ['format' => ['type' => 'json']],
         ];
 

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -87,15 +87,20 @@ try {
         $prompt .= "{$h['id']} {$h['name']}: [" . implode(',', $h['totals']) . "]\n";
     }
 
+    $model = Setting::get('ai_model') ?? 'gpt-5-nano';
+    $temperature = Setting::get('ai_temperature');
+    if ($temperature === null || $temperature === '') {
+        $temperature = 1;
+    }
     $payload = [
-        'model' => 'gpt-5-nano',
+        'model' => $model,
         'input' => [
             ['role' => 'system', 'content' => 'You create budgets and explanations in JSON.'],
-        ['role' => 'user', 'content' => $prompt]
-    ],
-    'temperature' => 1,
-    'text' => ['format' => ['type' => 'json']],
-];
+            ['role' => 'user', 'content' => $prompt]
+        ],
+        'temperature' => (float)$temperature,
+        'text' => ['format' => ['type' => 'json']],
+    ];
 
     $ch = curl_init('https://api.openai.com/v1/responses');
     curl_setopt_array($ch, [

--- a/php_backend/public/ai_feedback.php
+++ b/php_backend/public/ai_feedback.php
@@ -59,15 +59,20 @@ try {
         $prompt .= $c['name'] . ': £' . number_format((float)$c['total'], 2) . "\n";
     }
 
+    $model = Setting::get('ai_model') ?? 'gpt-5-mini';
+    $temperature = Setting::get('ai_temperature');
+    if ($temperature === null || $temperature === '') {
+        $temperature = 1;
+    }
     $payload = [
-        'model' => 'gpt-5-mini',
+        'model' => $model,
         'input' => [
             ['role' => 'system', 'content' => 'You are a financial analyst that writes long, clear summaries without asking questions.'],
-        ['role' => 'user', 'content' => $prompt]
-    ],
-    'temperature' => 1,
-    'text' => ['format' => ['type' => 'json']],
-];
+            ['role' => 'user', 'content' => $prompt]
+        ],
+        'temperature' => (float)$temperature,
+        'text' => ['format' => ['type' => 'json']],
+    ];
 
     $ch = curl_init('https://api.openai.com/v1/responses');
     curl_setopt_array($ch, [

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -45,13 +45,18 @@ foreach ($txns as $t) {
     $prompt .= "{$t['id']}: {$t['description']}{$memo} ({$t['amount']})\n";
 }
 
+$model = Setting::get('ai_model') ?? 'gpt-5-nano';
+$temperature = Setting::get('ai_temperature');
+if ($temperature === null || $temperature === '') {
+    $temperature = 1;
+}
 $payload = [
-    'model' => 'gpt-5-nano',
+    'model' => $model,
     'input' => [
         ['role' => 'system', 'content' => 'You label bank transactions. Use JSON.'],
         ['role' => 'user', 'content' => $prompt]
     ],
-    'temperature' => 1,
+    'temperature' => (float)$temperature,
     'text' => ['format' => ['type' => 'json']],
 ];
 

--- a/settings.php
+++ b/settings.php
@@ -13,6 +13,8 @@ if (!isset($_SESSION['user_id'])) {
 $message = '';
 $openai = Setting::get('openai_api_token') ?? '';
 $batch = Setting::get('ai_tag_batch_size') ?? '20';
+$aiModel = Setting::get('ai_model') ?? 'gpt-5-nano';
+$aiTemp = Setting::get('ai_temperature') ?? '1';
 $retention = Setting::get('log_retention_days') ?? '30';
 $timeout = Setting::get('session_timeout_minutes') ?? '0';
 $fontSettings = Setting::getFonts();
@@ -41,6 +43,8 @@ $colorMap = [
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $openai = trim($_POST['openai_api_token'] ?? '');
     $batch = trim($_POST['ai_tag_batch_size'] ?? '');
+    $aiModel = trim($_POST['ai_model'] ?? '');
+    $aiTemp = trim($_POST['ai_temperature'] ?? '');
     $retention = trim($_POST['log_retention_days'] ?? '');
     $timeout = trim($_POST['session_timeout_minutes'] ?? '');
     $fontHeading = trim($_POST['font_heading'] ?? '');
@@ -53,6 +57,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($batch !== '') {
         Setting::set('ai_tag_batch_size', $batch);
         Log::write('Updated AI tag batch size');
+    }
+    if ($aiModel !== '') {
+        Setting::set('ai_model', $aiModel);
+        Log::write('Updated AI model');
+    }
+    if ($aiTemp !== '') {
+        Setting::set('ai_temperature', $aiTemp);
+        Log::write('Updated AI temperature');
     }
     if ($retention !== '') {
         Setting::set('log_retention_days', $retention);
@@ -129,6 +141,12 @@ $bg600 = "bg-{$colorScheme}-600";
             </label>
             <label class="block">AI Tag Batch Size:
                 <input type="number" name="ai_tag_batch_size" value="<?= htmlspecialchars($batch) ?>" class="border p-2 rounded w-full" data-help="How many transactions to submit for AI tagging at once">
+            </label>
+            <label class="block">AI Model:
+                <input type="text" name="ai_model" value="<?= htmlspecialchars($aiModel) ?>" class="border p-2 rounded w-full" data-help="Model name for OpenAI responses">
+            </label>
+            <label class="block">AI Temperature:
+                <input type="number" step="0.1" name="ai_temperature" value="<?= htmlspecialchars($aiTemp) ?>" class="border p-2 rounded w-full" data-help="Creativity level for AI responses">
             </label>
             <label class="block">Log Retention Days:
                 <input type="number" name="log_retention_days" value="<?= htmlspecialchars($retention) ?>" class="border p-2 rounded w-full" data-help="Automatically prune logs older than this many days">


### PR DESCRIPTION
## Summary
- add `ai_model` and `ai_temperature` controls to the system settings page
- use configured AI model and temperature for tagging, budgeting, feedback, and report parsing
- note configurable AI options in AGENTS documentation

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b97162d9c8832eba627f147742d936