### PR TITLE
Apply palette shading to donut and sunburst charts

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -128,12 +128,20 @@
         // Create hierarchical data for either income or outgoing values
         function createData(isIncome){
             const data = [{ id: 'root', parent: '', name: '' }];
+            const segmentIds = {};
             categories.forEach(c => {
                 const total = parseFloat(c.total);
                 if ((isIncome && total > 0) || (!isIncome && total < 0)) {
-                    const color = getCategoryColor(c.name, c.segment_name);
+                    const segName = c.segment_name || 'Not Segmented';
+                    let segId = segmentIds[segName];
+                    if (!segId) {
+                        segId = 'seg_' + segName.replace(/\s+/g, '_');
+                        segmentIds[segName] = segId;
+                        data.push({ id: segId, parent: 'root', name: segName, color: getSegmentColor(segName) });
+                    }
+                    const color = getCategoryColor(c.name, segName);
                     const catId = c.name;
-                    data.push({ id: catId, parent: 'root', name: c.name, value: Math.abs(total), color });
+                    data.push({ id: catId, parent: segId, name: c.name, value: Math.abs(total), color });
                     tags.filter(t => t.category === c.name && ((isIncome && parseFloat(t.total) > 0) || (!isIncome && parseFloat(t.total) < 0))).forEach(t => {
                         data.push({
                             name: t.name,

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -150,12 +150,20 @@
         // Create hierarchical data for income or outgoings
         function createData(isIncome){
             const data = [{ id: 'root', parent: '', name: '' }];
+            const segmentIds = {};
             categories.forEach(c => {
                 const total = parseFloat(c.total);
                 if ((isIncome && total > 0) || (!isIncome && total < 0)) {
-                    const color = getCategoryColor(c.name, c.segment_name);
+                    const segName = c.segment_name || 'Not Segmented';
+                    let segId = segmentIds[segName];
+                    if (!segId) {
+                        segId = 'seg_' + segName.replace(/\s+/g, '_');
+                        segmentIds[segName] = segId;
+                        data.push({ id: segId, parent: 'root', name: segName, color: getSegmentColor(segName) });
+                    }
+                    const color = getCategoryColor(c.name, segName);
                     const catId = c.name;
-                    data.push({ id: catId, parent: 'root', name: c.name, value: Math.abs(total), color });
+                    data.push({ id: catId, parent: segId, name: c.name, value: Math.abs(total), color });
                     tags.filter(t => t.category === c.name && ((isIncome && parseFloat(t.total) > 0) || (!isIncome && parseFloat(t.total) < 0))).forEach(t => {
                         data.push({
                             name: t.name,

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -88,8 +88,9 @@
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="js/color_map.js"></script>
 
-    
+
 <script>
 const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
@@ -391,7 +392,7 @@ function buildDonutChart(spendings, prevSpendings){
     const data = Object.entries(spendings).map(([cat, total]) => {
         const prev = prevSpendings[cat] || 0;
         const change = total - prev;
-        const color = change > 0 ? '#dc2626' : (change < 0 ? '#16a34a' : '#9ca3af');
+        const color = getCategoryColor(cat);
         return { name: cat, y: parseFloat(total.toFixed(2)), color, change };
     });
     Highcharts.chart('category-donut', {

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -132,12 +132,20 @@
         // Build hierarchical series data filtered by income or outgoings
         function createData(isIncome){
             const data = [{ id: 'root', parent: '', name: '' }];
+            const segmentIds = {};
             categories.forEach(c => {
                 const total = parseFloat(c.total);
                 if ((isIncome && total > 0) || (!isIncome && total < 0)) {
-                    const color = getCategoryColor(c.name, c.segment_name);
+                    const segName = c.segment_name || 'Not Segmented';
+                    let segId = segmentIds[segName];
+                    if (!segId) {
+                        segId = 'seg_' + segName.replace(/\s+/g, '_');
+                        segmentIds[segName] = segId;
+                        data.push({ id: segId, parent: 'root', name: segName, color: getSegmentColor(segName) });
+                    }
+                    const color = getCategoryColor(c.name, segName);
                     const catId = c.name;
-                    data.push({ id: catId, parent: 'root', name: c.name, value: Math.abs(total), color });
+                    data.push({ id: catId, parent: segId, name: c.name, value: Math.abs(total), color });
                     tags.filter(t => t.category === c.name && ((isIncome && parseFloat(t.total) > 0) || (!isIncome && parseFloat(t.total) < 0))).forEach(t => {
                         data.push({
                             name: t.name,


### PR DESCRIPTION
## Summary
- Add shared palette loader to monthly statement and color donut categories by segment-derived shades
- Build sunburst charts with segment nodes and category colours derived from their segments across dashboards

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9b9ef7878832eac68b72e14002e4b