### PR TITLE
Add palette refresh control and unique segment colors

### DIFF
--- a/frontend/js/palette.js
+++ b/frontend/js/palette.js
@@ -10,16 +10,20 @@ export function supportsOklch() {
 
 export function generatePalette(seedHex, segments, shadeCount = 7) {
   const seed = hexToOklch(seedHex);
-  const hues = [];
+  const used = new Set();
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i];
+    let h;
     if (seg.locked && seg.hue_deg !== null) {
-      hues.push(seg.hue_deg);
+      h = seg.hue_deg;
     } else {
-      const h = (seed.h + i * GOLDEN_ANGLE) % 360;
-      hues.push(h);
+      h = (seed.h + i * GOLDEN_ANGLE) % 360;
+      while (used.has(Math.round(h))) {
+        h = (h + GOLDEN_ANGLE) % 360;
+      }
       seg.hue_deg = h;
     }
+    used.add(Math.round(seg.hue_deg));
     seg.base_l_pct = clamp(seg.base_l_pct ?? 67, 65, 70);
     seg.base_c = clamp(seg.base_c ?? 0.12, 0.1, 0.14);
   }

--- a/frontend/js/palette_ui.js
+++ b/frontend/js/palette_ui.js
@@ -17,6 +17,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     update();
   });
   document.getElementById('apply').addEventListener('click', save);
+  document.getElementById('refresh').addEventListener('click', update);
 });
 
 function buildSegmentInputs() {
@@ -39,10 +40,13 @@ function buildSegmentInputs() {
     colorInput.addEventListener('input', e => {
       const o = hexToOklch(e.target.value);
       seg.hue_deg = o.h;
+      seg.locked = true;
+      lockInput.checked = true;
       update();
     });
     lockInput.addEventListener('change', e => {
       seg.locked = e.target.checked;
+      update();
     });
     container.appendChild(div);
     seg._preview = div.querySelector('.preview');

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -17,7 +17,10 @@
         </label>
         <p>Segments: <span id="segment-count"></span></p>
         <div id="segments"></div>
-        <button id="apply" class="bg-indigo-600 text-white px-4 py-2 rounded">Apply</button>
+        <div class="flex gap-2">
+          <button id="refresh" class="bg-indigo-500 text-white px-4 py-2 rounded" aria-label="Refresh palette">Refresh</button>
+          <button id="apply" class="bg-indigo-600 text-white px-4 py-2 rounded" aria-label="Apply palette">Apply</button>
+        </div>
       </div>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- add refresh button to palette settings
- auto-lock chosen segment colours and regenerate others
- ensure generated palette assigns unique hues

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9a0a5b83c832e81fe59d7c22c94b9