### PR TITLE
Add range selector for account history

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -20,6 +20,14 @@
             <h1 id="account-name" class="text-2xl font-semibold mb-4 text-indigo-700">Account Balance</h1>
             <p id="account-details" class="mb-4 text-gray-600"></p>
             <p class="mb-4">View the balance over time based on the latest bank statement.</p>
+            <label for="range-select" class="block mb-4">Range:
+                <select id="range-select" class="border p-2 rounded" data-help="Select time range">
+                    <option value="1">Last Month</option>
+                    <option value="3">Last 3 Months</option>
+                    <option value="12">Last Year</option>
+                    <option value="all">All</option>
+                </select>
+            </label>
             <div class="bg-white p-6 rounded shadow border border-gray-400">
                 <div id="balance-chart" style="height:400px" data-chart-desc="Line chart of account balance over time."></div>
             </div>
@@ -59,8 +67,19 @@
 
     const params = new URLSearchParams(window.location.search);
     const id = params.get('id');
-    if (id) {
-        fetch(`../php_backend/public/account_balance.php?id=${id}`)
+
+    function loadRange(range){
+        if (!id) {
+            document.getElementById('balance-chart').textContent = 'No account specified.';
+            return;
+        }
+        let balanceUrl = `../php_backend/public/account_balance.php?id=${id}`;
+        let stmtUrl = `../php_backend/public/account_statement.php?id=${id}`;
+        if (range !== 'all') {
+            balanceUrl += `&months=${range}`;
+            stmtUrl += `&months=${range}`;
+        }
+        fetch(balanceUrl)
             .then(r => r.json())
             .then(data => {
                 if (data.error) {
@@ -82,11 +101,12 @@
                 });
             });
 
-
-        fetch(`../php_backend/public/account_statement.php?id=${id}`)
+        fetch(stmtUrl)
             .then(r => r.json())
             .then(rows => {
-                tailwindTabulator(document.getElementById('statement-table'), {
+                const tableEl = document.getElementById('statement-table');
+                tableEl.innerHTML = '';
+                tailwindTabulator(tableEl, {
                     data: rows,
                     layout: 'fitDataStretch',
                     rowClick: (e, row) => {
@@ -99,10 +119,11 @@
                     ]
                 });
             });
-
-    } else {
-        document.getElementById('balance-chart').textContent = 'No account specified.';
     }
+
+    const rangeSelect = document.getElementById('range-select');
+    rangeSelect.addEventListener('change', () => loadRange(rangeSelect.value));
+    loadRange(rangeSelect.value);
     </script>
     <script src="js/overlay.js"></script>
 </body>

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -288,7 +288,7 @@ class Transaction {
     /**
      * Retrieve all transactions for a specific account ordered by date.
      */
-    public static function getByAccount(int $accountId): array {
+    public static function getByAccount(int $accountId, ?string $startDate = null): array {
         $db = Database::getConnection();
         $ignore = Tag::getIgnoreId();
         $sql = 'SELECT t.`id`, t.`date`, t.`amount`, t.`description`, t.`memo`, '
@@ -299,10 +299,17 @@ class Transaction {
              . 'LEFT JOIN `tags` tg ON t.`tag_id` = tg.`id` '
              . 'LEFT JOIN `transaction_groups` g ON t.`group_id` = g.`id` '
              . 'WHERE t.`account_id` = :acc '
-             . 'AND (t.`tag_id` IS NULL OR t.`tag_id` != :ignore) '
-             . 'ORDER BY t.`date` DESC, t.`id` DESC';
+             . 'AND (t.`tag_id` IS NULL OR t.`tag_id` != :ignore) ';
+        if ($startDate) {
+            $sql .= 'AND t.`date` >= :start ';
+        }
+        $sql .= 'ORDER BY t.`date` DESC, t.`id` DESC';
         $stmt = $db->prepare($sql);
-        $stmt->execute(['acc' => $accountId, 'ignore' => $ignore]);
+        $params = ['acc' => $accountId, 'ignore' => $ignore];
+        if ($startDate) {
+            $params['start'] = $startDate;
+        }
+        $stmt->execute($params);
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 

--- a/php_backend/public/account_balance.php
+++ b/php_backend/public/account_balance.php
@@ -13,6 +13,15 @@ try {
         throw new Exception('Account id required');
     }
     $id = (int)$_GET['id'];
+    $months = null;
+    if (isset($_GET['months']) && $_GET['months'] !== 'all') {
+        $months = max(1, (int)$_GET['months']);
+    }
+    $cutoff = null;
+    if ($months) {
+        $cutoff = (new DateTime())->modify("-{$months} months")->format('Y-m-d');
+    }
+
     $db = Database::getConnection();
     $stmt = $db->prepare('SELECT name, sort_code, account_number, ledger_balance, ledger_balance_date FROM accounts WHERE id = :id');
     $stmt->execute(['id' => $id]);
@@ -30,9 +39,16 @@ try {
     $stmt->execute(['id' => $id, 'ignore' => $ignore]);
     while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
         $balance -= (float)$row['amount'];
-        $history[] = ['date' => $row['date'], 'balance' => $balance];
+        if (!$cutoff || $row['date'] >= $cutoff) {
+            $history[] = ['date' => $row['date'], 'balance' => $balance];
+        }
     }
     $history = array_reverse($history);
+    if ($cutoff) {
+        $history = array_values(array_filter($history, function($h) use ($cutoff){
+            return $h['date'] >= $cutoff;
+        }));
+    }
     echo json_encode([
         'name' => $account['name'],
         'sort_code' => $account['sort_code'],

--- a/php_backend/public/account_statement.php
+++ b/php_backend/public/account_statement.php
@@ -11,7 +11,15 @@ try {
         throw new Exception('Account id required');
     }
     $id = (int)$_GET['id'];
-    $transactions = Transaction::getByAccount($id);
+    $months = null;
+    if (isset($_GET['months']) && $_GET['months'] !== 'all') {
+        $months = max(1, (int)$_GET['months']);
+    }
+    $startDate = null;
+    if ($months) {
+        $startDate = (new DateTime())->modify("-{$months} months")->format('Y-m-d');
+    }
+    $transactions = Transaction::getByAccount($id, $startDate);
     echo json_encode($transactions);
 } catch (Exception $e) {
     http_response_code(500);


### PR DESCRIPTION
## Summary
- limit account balance view to one month by default
- allow selecting wider ranges including all data
- support range filtering in account history and statements

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68babc3457bc832ebc0823252cddfbc7