### PR TITLE
Remove seed palette option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - Projects board page presents each active project as an individual card with key details and actions.
 - Projects board cards display post-description details in a compact table with a smaller font to minimise card size.
 - Colour palettes are generated in OKLCH with an HSL fallback. Palette settings are stored using hue, lightness and chroma parameters rather than hex values.
-- Palette seed colour defaults to the configured colour scheme and updates when the colour scheme changes.
+- Palette generation spaces segment hues using the golden angle without a seed colour.
 
 
 ## Environment

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ sequenceDiagram
 
 ## Palette Generation
 
-The interface offers a seed-driven colour palette. A global seed colour disperses segment hues around the wheel using the golden angle for even spacing. All colour maths use the perceptually uniform OKLCH space with graceful HSL fallbacks when OKLCH is unsupported.
+The interface generates a colour palette by spacing segment hues around the wheel using the golden angle for even distribution. All colour maths use the perceptually uniform OKLCH space with graceful HSL fallbacks when OKLCH is unsupported.
 
 Segment colours are persisted by storing only `hue_deg`, `base_l_pct` and `base_c` values. Shade indices for categories are stored separately. The endpoint `/php_backend/public/palette.php` reads and writes these parameters, while `/php_backend/public/palette_css.php` outputs matching CSS custom properties for non-JavaScript environments.
 
-Updating the seed or segment hues in `frontend/palette.html` regenerates the palette deterministically and ensures text contrast meets WCAG AA.
+Updating segment hues in `frontend/palette.html` regenerates the palette deterministically and ensures text contrast meets WCAG AA.
 - Search and report on transactions in detail.
 - Generate reports using natural-language queries.
 - Back up and restore your data and export it to OFX, CSV, or XLSX.

--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -39,7 +39,7 @@ const init = () => {
 
     'yearly_dashboard.html': `Analyse totals for a chosen year using charts and tables. Look through the months to see how spending and income evolved as the year progressed. This broader view helps you understand whether you are meeting your long‑term goals and where you might need to cut back.`,
     'recurring_spend.html': `Identify expenses that recur over the past year so you are aware of ongoing commitments. The page highlights regular payments like subscriptions or rent and shows how much they cost overall. Spotting these repeated charges helps you decide which ones are essential and which could be reduced or cancelled.`,
-    'palette.html': `Customise segment colours for charts and reports. Pick a seed colour, adjust segment hues and lock any you want to keep. Use Refresh to regenerate unlocked colours and Apply to save your palette.`,
+    'palette.html': `Customise segment colours for charts and reports. Adjust segment hues and lock any you want to keep. Use Refresh to regenerate unlocked colours and Apply to save your palette.`,
     'pivot.html': `Explore transactions with a pivot table. Choose a year or view all records to break down amounts by category, month or other fields. Use the export options to save the results for further analysis.`
 
   };

--- a/frontend/js/palette.js
+++ b/frontend/js/palette.js
@@ -1,6 +1,6 @@
-// Seed-driven palette generation using OKLCH with HSL fallback.
+// Palette generation using OKLCH with HSL fallback.
 // Requires colour.js utilities.
-import {hexToOklch, oklchToHsl, oklchToRgb, contrastRatio} from './colour.js';
+import {oklchToHsl, oklchToRgb, contrastRatio} from './colour.js';
 
 const GOLDEN_ANGLE = 137.50776405;
 
@@ -8,8 +8,8 @@ export function supportsOklch() {
   return CSS && CSS.supports && CSS.supports('color', 'oklch(50% 0.1 40)');
 }
 
