### PR TITLE
Explain palette page controls and enable input help

### DIFF
--- a/frontend/js/input_help.js
+++ b/frontend/js/input_help.js
@@ -19,10 +19,16 @@ document.addEventListener('DOMContentLoaded', () => {
         helpBox.classList.add('hidden');
     }
 
-    document.querySelectorAll('input[data-help], select[data-help]').forEach(el => {
-        el.addEventListener('focus', () => showHelp(el));
-        el.addEventListener('blur', hideHelp);
-        el.addEventListener('mouseenter', () => showHelp(el));
-        el.addEventListener('mouseleave', hideHelp);
-    });
+    // Allow other scripts to attach help to dynamically created inputs
+    window.initInputHelp = function(root = document) {
+        root.querySelectorAll('input[data-help], select[data-help]').forEach(el => {
+            el.addEventListener('focus', () => showHelp(el));
+            el.addEventListener('blur', hideHelp);
+            el.addEventListener('mouseenter', () => showHelp(el));
+            el.addEventListener('mouseleave', hideHelp);
+        });
+    };
+
+    // Initialise for existing elements
+    window.initInputHelp();
 });

--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -39,6 +39,7 @@ const init = () => {
 
     'yearly_dashboard.html': `Analyse totals for a chosen year using charts and tables. Look through the months to see how spending and income evolved as the year progressed. This broader view helps you understand whether you are meeting your long‑term goals and where you might need to cut back.`,
     'recurring_spend.html': `Identify expenses that recur over the past year so you are aware of ongoing commitments. The page highlights regular payments like subscriptions or rent and shows how much they cost overall. Spotting these repeated charges helps you decide which ones are essential and which could be reduced or cancelled.`,
+    'palette.html': `Customise segment colours for charts and reports. Pick a seed colour, adjust segment hues and lock any you want to keep. Use Refresh to regenerate unlocked colours and Apply to save your palette.`,
     'pivot.html': `Explore transactions with a pivot table. Choose a year or view all records to break down amounts by category, month or other fields. Use the export options to save the results for further analysis.`
 
   };

--- a/frontend/js/palette_ui.js
+++ b/frontend/js/palette_ui.js
@@ -30,8 +30,8 @@ function buildSegmentInputs() {
     div.innerHTML = `
       <div class="flex items-center gap-2">
         <span class="w-32">${seg.name}</span>
-        <input type="color" class="hue" value="${color}">
-        <label class="text-sm"><input type="checkbox" class="lock" ${seg.locked ? 'checked' : ''}> Lock</label>
+        <input type="color" class="hue" value="${color}" data-help="Select a hue for this segment">
+        <label class="text-sm"><input type="checkbox" class="lock" ${seg.locked ? 'checked' : ''} data-help="Keep this colour when refreshing"> Lock</label>
       </div>
       <div class="preview flex mt-2 gap-1"></div>
     `;
@@ -50,6 +50,7 @@ function buildSegmentInputs() {
     });
     container.appendChild(div);
     seg._preview = div.querySelector('.preview');
+    if (window.initInputHelp) window.initInputHelp(div);
   });
 }
 

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -12,9 +12,15 @@
     <main class="flex-1 p-6">
       <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Palette Settings</h1>
       <div class="bg-white p-6 rounded shadow space-y-4">
+        <p class="text-gray-700">Adjust segment colours for charts and reports.</p>
         <label class="block">Seed Colour
-          <input type="color" id="seed" class="ml-2" aria-label="Seed colour picker">
+          <input type="color" id="seed" class="ml-2" aria-label="Seed colour picker" data-help="Base colour for generating the palette">
         </label>
+        <ul class="list-disc pl-5 text-gray-700">
+          <li>Set segment colours using the picker beside each name. Ticking <em>Lock</em> keeps your choice.</li>
+          <li>To reset a segment, untick its <em>Lock</em> box and press <strong>Refresh</strong>.</li>
+          <li>Press <strong>Apply</strong> to save the seed and any locked colours.</li>
+        </ul>
         <p>Segments: <span id="segment-count"></span></p>
         <div id="segments"></div>
         <div class="flex gap-2">
@@ -25,6 +31,8 @@
     </main>
   </div>
   <script src="js/menu.js"></script>
+  <script src="js/input_help.js"></script>
+  <script src="js/overlay.js"></script>
   <script type="module" src="js/palette_ui.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Documented how to set, reset, and save segment colours on the palette page, clarifying Refresh and Apply button behaviour.
- Added input-help hooks for dynamically created palette controls and registered palette help text with the self-help overlay.

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68b9a84fe06c832ea9c45a486568c696