### PR TITLE
Fix parsing of OpenAI budget responses

### DIFF
--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -120,7 +120,7 @@ try {
         exit;
     }
     $data = json_decode($response, true);
-    $content = $data['output'][0]['content'][0]['text'] ?? '';
+    $content = $data['output_text'] ?? ($data['output'][0]['content'][0]['text'] ?? '');
     $usage = $data['usage']['total_tokens'] ?? 0;
 
     $content = trim($content);


### PR DESCRIPTION
## Summary
- Handle `output_text` field from OpenAI Responses API when decoding AI budget suggestions

## Testing
- `php tests/run_tests.php` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a901f7e4832ea3990742d4f0574b