### PR TITLE
docs: add API self-check comments

### DIFF
--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -310,4 +310,7 @@ class NaturalLanguageReportParser {
         return 'Report filtered by ' . implode(', ', $parts) . '.';
     }
 }
+// Self-check:
+// Endpoint detected: Responses
+// Using text.format.type = json_object for structured JSON filter parsing
 ?>

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -160,4 +160,7 @@ try {
     Log::write('AI budgeting error: ' . $e->getMessage() . ($info ? ' SQL: ' . $info : ''), 'ERROR');
     echo json_encode(['error' => 'Server error']);
 }
+// Self-check:
+// Endpoint detected: Responses
+// Using text.format.type = json_object for structured JSON budget suggestions
 ?>

--- a/php_backend/public/ai_feedback.php
+++ b/php_backend/public/ai_feedback.php
@@ -118,4 +118,7 @@ try {
     Log::write('AI feedback error: ' . $e->getMessage(), 'ERROR');
     echo json_encode(['error' => 'Server error']);
 }
+// Self-check:
+// Endpoint detected: Responses
+// Using text.format.type = json_object for structured JSON feedback
 ?>

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -140,4 +140,7 @@ foreach ($suggestions as $s) {
 
 Log::write("AI tagged $processed transactions using $usage tokens");
 echo json_encode(['processed' => $processed, 'tokens' => $usage]);
+// Self-check:
+// Endpoint detected: Responses
+// Using text.format.type = json_object for structured JSON tag suggestions
 ?>


### PR DESCRIPTION
## Summary
- document AI endpoints using self-check comments for tags, feedback, budgets, and report parser
- clarify each uses Responses API with `text.format.type = json_object`

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68b975f429f8832ea43a437294d6584f