### PR TITLE
Handle output_text in AI responses

### DIFF
--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -105,7 +105,7 @@ class NaturalLanguageReportParser {
             Log::write('NL report AI JSON decode failed: ' . $response, 'ERROR');
             return null;
         }
-        $content = $data['output'][0]['content'][0]['text'] ?? '';
+        $content = $data['output_text'] ?? ($data['output'][0]['content'][0]['text'] ?? '');
         Log::write('NL report AI raw content: ' . $content);
 
         $content = trim($content);

--- a/php_backend/public/ai_feedback.php
+++ b/php_backend/public/ai_feedback.php
@@ -93,7 +93,7 @@ try {
         exit;
     }
     $data = json_decode($response, true);
-    $content = $data['output'][0]['content'][0]['text'] ?? '';
+    $content = $data['output_text'] ?? ($data['output'][0]['content'][0]['text'] ?? '');
     $usage = $data['usage']['total_tokens'] ?? 0;
 
     $content = trim($content);

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -79,7 +79,7 @@ if ($response === false || $code !== 200) {
     exit;
 }
 $data = json_decode($response, true);
-$content = $data['output'][0]['content'][0]['text'] ?? '';
+$content = $data['output_text'] ?? ($data['output'][0]['content'][0]['text'] ?? '');
 $usage = $data['usage']['total_tokens'] ?? 0;
 
 


### PR DESCRIPTION
## Summary
- Handle `output_text` field from OpenAI Responses API in NaturalLanguageReportParser
- Read `output_text` fallback in tag and feedback AI endpoints

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68bad590c0cc832e9816b5a29776609d