### PR TITLE
Seed palette generation with locked hues

### DIFF
--- a/frontend/js/palette.js
+++ b/frontend/js/palette.js
@@ -10,7 +10,11 @@ export function supportsOklch() {
 
 export function generatePalette(seedHex, segments, shadeCount = 7) {
   const seed = hexToOklch(seedHex);
-  const used = new Set();
+  const used = new Set(
+    segments
+      .filter(s => s.locked && s.hue_deg !== null)
+      .map(s => Math.round(s.hue_deg))
+  );
   for (let i = 0; i < segments.length; i++) {
     const seg = segments[i];
     let h;


### PR DESCRIPTION
## Summary
- prevent unlocked segments from duplicating later locked hues by seeding used set

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9a3ae6f48832e8cbbed0a8df24bbe