### PR TITLE
Sync palette seed with color scheme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - Projects board page presents each active project as an individual card with key details and actions.
 - Projects board cards display post-description details in a compact table with a smaller font to minimise card size.
 - Colour palettes are generated in OKLCH with an HSL fallback. Palette settings are stored using hue, lightness and chroma parameters rather than hex values.
+- Palette seed colour defaults to the configured colour scheme and updates when the colour scheme changes.
 
 
 ## Environment

--- a/php_backend/public/palette.php
+++ b/php_backend/public/palette.php
@@ -13,8 +13,22 @@ $input = json_decode(file_get_contents('php://input'), true) ?? [];
 try {
     switch ($method) {
         case 'GET':
+            $seed = Setting::get('palette_seed');
+            if (!$seed) {
+                $brand = Setting::getBrand();
+                $colorMap = [
+                    'indigo' => '#4f46e5',
+                    'blue'   => '#2563eb',
+                    'green'  => '#059669',
+                    'red'    => '#dc2626',
+                    'purple' => '#9333ea',
+                    'teal'   => '#0d9488',
+                    'orange' => '#ea580c',
+                ];
+                $seed = $colorMap[$brand['color_scheme']] ?? '#4f46e5';
+            }
             echo json_encode([
-                'seed' => Setting::get('palette_seed'),
+                'seed' => $seed,
                 'segments' => Segment::allWithCategories()
             ]);
             break;

--- a/settings.php
+++ b/settings.php
@@ -93,6 +93,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($colorScheme !== '') {
         Setting::set('color_scheme', $colorScheme);
         Log::write('Updated color scheme');
+        if (isset($colorMap[$colorScheme])) {
+            Setting::set('palette_seed', $colorMap[$colorScheme]);
+            Log::write('Updated palette seed to match color scheme');
+        }
     }
     $message = 'Settings updated.';
 }


### PR DESCRIPTION
## Summary
- Ensure palette seed defaults to the configured color scheme when missing
- Update settings to keep palette seed in sync with color scheme changes
- Document palette seed convention in AGENTS guidelines

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b98fea5d08832eb7f3ab47726a011a