### PR TITLE
Add laptop and coin plant illustrations to landing page

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -24,6 +24,10 @@
                 <h1 class="font-['Roboto'] text-4xl font-semibold mb-4 text-indigo-700">Welcome to <span id="landing-site-name">Finance Manager</span></h1>
                 <p class="text-gray-700 mb-4">Select an option from the menu to get started exploring your finances. Each section opens tools and dashboards that help you understand where your money goes.</p>
                 <a href="upload.html" class="inline-block bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700 font-['Source_Sans_Pro'] font-light">Get Started</a>
+                <div class="mt-6 flex flex-col sm:flex-row justify-center items-center gap-8">
+                    <img src="laptop.png" alt="Laptop illustration" class="w-32 h-32 md:w-40 md:h-40 object-contain rounded shadow">
+                    <img src="coin_flower.png" alt="Coin plant illustration" class="w-32 h-32 md:w-40 md:h-40 object-contain rounded shadow">
+                </div>
                 <p id="version" class="text-gray-500 mt-2">Version: loading...</p>
             </section>
 


### PR DESCRIPTION
## Summary
- Feature: display laptop and coin plant illustrations on the landing page
- Style: responsive flex layout with Tailwind classes for a polished look

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68baf4fec67c832e8ad75a646a0446a4