### PR TITLE
Expose AI prompts in debug cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - Set `text.format.type` to `json_object` when requesting JSON responses.
 - AI model and temperature are configurable via `ai_model` and `ai_temperature` settings.
 - AI debug output can be toggled with `ai_debug` to expose request and response details.
+- When AI debug is enabled, AI pages show a card displaying the submitted prompt followed by the AI response.
 - Projects support archiving via an `archived` flag and can be restored from the Archived Projects page.
 
 - Projects view visualises benefits using a bubble chart plotting cost vs quality with bubble size representing score, displaying each project as its own series for distinct colours.

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -24,7 +24,7 @@
             <div id="debug" class="mt-4 hidden">
                 <div class="bg-white p-4 rounded shadow border border-gray-400">
                     <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
-                    <p class="text-sm font-semibold">Request</p>
+                    <p class="text-sm font-semibold">Prompt</p>
                     <pre id="debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
                     <p class="text-sm font-semibold">Response</p>
                     <pre id="debug-response" class="text-xs bg-gray-100 p-2 overflow-x-auto"></pre>
@@ -57,7 +57,7 @@ document.getElementById('run').addEventListener('click', async () => {
             showMessage('AI feedback ready');
         }
         if (data.debug) {
-            debugReq.textContent = JSON.stringify(data.debug.request, null, 2);
+            debugReq.textContent = data.debug.prompt;
             const resp = typeof data.debug.response === 'string' ? data.debug.response : JSON.stringify(data.debug.response, null, 2);
             debugRes.textContent = resp;
             debugContainer.classList.remove('hidden');

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -33,7 +33,7 @@
             <div id="debug" class="mt-4 hidden">
                 <div class="bg-white p-4 rounded shadow border border-gray-400">
                     <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
-                    <p class="text-sm font-semibold">Request</p>
+                    <p class="text-sm font-semibold">Prompt</p>
                     <pre id="debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
                     <p class="text-sm font-semibold">Response</p>
                     <pre id="debug-response" class="text-xs bg-gray-100 p-2 overflow-x-auto"></pre>
@@ -84,7 +84,7 @@ document.getElementById('run').addEventListener('click', async () => {
             showMessage('AI tagging complete');
         }
         if (data.debug) {
-            debugReq.textContent = JSON.stringify(data.debug.request, null, 2);
+            debugReq.textContent = data.debug.prompt;
             const resp = typeof data.debug.response === 'string' ? data.debug.response : JSON.stringify(data.debug.response, null, 2);
             debugRes.textContent = resp;
             debugContainer.classList.remove('hidden');

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -40,7 +40,7 @@
             <div id="ai-debug" class="mt-4 hidden">
                 <div class="bg-white p-4 rounded shadow border border-gray-400">
                     <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
-                    <p class="text-sm font-semibold">Request</p>
+                    <p class="text-sm font-semibold">Prompt</p>
                     <pre id="ai-debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
                     <p class="text-sm font-semibold">Response</p>
                     <pre id="ai-debug-response" class="text-xs bg-gray-100 p-2 overflow-x-auto"></pre>
@@ -192,7 +192,7 @@ document.getElementById('ai-form').addEventListener('submit',async e=>{
             showMessage('AI budgeting failed','error');
         }
         if(data.debug){
-            debugReq.textContent=JSON.stringify(data.debug.request,null,2);
+            debugReq.textContent=data.debug.prompt;
             const resp=typeof data.debug.response==='string'?data.debug.response:JSON.stringify(data.debug.response,null,2);
             debugRes.textContent=resp;
             debugContainer.classList.remove('hidden');

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -28,7 +28,7 @@
                 <div id="ai-debug" class="md:col-span-3 hidden">
                     <div class="bg-white p-4 rounded shadow border border-gray-400">
                         <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
-                        <p class="text-sm font-semibold">Request</p>
+                        <p class="text-sm font-semibold">Prompt</p>
                         <pre id="ai-debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
                         <p class="text-sm font-semibold">Response</p>
                         <pre id="ai-debug-response" class="text-xs bg-gray-100 p-2 overflow-x-auto"></pre>
@@ -224,7 +224,7 @@
                 document.getElementById('end').value = filters.end || '';
                 aiStatus.textContent = filters.summary || 'AI suggestions applied';
                 if (filters.debug) {
-                    aiDebugReq.textContent = JSON.stringify(filters.debug.request, null, 2);
+                    aiDebugReq.textContent = filters.debug.prompt;
                     const resp = typeof filters.debug.response === 'string' ? filters.debug.response : JSON.stringify(filters.debug.response, null, 2);
                     aiDebugRes.textContent = resp;
                     aiDebugContainer.classList.remove('hidden');

--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -172,7 +172,7 @@ class NaturalLanguageReportParser {
 
         Log::write('NL report AI filters: ' . json_encode($filters));
         if ($debugMode) {
-            $filters['debug'] = ['request' => $payload, 'response' => $content];
+            $filters['debug'] = ['prompt' => $prompt, 'response' => $content];
         }
         return $filters;
     }

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -153,7 +153,7 @@ try {
     $budgets = Budget::getMonthly($month, $year);
     $out = ['status' => 'ok', 'budgets' => $budgets, 'summary' => $summary];
     if ($debugMode) {
-        $out['debug'] = ['request' => $payload, 'response' => $content];
+        $out['debug'] = ['prompt' => $prompt, 'response' => $content];
     }
     Log::write("AI budgets applied for $month/$year with goal $goal using $usage tokens");
     echo json_encode($out);

--- a/php_backend/public/ai_feedback.php
+++ b/php_backend/public/ai_feedback.php
@@ -112,7 +112,7 @@ try {
     $content = trim($parsed['feedback']);
     $out = ['feedback' => $content, 'tokens' => $usage];
     if ($debugMode) {
-        $out['debug'] = ['request' => $payload, 'response' => $content];
+        $out['debug'] = ['prompt' => $prompt, 'response' => $content];
     }
     Log::write("AI feedback generated using $usage tokens");
     echo json_encode($out);

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -142,7 +142,7 @@ foreach ($suggestions as $s) {
 Log::write("AI tagged $processed transactions using $usage tokens");
  $out = ['processed' => $processed, 'tokens' => $usage];
  if ($debugMode) {
-     $out['debug'] = ['request' => $payload, 'response' => $content];
+     $out['debug'] = ['prompt' => $prompt, 'response' => $content];
  }
  echo json_encode($out);
 // Self-check:


### PR DESCRIPTION
## Summary
- Show AI debug card with submitted prompt and response on all AI pages
- Return prompt string from AI endpoints when debug mode is enabled
- Document debug card behaviour in AGENTS instructions

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68bad01beb6c832eaf98bb93e3bf97ab