### PR TITLE
Apply palette colors to segment-category graphs

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -439,10 +439,22 @@
     function renderHierarchyCharts(data){
         const edges = data.filter(d => d.parent).map(d => [d.parent, d.id]);
 
-        const nodes = data.map((d, i) => ({ id: d.id, name: d.name, color: d.color || chartColors[i % chartColors.length] }));
+        const nodes = data.map((d, i) => {
+            let color = d.color;
+            if (!color) {
+                if (d.id.startsWith('seg_')) {
+                    color = getSegmentColor(d.name);
+                } else if (d.id.startsWith('cat_')) {
+                    const parent = data.find(p => p.id === d.parent);
+                    color = getCategoryColor(d.name, parent ? parent.name : null);
+                } else {
+                    color = chartColors[i % chartColors.length];
+                }
+                d.color = color;
+            }
+            return { id: d.id, name: d.name, color };
+        });
         Highcharts.chart('network-graph', {
-            colors: chartColors,
-
             chart: { type: 'networkgraph' },
 
             title: { text: 'Segment / Category Network' },
@@ -454,8 +466,6 @@
             }]
         });
         Highcharts.chart('treegraph-chart', {
-
-            colors: chartColors,
 
             chart: {
                 spacingBottom: 30,


### PR DESCRIPTION
## Summary
- Derive network and tree graph node colors from segment and category palettes

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9a881319c832e9b2c1d4d364f31b2