### PR TITLE
Show AI debug requests and responses in cards

### DIFF
--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -21,7 +21,15 @@
                 <i class="fas fa-comments-dollar inline w-4 h-4 mr-1"></i>Generate Feedback
             </button>
             <div id="result" class="mt-4 whitespace-pre-wrap"></div>
-            <pre id="debug" class="mt-4 text-xs bg-gray-100 p-2 overflow-x-auto hidden"></pre>
+            <div id="debug" class="mt-4 hidden">
+                <div class="bg-white p-4 rounded shadow border border-gray-400">
+                    <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
+                    <p class="text-sm font-semibold">Request</p>
+                    <pre id="debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
+                    <p class="text-sm font-semibold">Response</p>
+                    <pre id="debug-response" class="text-xs bg-gray-100 p-2 overflow-x-auto"></pre>
+                </div>
+            </div>
         </section>
     </main>
 </div>
@@ -31,7 +39,9 @@
 <script>
 document.getElementById('run').addEventListener('click', async () => {
     const result = document.getElementById('result');
-    const debugEl = document.getElementById('debug');
+    const debugContainer = document.getElementById('debug');
+    const debugReq = document.getElementById('debug-request');
+    const debugRes = document.getElementById('debug-response');
     const btn = document.getElementById('run');
     btn.disabled = true;
     btn.classList.add('opacity-50', 'cursor-not-allowed');
@@ -47,15 +57,17 @@ document.getElementById('run').addEventListener('click', async () => {
             showMessage('AI feedback ready');
         }
         if (data.debug) {
-            debugEl.textContent = JSON.stringify(data.debug, null, 2);
-            debugEl.classList.remove('hidden');
+            debugReq.textContent = JSON.stringify(data.debug.request, null, 2);
+            const resp = typeof data.debug.response === 'string' ? data.debug.response : JSON.stringify(data.debug.response, null, 2);
+            debugRes.textContent = resp;
+            debugContainer.classList.remove('hidden');
         } else {
-            debugEl.classList.add('hidden');
+            debugContainer.classList.add('hidden');
         }
     } catch (e) {
         result.textContent = 'Request failed';
         showMessage('AI feedback failed', 'error');
-        debugEl.classList.add('hidden');
+        debugContainer.classList.add('hidden');
     } finally {
         btn.disabled = false;
         btn.classList.remove('opacity-50', 'cursor-not-allowed');

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -30,7 +30,15 @@
             <p class="mb-4">Use AI to suggest tags and categories for untagged transactions.</p>
             <button id="run" class="bg-green-600 text-white px-4 py-2 rounded"><i class="fas fa-robot inline w-4 h-4 mr-1"></i>Run AI Tagging</button>
             <div id="result" class="mt-4"></div>
-            <pre id="debug" class="mt-4 text-xs bg-gray-100 p-2 overflow-x-auto hidden"></pre>
+            <div id="debug" class="mt-4 hidden">
+                <div class="bg-white p-4 rounded shadow border border-gray-400">
+                    <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
+                    <p class="text-sm font-semibold">Request</p>
+                    <pre id="debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
+                    <p class="text-sm font-semibold">Response</p>
+                    <pre id="debug-response" class="text-xs bg-gray-100 p-2 overflow-x-auto"></pre>
+                </div>
+            </div>
         </section>
     </main>
 </div>
@@ -56,7 +64,9 @@ document.getElementById('save-token').addEventListener('click', async () => {
 
 document.getElementById('run').addEventListener('click', async () => {
     const resultEl = document.getElementById('result');
-    const debugEl = document.getElementById('debug');
+    const debugContainer = document.getElementById('debug');
+    const debugReq = document.getElementById('debug-request');
+    const debugRes = document.getElementById('debug-response');
     const btn = document.getElementById('run');
     btn.disabled = true;
     btn.classList.add('opacity-50', 'cursor-not-allowed');
@@ -74,15 +84,17 @@ document.getElementById('run').addEventListener('click', async () => {
             showMessage('AI tagging complete');
         }
         if (data.debug) {
-            debugEl.textContent = JSON.stringify(data.debug, null, 2);
-            debugEl.classList.remove('hidden');
+            debugReq.textContent = JSON.stringify(data.debug.request, null, 2);
+            const resp = typeof data.debug.response === 'string' ? data.debug.response : JSON.stringify(data.debug.response, null, 2);
+            debugRes.textContent = resp;
+            debugContainer.classList.remove('hidden');
         } else {
-            debugEl.classList.add('hidden');
+            debugContainer.classList.add('hidden');
         }
     } catch (e) {
         resultEl.textContent = 'Request failed';
         showMessage('AI tagging failed', 'error');
-        debugEl.classList.add('hidden');
+        debugContainer.classList.add('hidden');
     } finally {
         btn.disabled = false;
         btn.classList.remove('opacity-50', 'cursor-not-allowed');

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -37,7 +37,15 @@
                 <button id="ai-run" type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end"><i class="fas fa-robot inline w-4 h-4 mr-1"></i>Generate Budgets</button>
             </form>
             <div id="ai-result" class="mt-4"></div>
-            <pre id="ai-debug" class="mt-4 text-xs bg-gray-100 p-2 overflow-x-auto hidden"></pre>
+            <div id="ai-debug" class="mt-4 hidden">
+                <div class="bg-white p-4 rounded shadow border border-gray-400">
+                    <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
+                    <p class="text-sm font-semibold">Request</p>
+                    <pre id="ai-debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
+                    <p class="text-sm font-semibold">Response</p>
+                    <pre id="ai-debug-response" class="text-xs bg-gray-100 p-2 overflow-x-auto"></pre>
+                </div>
+            </div>
 
         </section>
         <section>
@@ -158,7 +166,9 @@ document.getElementById('ai-form').addEventListener('submit',async e=>{
     const goal=document.getElementById('goal').value;
 
     const resultEl=document.getElementById('ai-result');
-    const debugEl=document.getElementById('ai-debug');
+    const debugContainer=document.getElementById('ai-debug');
+    const debugReq=document.getElementById('ai-debug-request');
+    const debugRes=document.getElementById('ai-debug-response');
     const btn=document.getElementById('ai-run');
     btn.disabled=true;
     btn.classList.add('opacity-50','cursor-not-allowed');
@@ -182,15 +192,17 @@ document.getElementById('ai-form').addEventListener('submit',async e=>{
             showMessage('AI budgeting failed','error');
         }
         if(data.debug){
-            debugEl.textContent=JSON.stringify(data.debug,null,2);
-            debugEl.classList.remove('hidden');
+            debugReq.textContent=JSON.stringify(data.debug.request,null,2);
+            const resp=typeof data.debug.response==='string'?data.debug.response:JSON.stringify(data.debug.response,null,2);
+            debugRes.textContent=resp;
+            debugContainer.classList.remove('hidden');
         }else{
-            debugEl.classList.add('hidden');
+            debugContainer.classList.add('hidden');
         }
     }catch(err){
         resultEl.textContent='Request failed';
         showMessage('AI budgeting failed','error');
-        debugEl.classList.add('hidden');
+        debugContainer.classList.add('hidden');
     }finally{
         btn.disabled=false;
         btn.classList.remove('opacity-50','cursor-not-allowed');

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -25,7 +25,15 @@
                     <input type="text" id="nl-query" class="border p-2 rounded w-full" placeholder="e.g., costs for cars in the last 12 months" data-help="Describe the report you want in plain English">
                 </label>
                 <div id="ai-status" class="md:col-span-3 text-sm text-gray-600 hidden" aria-live="polite"></div>
-                <pre id="ai-debug" class="md:col-span-3 text-xs bg-gray-100 p-2 overflow-x-auto hidden"></pre>
+                <div id="ai-debug" class="md:col-span-3 hidden">
+                    <div class="bg-white p-4 rounded shadow border border-gray-400">
+                        <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
+                        <p class="text-sm font-semibold">Request</p>
+                        <pre id="ai-debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
+                        <p class="text-sm font-semibold">Response</p>
+                        <pre id="ai-debug-response" class="text-xs bg-gray-100 p-2 overflow-x-auto"></pre>
+                    </div>
+                </div>
                 <label class="block">Category: <select id="category" multiple class="border p-2 rounded w-full" data-help="Filter by category"></select></label>
                 <label class="block">Tag: <select id="tag" multiple class="border p-2 rounded w-full" data-help="Filter by tag"></select></label>
                 <label class="block">Group: <select id="group" multiple class="border p-2 rounded w-full" data-help="Filter by group"></select></label>
@@ -193,7 +201,9 @@
     async function runReport() {
         const nl = document.getElementById('nl-query').value.trim();
         const aiStatus = document.getElementById('ai-status');
-        const aiDebug = document.getElementById('ai-debug');
+        const aiDebugContainer = document.getElementById('ai-debug');
+        const aiDebugReq = document.getElementById('ai-debug-request');
+        const aiDebugRes = document.getElementById('ai-debug-response');
         if (nl) {
 
             aiStatus.textContent = 'Submitting query to AI...';
@@ -214,20 +224,22 @@
                 document.getElementById('end').value = filters.end || '';
                 aiStatus.textContent = filters.summary || 'AI suggestions applied';
                 if (filters.debug) {
-                    aiDebug.textContent = JSON.stringify(filters.debug, null, 2);
-                    aiDebug.classList.remove('hidden');
+                    aiDebugReq.textContent = JSON.stringify(filters.debug.request, null, 2);
+                    const resp = typeof filters.debug.response === 'string' ? filters.debug.response : JSON.stringify(filters.debug.response, null, 2);
+                    aiDebugRes.textContent = resp;
+                    aiDebugContainer.classList.remove('hidden');
                 } else {
-                    aiDebug.classList.add('hidden');
+                    aiDebugContainer.classList.add('hidden');
                 }
             } catch (e) {
                 aiStatus.textContent = 'AI request failed';
-                aiDebug.classList.add('hidden');
+                aiDebugContainer.classList.add('hidden');
             }
 
             document.getElementById('nl-query').value = '';
         } else {
             aiStatus.classList.add('hidden');
-            aiDebug.classList.add('hidden');
+            aiDebugContainer.classList.add('hidden');
         }
 
         const category = getSelectedValues(window.catChoices);


### PR DESCRIPTION
## Summary
- Display AI debugging info in card components across AI Budgeting, Feedback, Tags, and Report pages
- Split debug output into separate request and response blocks for clarity

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68b9bc331868832e90525c9c3b128632