### PR TITLE
Include settings in backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Back up and restore your data through the web interface. From the navigation
 menu open **Backup & Restore** under *Administration*. User accounts and
 account information are always included in backups. You can additionally choose
 which other parts of the database to download—transactions, categories, tags,
-groups, segments, projects, or budgets. The downloaded file contains gzipped JSON and is named after
+groups, segments, projects, budgets, or settings. The downloaded file contains gzipped JSON and is named after
 your site's hostname, the current date, and the selected sections (for example,
 `example.com-2024-05-15-transactions-categories.json.gz`). To restore a backup,
 choose the compressed file on the same page and click **Restore**; any included

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -31,6 +31,7 @@
                     <label class="block"><input type="checkbox" name="parts" value="segments" class="mr-2">Segments</label>
                     <label class="block"><input type="checkbox" name="parts" value="projects" class="mr-2">Projects</label>
                     <label class="block"><input type="checkbox" name="parts" value="budgets" class="mr-2">Budgets</label>
+                    <label class="block"><input type="checkbox" name="parts" value="settings" class="mr-2">Settings</label>
 
                 </div>
                 <button id="download-backup" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-download inline w-4 h-4 mr-2"></i>Download Backup</button>
@@ -39,7 +40,7 @@
             </section>
             <section class="bg-white p-6 rounded shadow space-y-4">
                 <h2 class="text-xl font-semibold">Restore Backup</h2>
-                <p>Select a gzipped JSON backup file to restore any included transactions, categories, tags, groups, segments, projects, or budgets.</p>
+                <p>Select a gzipped JSON backup file to restore any included transactions, categories, tags, groups, segments, projects, budgets, or settings.</p>
                 <form id="restore-form" action="../php_backend/public/restore.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                     <input type="file" id="backup-file" name="backup_file" accept="application/gzip,application/json" required data-help="Choose a previously downloaded compressed backup file">
                     <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-upload inline w-4 h-4 mr-2"></i>Restore</button>

--- a/frontend/js/backup.js
+++ b/frontend/js/backup.js
@@ -6,7 +6,7 @@ function initBackup() {
     if (dlBtn) {
         dlBtn.addEventListener('click', () => {
             const parts = Array.from(document.querySelectorAll('input[name="parts"]:checked')).map(cb => cb.value);
-            const allParts = ['categories','tags','groups','transactions','budgets','segments','projects'];
+            const allParts = ['categories','tags','groups','transactions','budgets','segments','projects','settings'];
             const selected = parts.length ? parts : allParts;
             const qs = parts.length ? `?parts=${parts.join(',')}` : '';
             fetch(`../php_backend/public/backup.php${qs}`)

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -1,7 +1,8 @@
 <?php
 // Exports selected data as JSON. Allows selecting categories, tags, groups,
-// segments, transactions, budgets, and projects via the `parts` query parameter.
-// User and account information is always included so a full backup can be restored.
+// segments, transactions, budgets, projects, and settings via the `parts`
+// query parameter. User and account information is always included so a full
+// backup can be restored.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Log.php';
@@ -9,7 +10,8 @@ require_once __DIR__ . '/../models/Log.php';
 // Determine which parts are being backed up so the filename can reflect them
 // Include segments so they can be exported and restored
 // Allow optionally including projects in the backup
-$allParts = ['categories','tags','groups','transactions','budgets','segments','projects'];
+// Settings may also be backed up and restored
+$allParts = ['categories','tags','groups','transactions','budgets','segments','projects','settings'];
 $parts = isset($_GET['parts']) && $_GET['parts'] !== ''
     ? array_intersect($allParts, explode(',', $_GET['parts']))
     : $allParts;
@@ -34,6 +36,9 @@ try {
     // Always include users and account details
     $data['users'] = $getAll('SELECT id, username, password FROM users ORDER BY id');
     $data['accounts'] = $getAll('SELECT id, name, sort_code, account_number, ledger_balance, ledger_balance_date FROM accounts ORDER BY id');
+    if (in_array('settings', $parts)) {
+        $data['settings'] = $getAll('SELECT name, value FROM settings ORDER BY name');
+    }
     if (in_array('categories', $parts)) {
         // Include segment references with categories
         $data['categories'] = $getAll('SELECT id, segment_id, name, description FROM categories ORDER BY id');

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -1,6 +1,6 @@
 <?php
 
-// Restores users, accounts, segments, categories, tags, groups,
+// Restores users, accounts, settings, segments, categories, tags, groups,
 // transactions, budgets, and projects from an uploaded gzipped JSON backup.
 
 require_once __DIR__ . '/../nocache.php';
@@ -85,6 +85,7 @@ try {
     if (isset($data['groups'])) $db->exec('TRUNCATE TABLE transaction_groups');
     if (isset($data['projects'])) $db->exec('TRUNCATE TABLE projects');
     if (isset($data['budgets'])) $db->exec('TRUNCATE TABLE budgets');
+    if (isset($data['settings'])) $db->exec('TRUNCATE TABLE settings');
     if (isset($data['accounts'])) $db->exec('TRUNCATE TABLE accounts');
     if (isset($data['users'])) $db->exec('TRUNCATE TABLE users');
     $db->exec('SET FOREIGN_KEY_CHECKS=1');
@@ -107,6 +108,13 @@ try {
                 'ledger_balance' => $row['ledger_balance'],
                 'ledger_balance_date' => $row['ledger_balance_date'] ?? null
             ]);
+        }
+    }
+
+    if (isset($data['settings'])) {
+        $stmtSet = $db->prepare('INSERT INTO settings (name, value) VALUES (:name, :value)');
+        foreach ($data['settings'] as $row) {
+            $stmtSet->execute(['name' => $row['name'], 'value' => $row['value']]);
         }
     }
 


### PR DESCRIPTION
## Summary
- Allow backups and restores to include application settings.
- Expose settings as a selectable option on the Backup & Restore page.
- Document settings support in backup instructions.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b98cc94914832e9b9e070002975cfb