### PR TITLE
Use site title in PDF report

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -357,7 +357,10 @@
         doc.rect(0, 0, pageWidth, 20, 'F');
         doc.setTextColor(255, 255, 255);
         doc.setFontSize(16);
-        doc.text('Accounts - Transaction Report', 14, 12);
+        const siteTitle = document.querySelector('#site-title')?.textContent?.trim() || 'Accounts';
+        const reportTitle = `${siteTitle} - Transaction Report`;
+        doc.text(reportTitle, 14, 12);
+        doc.setProperties({ title: reportTitle });
 
         // Description
         doc.setTextColor(0, 0, 0);


### PR DESCRIPTION
## Summary
- Use the configured site title when generating PDF reports, applying it to the header and document metadata.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9ae884b08832ea08aca7a9f118465