### PR TITLE
Restrict AI report parser to tags and date range

### DIFF
--- a/tests/NaturalLanguageReportParserTest.php
+++ b/tests/NaturalLanguageReportParserTest.php
@@ -23,10 +23,10 @@ class NaturalLanguageReportParserTest extends TestCase
         $db->exec('INSERT INTO categories (name) VALUES ("cars");');
     }
 
-    public function testParseCategoryAndDateRange(): void
+    public function testParseDateRange(): void
     {
         $filters = NaturalLanguageReportParser::parse('costs for cars in the last 12 months');
-        $this->assertSame(1, $filters['category']);
+        $this->assertNull($filters['category']);
         $this->assertSame(date('Y-m-d', strtotime('-12 months')), $filters['start']);
         $this->assertSame(date('Y-m-d'), $filters['end']);
     }
@@ -41,12 +41,12 @@ class NaturalLanguageReportParserTest extends TestCase
         $this->assertSame([1,2], $filters['tag']);
     }
 
-    public function testCategoryNameWithLeadingSymbol(): void
+    public function testCategoryNamesIgnored(): void
     {
         $db = Database::getConnection();
         $db->exec("INSERT INTO categories (name) VALUES ('#groceries')");
         $filters = NaturalLanguageReportParser::parse('#groceries');
-        $this->assertSame(2, $filters['category']);
+        $this->assertNull($filters['category']);
     }
 
     public function testTagNamesWithNonWordCharacters(): void

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -255,7 +255,7 @@ $db->exec('DELETE FROM categories');
 $db->exec("INSERT INTO categories (name) VALUES ('cars')");
 $carId = (int)$db->lastInsertId();
 $parsed = NaturalLanguageReportParser::parse('costs for cars in the last 12 months');
-assertEqual($carId, $parsed['category'], 'Natural language parser finds category');
+assertEqual(null, $parsed['category'], 'Natural language parser ignores category');
 assertEqual(date('Y-m-d', strtotime('-12 months')), $parsed['start'], 'Natural language parser sets start date');
 
 $db->exec('DELETE FROM tags');
@@ -270,7 +270,7 @@ $db->exec('DELETE FROM sqlite_sequence WHERE name="categories"');
 $db->exec("INSERT INTO categories (name) VALUES ('#groceries')");
 $catSymbolId = (int)$db->lastInsertId();
 $parsedPunctCat = NaturalLanguageReportParser::parse('#groceries');
-assertEqual($catSymbolId, $parsedPunctCat['category'], 'Natural language parser handles category starting with symbol');
+assertEqual(null, $parsedPunctCat['category'], 'Natural language parser ignores category starting with symbol');
 
 $db->exec('DELETE FROM tags');
 $db->exec('DELETE FROM sqlite_sequence WHERE name="tags"');


### PR DESCRIPTION
## Summary
- Limit natural language report parser to only request tags and dates from the AI service
- Adjust fallback parser and tests to ignore categories, segments, groups, and text

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bafa8ee9fc832e883f146e9c6207a1