### PR TITLE
Ensure static pages bypass caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@
 
 - Frontend pages query `php_backend/public/ai_debug.php` to determine whether to display the debug card.
 
+- Static pages must prevent caching via `<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">` tags or equivalent PHP headers.
+
 - Projects support archiving via an `archived` flag and can be restored from the Archived Projects page.
 
 - Projects view visualises benefits using a bubble chart plotting cost vs quality with bubble size representing score, displaying each project as its own series for distinct colours.

--- a/frontend/export.html
+++ b/frontend/export.html
@@ -4,6 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>Exports</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -183,7 +183,7 @@ document.addEventListener('DOMContentLoaded', () => {
       'z-40'
     );
 
-    fetch('menu.html')
+    fetch('menu.php')
       .then(resp => resp.text())
       .then(html => {
         menu.innerHTML = html;

--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -1,3 +1,8 @@
+<?php
+header('Cache-Control: no-cache, no-store, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
+?>
 <!-- Navigation menu shared across pages -->
 <div class="flex items-center space-x-2 mb-4">
   <img src="/favicon.svg" alt="Finance Manager logo" class="h-8 w-8" />

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <title>Palette Settings</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -4,6 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     <title>Pivot Analysis</title>
     <script src="https://cdn.tailwindcss.com"></script>
 

--- a/sample_data/link_preview.html
+++ b/sample_data/link_preview.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+<meta http-equiv="Pragma" content="no-cache">
+<meta http-equiv="Expires" content="0">
 <title>Sample Title</title>
 <meta property="og:title" content="OG Sample Title">
 <meta property="og:description" content="OG Sample Description">


### PR DESCRIPTION
## Summary
- Add no-cache meta tags to remaining HTML pages.
- Serve navigation menu through PHP with no-cache headers and update loader.
- Document the no-cache convention in AGENTS.md.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad81be774832e90d3168ecbdfa4a1