### PR TITLE
Handle optional transactions wrapper in AI tags response

### DIFF
--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -32,7 +32,7 @@ if (!$txns) {
 $categories = $db->query('SELECT id, name FROM categories')->fetchAll(PDO::FETCH_ASSOC);
 
 $txnMap = [];
-$prompt = "You are a financial assistant. For each transaction provide a short tag, a brief description for the tag and one of the provided categories. If the transaction details are ambiguous, use a generic tag name. Return JSON array with objects {\"id\":<id>,\"tag\":\"tag name\",\"description\":\"tag description\",\"category\":\"category name\"}.\n\n";
+$prompt = "You are a financial assistant. For each transaction provide a short tag, a brief description for the tag and one of the provided categories. If the transaction details are ambiguous, use a generic tag name. Return JSON as either a top-level array of objects {\"id\":<id>,\"tag\":\"tag name\",\"description\":\"tag description\",\"category\":\"category name\"} or an object {\"transactions\":[...]} containing that array.\n\n";
 
 $prompt .= "Categories:\n";
 foreach ($categories as $c) {
@@ -93,6 +93,15 @@ if (substr($content, 0, 3) === '```') {
 
 
 $suggestions = json_decode($content, true);
+if (json_last_error() !== JSON_ERROR_NONE) {
+    http_response_code(500);
+    Log::write('AI tag invalid JSON: ' . json_last_error_msg() . ' | ' . $content, 'ERROR');
+    echo json_encode(['error' => 'Invalid AI response']);
+    exit;
+}
+if (is_array($suggestions) && isset($suggestions['transactions']) && is_array($suggestions['transactions'])) {
+    $suggestions = $suggestions['transactions'];
+}
 if (!is_array($suggestions)) {
     http_response_code(500);
     Log::write('AI tag invalid response: ' . $content, 'ERROR');


### PR DESCRIPTION
## Summary
- Accept AI responses wrapped in a `transactions` object
- Clarify AI prompt to allow top-level array or `{ "transactions": [...] }`
- Validate decoded JSON and guard optional `transactions` wrapper

## Testing
- `php -r '$content="[{"id":1,"tag":"t","description":"d","category":"c"}]"; $suggestions=json_decode($content,true); if(json_last_error()!==JSON_ERROR_NONE){echo "err";} if(is_array($suggestions)&&isset($suggestions["transactions"])&&is_array($suggestions["transactions"])){$suggestions=$suggestions["transactions"];} if(!is_array($suggestions)){echo "invalid";} var_export($suggestions);'`
- `php -r '$content="{\"transactions\":[{\"id\":1,\"tag\":\"t\",\"description\":\"d\",\"category\":\"c\"}]}"; $suggestions=json_decode($content,true); if(json_last_error()!==JSON_ERROR_NONE){echo "err";} if(is_array($suggestions)&&isset($suggestions["transactions"])&&is_array($suggestions["transactions"])){$suggestions=$suggestions["transactions"];} if(!is_array($suggestions)){echo "invalid";} var_export($suggestions);'`
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68bae8e98b60832e8884a1d80981c05f