-export function generatePalette(seedHex, segments, shadeCount = 7) {
-  const seed = hexToOklch(seedHex);
+export function generatePalette(segments, shadeCount = 7) {
+  const startHue = 0;
   const used = new Set(
     segments
       .filter(s => s.locked && s.hue_deg !== null)
@@ -21,7 +21,7 @@ export function generatePalette(seedHex, segments, shadeCount = 7) {
     if (seg.locked && seg.hue_deg !== null) {
       h = seg.hue_deg;
     } else {
-      h = (seed.h + i * GOLDEN_ANGLE) % 360;
+      h = (startHue + i * GOLDEN_ANGLE) % 360;
       while (used.has(Math.round(h))) {
         h = (h + GOLDEN_ANGLE) % 360;
       }

--- a/frontend/js/palette_ui.js
+++ b/frontend/js/palette_ui.js
@@ -1,21 +1,15 @@
 import {generatePalette, applyCss, supportsOklch} from './palette.js';
 import {hexToOklch, oklchToHex} from './colour.js';
 
-const state = { seed: '#ff0000', segments: [] };
+const state = { segments: [] };
 
 document.addEventListener('DOMContentLoaded', async () => {
   const res = await fetch('../php_backend/public/palette.php', {cache: 'no-store'});
   const data = await res.json();
-  state.seed = data.seed || '#ff0000';
   state.segments = data.segments;
-  document.getElementById('seed').value = state.seed;
   document.getElementById('segment-count').textContent = state.segments.length;
   buildSegmentInputs();
   update();
-  document.getElementById('seed').addEventListener('input', e => {
-    state.seed = e.target.value;
-    update();
-  });
   document.getElementById('apply').addEventListener('click', save);
   document.getElementById('refresh').addEventListener('click', update);
 });
@@ -55,7 +49,7 @@ function buildSegmentInputs() {
 }
 
 function update() {
-  generatePalette(state.seed, state.segments);
+  generatePalette(state.segments);
   applyCss(state.segments);
   renderPreview();
 }
@@ -79,7 +73,6 @@ function renderPreview() {
 
 async function save() {
   const payload = {
-    seed: state.seed,
     segments: state.segments.map(s => ({
       id: s.id,
       hue_deg: s.hue_deg,

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -13,14 +13,10 @@
       <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Palette Settings</h1>
 
       <div class="bg-white p-6 rounded shadow border border-gray-400 space-y-4">
-
-        <label class="block">Seed Colour
-          <input type="color" id="seed" class="ml-2" aria-label="Seed colour picker" data-help="Base colour for generating the palette">
-        </label>
         <ul class="list-disc pl-5 text-gray-700">
           <li>Set segment colours using the picker beside each name. Ticking <em>Lock</em> keeps your choice.</li>
           <li>To reset a segment, untick its <em>Lock</em> box and press <strong>Refresh</strong>.</li>
-          <li>Press <strong>Apply</strong> to save the seed and any locked colours.</li>
+          <li>Press <strong>Apply</strong> to save any locked colours.</li>
         </ul>
         <p>Segments: <span id="segment-count"></span></p>
         <div id="segments"></div>

--- a/php_backend/public/palette.php
+++ b/php_backend/public/palette.php
@@ -2,7 +2,6 @@
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Segment.php';
 require_once __DIR__ . '/../models/Category.php';
-require_once __DIR__ . '/../models/Setting.php';
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
@@ -13,30 +12,11 @@ $input = json_decode(file_get_contents('php://input'), true) ?? [];
 try {
     switch ($method) {
         case 'GET':
-            $seed = Setting::get('palette_seed');
-            if (!$seed) {
-                $brand = Setting::getBrand();
-                $colorMap = [
-                    'indigo' => '#4f46e5',
-                    'blue'   => '#2563eb',
-                    'green'  => '#059669',
-                    'red'    => '#dc2626',
-                    'purple' => '#9333ea',
-                    'teal'   => '#0d9488',
-                    'orange' => '#ea580c',
-                ];
-                $seed = $colorMap[$brand['color_scheme']] ?? '#4f46e5';
-            }
             echo json_encode([
-                'seed' => $seed,
                 'segments' => Segment::allWithCategories()
             ]);
             break;
         case 'POST':
-            if (isset($input['seed'])) {
-                Setting::set('palette_seed', (string)$input['seed']);
-                Log::write('Updated palette seed');
-            }
             if (!empty($input['segments']) && is_array($input['segments'])) {
                 foreach ($input['segments'] as $seg) {
                     Segment::updatePalette(

--- a/settings.php
+++ b/settings.php
@@ -39,7 +39,6 @@ $colorMap = [
     'teal'   => '#0d9488',
     'orange' => '#ea580c',
 ];
-$paletteSeed = Setting::get('palette_seed');
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $openai = trim($_POST['openai_api_token'] ?? '');
@@ -95,14 +94,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($newColorScheme !== $colorScheme) {
             Setting::set('color_scheme', $newColorScheme);
             Log::write('Updated color scheme');
-            if (isset($colorMap[$newColorScheme])) {
-                Setting::set('palette_seed', $colorMap[$newColorScheme]);
-                Log::write('Updated palette seed to match color scheme');
-            }
             $colorScheme = $newColorScheme;
-        } elseif (($paletteSeed === null || $paletteSeed === '') && isset($colorMap[$newColorScheme])) {
-            Setting::set('palette_seed', $colorMap[$newColorScheme]);
-            Log::write('Updated palette seed to match color scheme');
         }
     }
     $message = 'Settings updated.';


### PR DESCRIPTION
## Summary
- Drop seed colour field from palette settings and related backend logic
- Simplify palette generation to space hues without a seed value
- Update docs and help text to reflect seedless palette behaviour

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9ade380b8832eb666d3d8c00d2106