### PR TITLE
Link charts to saved colour palette

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -111,32 +111,27 @@
     }
 
     // Draw a column chart summarising totals
-    function buildChart(id, title, data){
+    function buildChart(id, title, data, colorFn){
         Highcharts.chart(id, {
-            colors: chartColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
             tooltip: { pointFormatter: columnTooltip },
-            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
+            series: [{ name: 'Total', data: data.map(d => ({ y: parseFloat(d.total), color: colorFn ? colorFn(d) : chartColors[0] })) }]
         });
     }
 
     // Build sunburst charts for categories and tags across all years
     function buildSunburstCharts(incomeId, outgoingsId, categories, tags){
 
-        const colors = Highcharts.getOptions().colors;
-
         // Create hierarchical data for either income or outgoing values
         function createData(isIncome){
             const data = [{ id: 'root', parent: '', name: '' }];
-            let colorIndex = 0;
             categories.forEach(c => {
                 const total = parseFloat(c.total);
                 if ((isIncome && total > 0) || (!isIncome && total < 0)) {
-                    const color = colors[colorIndex % colors.length];
-                    colorIndex++;
+                    const color = getCategoryColor(c.name, c.segment_name);
                     const catId = c.name;
                     data.push({ id: catId, parent: 'root', name: c.name, value: Math.abs(total), color });
                     tags.filter(t => t.category === c.name && ((isIncome && parseFloat(t.total) > 0) || (!isIncome && parseFloat(t.total) < 0))).forEach(t => {
@@ -180,10 +175,10 @@
                 buildTable('tags-table', data.tags, data.years, 'bg-indigo-200 text-indigo-800');
                 buildChart('tags-chart', 'Tag Totals', data.tags);
                 buildTable('categories-table', data.categories, data.years, 'bg-green-200 text-green-800');
-                buildChart('categories-chart', 'Category Totals', data.categories);
+                buildChart('categories-chart', 'Category Totals', data.categories, d => getCategoryColor(d.name, d.segment_name));
                 buildSunburstCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
                 buildTable('segments-table', data.segments, data.years, 'bg-yellow-200 text-yellow-800');
-                buildChart('segments-chart', 'Segment Totals', data.segments);
+                buildChart('segments-chart', 'Segment Totals', data.segments, d => getSegmentColor(d.name));
                 buildTable('groups-table', data.groups, data.years, 'bg-purple-200 text-purple-800');
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -111,7 +111,6 @@
         const segmentIds = {};
         const segmentTotals = {};
         const categoryTotals = {};
-        const catCounts = {};
         (yearly.categories || []).forEach(c => {
             if (!c.name) return;
             const segName = categoryMap[c.name] || 'Not Segmented';
@@ -124,9 +123,7 @@
             const catId = 'cat_' + makeId(c.name);
 
             const total = Math.abs(parseFloat(c.total));
-            const count = catCounts[segName] || 0;
-            catCounts[segName] = count + 1;
-            const catColor = getCategoryColor(segName, count);
+            const catColor = getCategoryColor(c.name, segName);
             const catNode = { id: catId, parent: segId, name: c.name, color: catColor };
             if (!includeTags) { catNode.value = total; }
             data.push(catNode);
@@ -150,9 +147,7 @@
                         data.push({ id: segId, parent: 'root', name: segName, color: getSegmentColor(segName) });
                     }
                     catId = 'cat_' + makeId(t.category);
-                    const count = catCounts[segName] || 0;
-                    catCounts[segName] = count + 1;
-                    const catColor = getCategoryColor(segName, count);
+                    const catColor = getCategoryColor(t.category, segName);
                     data.push({ id: catId, parent: segId, name: t.category, color: catColor });
                     catInfo = categoryTotals[t.category] = { id: catId, total: 0, segment: segName, fromYearly: false, color: catColor };
                 }
@@ -207,13 +202,10 @@
                 y: parseFloat(m.spent),
                 z: Math.abs(parseFloat(m.income || 0) - parseFloat(m.spent))
             }));
-            const segCounts = {};
             const catColors = {};
             const categorySeries = yearly.categories.map(c => {
                 const seg = c.segment_name || 'Not Segmented';
-                const count = segCounts[seg] || 0;
-                segCounts[seg] = count + 1;
-                const color = getCategoryColor(seg, count);
+                const color = getCategoryColor(c.name, seg);
                 catColors[c.name] = color;
                 return {
                     name: c.name,

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -133,32 +133,27 @@
     }
 
     // Draw a column chart visualising totals
-    function buildChart(id, title, data){
+    function buildChart(id, title, data, colorFn){
         Highcharts.chart(id, {
-            colors: chartColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
             tooltip: { pointFormatter: columnTooltip },
-            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
+            series: [{ name: 'Total', data: data.map(d => ({ y: parseFloat(d.total), color: colorFn ? colorFn(d) : chartColors[0] })) }]
         });
     }
 
     // Render paired sunburst charts for categories and tags
     function buildSunburstCharts(incomeId, outgoingsId, categories, tags){
 
-        const colors = Highcharts.getOptions().colors;
-
         // Create hierarchical data for income or outgoings
         function createData(isIncome){
             const data = [{ id: 'root', parent: '', name: '' }];
-            let colorIndex = 0;
             categories.forEach(c => {
                 const total = parseFloat(c.total);
                 if ((isIncome && total > 0) || (!isIncome && total < 0)) {
-                    const color = colors[colorIndex % colors.length];
-                    colorIndex++;
+                    const color = getCategoryColor(c.name, c.segment_name);
                     const catId = c.name;
                     data.push({ id: catId, parent: 'root', name: c.name, value: Math.abs(total), color });
                     tags.filter(t => t.category === c.name && ((isIncome && parseFloat(t.total) > 0) || (!isIncome && parseFloat(t.total) < 0))).forEach(t => {
@@ -212,10 +207,10 @@
                 buildTable('tags-table', data.tags, days, 'bg-indigo-200 text-indigo-800');
                 buildChart('tags-chart', 'Tag Totals', data.tags);
                 buildTable('categories-table', data.categories, days, 'bg-green-200 text-green-800');
-                buildChart('categories-chart', 'Category Totals', data.categories);
+                buildChart('categories-chart', 'Category Totals', data.categories, d => getCategoryColor(d.name, d.segment_name));
                 buildSunburstCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
                 buildTable('segments-table', data.segments, days, 'bg-yellow-200 text-yellow-800');
-                buildChart('segments-chart', 'Segment Totals', data.segments);
+                buildChart('segments-chart', 'Segment Totals', data.segments, d => getSegmentColor(d.name));
                 buildTable('groups-table', data.groups, days, 'bg-purple-200 text-purple-800');
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -260,8 +260,16 @@
             });
             const grouped = groupTransactions(data);
             const cats = grouped.grouped.map(g => g.label);
-            const amounts = grouped.grouped.map(g => parseFloat(g.total));
             const label = grouped.group.charAt(0).toUpperCase() + grouped.group.slice(1);
+            const seriesData = grouped.grouped.map(g => {
+                let color = chartColors[0];
+                if (grouped.group === 'segment') {
+                    color = getSegmentColor(g.label);
+                } else if (grouped.group === 'category') {
+                    color = getCategoryColor(g.label);
+                }
+                return { y: parseFloat(g.total), color };
+            });
             Highcharts.chart('chart', {
                 chart: { type: 'column', backgroundColor: 'transparent' },
                 title: { text: 'Transaction Amounts by ' + label },
@@ -269,7 +277,7 @@
                 yAxis: { title: { text: 'Amount' } },
                 legend: { enabled: false },
                 tooltip: { pointFormatter: columnTooltip },
-                series: [{ name: 'Amount', data: amounts, color: chartColors[0] }]
+                series: [{ name: 'Amount', data: seriesData }]
             });
         } else {
             gridEl.innerHTML = 'No transactions found.';

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -115,32 +115,27 @@
     }
 
     // Draw a column chart for the provided data set
-    function buildChart(id, title, data){
+    function buildChart(id, title, data, colorFn){
         Highcharts.chart(id, {
-            colors: chartColors,
             chart: { type: 'column' },
             title: { text: title },
             xAxis: { categories: data.map(d => d.name) },
             yAxis: { title: { text: 'Amount (£)' }, labels: { formatter: function(){ return '£' + Highcharts.numberFormat(this.value, 2); } } },
             tooltip: { pointFormatter: columnTooltip },
-            series: [{ name: 'Total', data: data.map(d => parseFloat(d.total)), colorByPoint: true }]
+            series: [{ name: 'Total', data: data.map(d => ({ y: parseFloat(d.total), color: colorFn ? colorFn(d) : chartColors[0] })) }]
         });
     }
 
     // Create sunburst charts for income and outgoings categories/tags
     function buildSunburstCharts(incomeId, outgoingsId, categories, tags){
 
-        const colors = Highcharts.getOptions().colors;
-
         // Build hierarchical series data filtered by income or outgoings
         function createData(isIncome){
             const data = [{ id: 'root', parent: '', name: '' }];
-            let colorIndex = 0;
             categories.forEach(c => {
                 const total = parseFloat(c.total);
                 if ((isIncome && total > 0) || (!isIncome && total < 0)) {
-                    const color = colors[colorIndex % colors.length];
-                    colorIndex++;
+                    const color = getCategoryColor(c.name, c.segment_name);
                     const catId = c.name;
                     data.push({ id: catId, parent: 'root', name: c.name, value: Math.abs(total), color });
                     tags.filter(t => t.category === c.name && ((isIncome && parseFloat(t.total) > 0) || (!isIncome && parseFloat(t.total) < 0))).forEach(t => {
@@ -185,10 +180,10 @@
                 buildTable('tags-table', data.tags, 'bg-indigo-200 text-indigo-800');
                 buildChart('tags-chart', 'Tag Totals ' + year, data.tags);
                 buildTable('categories-table', data.categories, 'bg-green-200 text-green-800');
-                buildChart('categories-chart', 'Category Totals ' + year, data.categories);
+                buildChart('categories-chart', 'Category Totals ' + year, data.categories, d => getCategoryColor(d.name, d.segment_name));
                 buildSunburstCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
                 buildTable('segments-table', data.segments, 'bg-yellow-200 text-yellow-800');
-                buildChart('segments-chart', 'Segment Totals ' + year, data.segments);
+                buildChart('segments-chart', 'Segment Totals ' + year, data.segments, d => getSegmentColor(d.name));
                 buildTable('groups-table', data.groups, 'bg-purple-200 text-purple-800');
                 buildChart('groups-chart', 'Group Totals ' + year, data.groups);
             });


### PR DESCRIPTION
## Summary
- load saved palette and expose helpers for segment and category colours
- apply palette colours to segment/category charts across dashboards and reports

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b990171cdc832eb0f640fd4b99b3fe