### PR TITLE
Add colour palette link to sidebar

### DIFF
--- a/frontend/menu.html
+++ b/frontend/menu.html
@@ -72,6 +72,7 @@
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="categories.html"><i class="fas fa-folder-open mr-1"></i> Manage Categories</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="groups.html"><i class="fas fa-layer-group mr-1"></i> Manage Groups</a></li>
         <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="segments.html"><i class="fas fa-chart-pie mr-1"></i> Manage Segments</a></li>
+        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="palette.html"><i class="fas fa-palette mr-1"></i> Colour Palette</a></li>
       </ul>
   </div>
 


### PR DESCRIPTION
## Summary
- add Colour Palette link in sidebar navigation

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b98ef1df94832e8ee4cffc9277122a