### PR TITLE
Add AI debug mode for troubleshooting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - AI integrations use the OpenAI Responses API with JSON text via `text.format` responses.
 - Set `text.format.type` to `json_object` when requesting JSON responses.
 - AI model and temperature are configurable via `ai_model` and `ai_temperature` settings.
+- AI debug output can be toggled with `ai_debug` to expose request and response details.
 - Projects support archiving via an `archived` flag and can be restored from the Archived Projects page.
 
 - Projects view visualises benefits using a bubble chart plotting cost vs quality with bubble size representing score, displaying each project as its own series for distinct colours.

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -21,6 +21,7 @@
                 <i class="fas fa-comments-dollar inline w-4 h-4 mr-1"></i>Generate Feedback
             </button>
             <div id="result" class="mt-4 whitespace-pre-wrap"></div>
+            <pre id="debug" class="mt-4 text-xs bg-gray-100 p-2 overflow-x-auto hidden"></pre>
         </section>
     </main>
 </div>
@@ -30,6 +31,7 @@
 <script>
 document.getElementById('run').addEventListener('click', async () => {
     const result = document.getElementById('result');
+    const debugEl = document.getElementById('debug');
     const btn = document.getElementById('run');
     btn.disabled = true;
     btn.classList.add('opacity-50', 'cursor-not-allowed');
@@ -44,9 +46,16 @@ document.getElementById('run').addEventListener('click', async () => {
             result.textContent = data.feedback;
             showMessage('AI feedback ready');
         }
+        if (data.debug) {
+            debugEl.textContent = JSON.stringify(data.debug, null, 2);
+            debugEl.classList.remove('hidden');
+        } else {
+            debugEl.classList.add('hidden');
+        }
     } catch (e) {
         result.textContent = 'Request failed';
         showMessage('AI feedback failed', 'error');
+        debugEl.classList.add('hidden');
     } finally {
         btn.disabled = false;
         btn.classList.remove('opacity-50', 'cursor-not-allowed');

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -30,6 +30,7 @@
             <p class="mb-4">Use AI to suggest tags and categories for untagged transactions.</p>
             <button id="run" class="bg-green-600 text-white px-4 py-2 rounded"><i class="fas fa-robot inline w-4 h-4 mr-1"></i>Run AI Tagging</button>
             <div id="result" class="mt-4"></div>
+            <pre id="debug" class="mt-4 text-xs bg-gray-100 p-2 overflow-x-auto hidden"></pre>
         </section>
     </main>
 </div>
@@ -55,6 +56,7 @@ document.getElementById('save-token').addEventListener('click', async () => {
 
 document.getElementById('run').addEventListener('click', async () => {
     const resultEl = document.getElementById('result');
+    const debugEl = document.getElementById('debug');
     const btn = document.getElementById('run');
     btn.disabled = true;
     btn.classList.add('opacity-50', 'cursor-not-allowed');
@@ -71,9 +73,16 @@ document.getElementById('run').addEventListener('click', async () => {
             resultEl.textContent = `Tagged ${data.processed} transactions using ${data.tokens} tokens.`;
             showMessage('AI tagging complete');
         }
+        if (data.debug) {
+            debugEl.textContent = JSON.stringify(data.debug, null, 2);
+            debugEl.classList.remove('hidden');
+        } else {
+            debugEl.classList.add('hidden');
+        }
     } catch (e) {
         resultEl.textContent = 'Request failed';
         showMessage('AI tagging failed', 'error');
+        debugEl.classList.add('hidden');
     } finally {
         btn.disabled = false;
         btn.classList.remove('opacity-50', 'cursor-not-allowed');

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -37,6 +37,7 @@
                 <button id="ai-run" type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end"><i class="fas fa-robot inline w-4 h-4 mr-1"></i>Generate Budgets</button>
             </form>
             <div id="ai-result" class="mt-4"></div>
+            <pre id="ai-debug" class="mt-4 text-xs bg-gray-100 p-2 overflow-x-auto hidden"></pre>
 
         </section>
         <section>
@@ -157,6 +158,7 @@ document.getElementById('ai-form').addEventListener('submit',async e=>{
     const goal=document.getElementById('goal').value;
 
     const resultEl=document.getElementById('ai-result');
+    const debugEl=document.getElementById('ai-debug');
     const btn=document.getElementById('ai-run');
     btn.disabled=true;
     btn.classList.add('opacity-50','cursor-not-allowed');
@@ -179,9 +181,16 @@ document.getElementById('ai-form').addEventListener('submit',async e=>{
             resultEl.textContent=data.error||'AI budgeting failed.';
             showMessage('AI budgeting failed','error');
         }
+        if(data.debug){
+            debugEl.textContent=JSON.stringify(data.debug,null,2);
+            debugEl.classList.remove('hidden');
+        }else{
+            debugEl.classList.add('hidden');
+        }
     }catch(err){
         resultEl.textContent='Request failed';
         showMessage('AI budgeting failed','error');
+        debugEl.classList.add('hidden');
     }finally{
         btn.disabled=false;
         btn.classList.remove('opacity-50','cursor-not-allowed');

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -25,6 +25,7 @@
                     <input type="text" id="nl-query" class="border p-2 rounded w-full" placeholder="e.g., costs for cars in the last 12 months" data-help="Describe the report you want in plain English">
                 </label>
                 <div id="ai-status" class="md:col-span-3 text-sm text-gray-600 hidden" aria-live="polite"></div>
+                <pre id="ai-debug" class="md:col-span-3 text-xs bg-gray-100 p-2 overflow-x-auto hidden"></pre>
                 <label class="block">Category: <select id="category" multiple class="border p-2 rounded w-full" data-help="Filter by category"></select></label>
                 <label class="block">Tag: <select id="tag" multiple class="border p-2 rounded w-full" data-help="Filter by tag"></select></label>
                 <label class="block">Group: <select id="group" multiple class="border p-2 rounded w-full" data-help="Filter by group"></select></label>
@@ -192,6 +193,7 @@
     async function runReport() {
         const nl = document.getElementById('nl-query').value.trim();
         const aiStatus = document.getElementById('ai-status');
+        const aiDebug = document.getElementById('ai-debug');
         if (nl) {
 
             aiStatus.textContent = 'Submitting query to AI...';
@@ -210,14 +212,22 @@
                 document.getElementById('text').value = filters.text || '';
                 document.getElementById('start').value = filters.start || '';
                 document.getElementById('end').value = filters.end || '';
-                aiStatus.textContent = filters.summary || 'AI suggestions applied';
+                aiStatus.textContent = filters.error || filters.summary || 'AI suggestions applied';
+                if (filters.debug) {
+                    aiDebug.textContent = JSON.stringify(filters.debug, null, 2);
+                    aiDebug.classList.remove('hidden');
+                } else {
+                    aiDebug.classList.add('hidden');
+                }
             } catch (e) {
                 aiStatus.textContent = 'AI request failed';
+                aiDebug.classList.add('hidden');
             }
 
             document.getElementById('nl-query').value = '';
         } else {
             aiStatus.classList.add('hidden');
+            aiDebug.classList.add('hidden');
         }
 
         const category = getSelectedValues(window.catChoices);

--- a/settings.php
+++ b/settings.php
@@ -15,6 +15,7 @@ $openai = Setting::get('openai_api_token') ?? '';
 $batch = Setting::get('ai_tag_batch_size') ?? '20';
 $aiModel = Setting::get('ai_model') ?? 'gpt-5-nano';
 $aiTemp = Setting::get('ai_temperature') ?? '1';
+$aiDebug = Setting::get('ai_debug') === '1';
 $retention = Setting::get('log_retention_days') ?? '30';
 $timeout = Setting::get('session_timeout_minutes') ?? '0';
 $fontSettings = Setting::getFonts();
@@ -46,6 +47,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $batch = trim($_POST['ai_tag_batch_size'] ?? '');
     $aiModel = trim($_POST['ai_model'] ?? '');
     $aiTemp = trim($_POST['ai_temperature'] ?? '');
+    $aiDebug = isset($_POST['ai_debug']);
     $retention = trim($_POST['log_retention_days'] ?? '');
     $timeout = trim($_POST['session_timeout_minutes'] ?? '');
     $fontHeading = trim($_POST['font_heading'] ?? '');
@@ -67,6 +69,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         Setting::set('ai_temperature', $aiTemp);
         Log::write('Updated AI temperature');
     }
+    Setting::set('ai_debug', $aiDebug ? '1' : '0');
+    Log::write('Updated AI debug mode');
     if ($retention !== '') {
         Setting::set('log_retention_days', $retention);
         Log::write('Updated log retention days');
@@ -158,6 +162,9 @@ $bg600 = "bg-{$colorScheme}-600";
             </label>
             <label class="block">AI Temperature:
                 <input type="number" step="0.1" name="ai_temperature" value="<?= htmlspecialchars($aiTemp) ?>" class="border p-2 rounded w-full" data-help="Creativity level for AI responses">
+            </label>
+            <label class="block">AI Debug Mode:
+                <input type="checkbox" name="ai_debug" value="1" <?= $aiDebug ? 'checked' : '' ?> class="ml-2" data-help="Show AI request and response details on pages for troubleshooting">
             </label>
             <label class="block">Log Retention Days:
                 <input type="number" name="log_retention_days" value="<?= htmlspecialchars($retention) ?>" class="border p-2 rounded w-full" data-help="Automatically prune logs older than this many days">


### PR DESCRIPTION
## Summary
- Return AI request/response details when calls error out to aid debugging
- Surface debug metadata in natural language report parsing with fallback filters
- Show any collected debug info on the report page regardless of success

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68b9ae3398a0832e83993cd03e485627