### PR TITLE
Fix OpenAI response format error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 - Record any additional project decisions or conventions in this file.
 - AI integrations use the OpenAI Responses API with JSON text via `text.format` responses.
+- Set `text.format.type` to `json_object` when requesting JSON responses.
 - AI model and temperature are configurable via `ai_model` and `ai_temperature` settings.
 - Projects support archiving via an `archived` flag and can be restored from the Archived Projects page.
 

--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -76,7 +76,7 @@ class NaturalLanguageReportParser {
                 ['role' => 'user', 'content' => $prompt],
             ],
             'temperature' => (float)$temperature,
-            'text' => ['format' => ['type' => 'json']],
+            'text' => ['format' => ['type' => 'json_object']],
         ];
 
         $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -99,7 +99,7 @@ try {
             ['role' => 'user', 'content' => $prompt]
         ],
         'temperature' => (float)$temperature,
-        'text' => ['format' => ['type' => 'json']],
+        'text' => ['format' => ['type' => 'json_object']],
     ];
 
     $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_feedback.php
+++ b/php_backend/public/ai_feedback.php
@@ -71,7 +71,7 @@ try {
             ['role' => 'user', 'content' => $prompt]
         ],
         'temperature' => (float)$temperature,
-        'text' => ['format' => ['type' => 'json']],
+        'text' => ['format' => ['type' => 'json_object']],
     ];
 
     $ch = curl_init('https://api.openai.com/v1/responses');

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -57,7 +57,7 @@ $payload = [
         ['role' => 'user', 'content' => $prompt]
     ],
     'temperature' => (float)$temperature,
-    'text' => ['format' => ['type' => 'json']],
+    'text' => ['format' => ['type' => 'json_object']],
 ];
 
 $ch = curl_init('https://api.openai.com/v1/responses');


### PR DESCRIPTION
## Summary
- Use `json_object` for `text.format.type` in all OpenAI requests to match supported values
- Document the required `json_object` format in AGENTS guidance

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9745888bc832eaad0024fa0b83485