### PR TITLE
Persist saved reports with descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@
 - Secure accounts with two-factor authentication and offer detailed search and reporting.
 - Transaction groups include an `active` flag. Inactive groups are hidden from selection and projects set to archived automatically deactivate their associated group.
 - PDF reports are named using a timestamped `transactions_report_YYYYMMDD_HHMMSS.pdf` format to ensure uniqueness and clarity.
+- Saved reports persist in a `saved_reports` table storing each report's name, description, and filter criteria.
 
 ## Testing
 - Run `php tests/run_tests.php` to execute the test suite.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Many form inputs include popover help that appears when fields with a `data-help
 
 The frontend also includes a simple reporting page available at `frontend/report.html`.
 It allows running a report to list all transactions filtered by category, tag or group.
-Reports can be saved in the browser for reuse and removed when no longer needed.
+Reports can be saved to the server with optional descriptions for reuse and removed when no longer needed.
 The page sends requests to `php_backend/public/report.php` which returns matching
 transactions as JSON.
 

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -180,20 +180,27 @@
         window.segmentChoices = new Choices(segmentSelect, { searchEnabled: true, shouldSort: false, removeItemButton: true });
     }
 
-    // Populate the saved reports dropdown from localStorage
-    function loadSavedReports() {
-        const saved = JSON.parse(localStorage.getItem('reports') || '[]');
-        const select = document.getElementById('saved-reports');
-        select.innerHTML = '<option value="">Select</option>';
-        saved.forEach((r, idx) => {
-            const opt = document.createElement('option');
-            opt.value = idx;
-            opt.textContent = r.name;
-            select.appendChild(opt);
-        });
-        if (window.savedChoices) { window.savedChoices.destroy(); }
-        window.savedChoices = new Choices(select, { searchEnabled: true, shouldSort: false, itemSelectText: '' });
-        document.getElementById('delete-report').disabled = saved.length === 0;
+    // Populate the saved reports dropdown from the server
+    async function loadSavedReports() {
+        try {
+            const res = await fetch('../php_backend/public/saved_reports.php');
+            const saved = await res.json();
+            window.savedReports = saved;
+            const select = document.getElementById('saved-reports');
+            select.innerHTML = '<option value="">Select</option>';
+            saved.forEach(r => {
+                const opt = document.createElement('option');
+                opt.value = r.id;
+                opt.textContent = r.name;
+                if (r.description) opt.title = r.description;
+                select.appendChild(opt);
+            });
+            if (window.savedChoices) { window.savedChoices.destroy(); }
+            window.savedChoices = new Choices(select, { searchEnabled: true, shouldSort: false, itemSelectText: '' });
+            document.getElementById('delete-report').disabled = saved.length === 0;
+        } catch (e) {
+            console.error('Failed to load saved reports', e);
+        }
     }
 
     // Execute the report query and render results and chart
@@ -311,11 +318,13 @@
         runReport();
     });
 
-    document.getElementById('save-report').addEventListener('click', function() {
+    document.getElementById('save-report').addEventListener('click', async function() {
         const name = prompt('Report name');
         if (!name) return;
+        const description = prompt('Report description') || '';
         const report = {
             name,
+            description,
             category: getSelectedValues(window.catChoices),
             tag: getSelectedValues(window.tagChoices),
             group: getSelectedValues(window.groupChoices),
@@ -324,40 +333,45 @@
             start: document.getElementById('start').value,
             end: document.getElementById('end').value
         };
-        const saved = JSON.parse(localStorage.getItem('reports') || '[]');
-        saved.push(report);
-        localStorage.setItem('reports', JSON.stringify(saved));
+        await fetch('../php_backend/public/saved_reports.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(report)
+        });
         loadSavedReports();
     });
 
     document.getElementById('saved-reports').addEventListener('change', function() {
-        const saved = JSON.parse(localStorage.getItem('reports') || '[]');
-        const idx = this.value;
-        if (idx === '') return;
-        const r = saved[idx];
+        const id = this.value;
+        if (id === '') return;
+        const r = (window.savedReports || []).find(s => String(s.id) === String(id));
+        if (!r) return;
+        const f = r.filters || {};
 
-        const catVals = Array.isArray(r.category) ? r.category : (r.category ? [r.category] : []);
-        const tagVals = Array.isArray(r.tag) ? r.tag : (r.tag ? [r.tag] : []);
-        const grpVals = Array.isArray(r.group) ? r.group : (r.group ? [r.group] : []);
-        const segVals = Array.isArray(r.segment) ? r.segment : (r.segment ? [r.segment] : []);
+        const catVals = Array.isArray(f.category) ? f.category : (f.category ? [f.category] : []);
+        const tagVals = Array.isArray(f.tag) ? f.tag : (f.tag ? [f.tag] : []);
+        const grpVals = Array.isArray(f.group) ? f.group : (f.group ? [f.group] : []);
+        const segVals = Array.isArray(f.segment) ? f.segment : (f.segment ? [f.segment] : []);
         if (window.catChoices) { window.catChoices.setChoiceByValue(catVals); } else { document.getElementById('category').value = catVals[0] || ''; }
         if (window.tagChoices) { window.tagChoices.setChoiceByValue(tagVals); } else { document.getElementById('tag').value = tagVals[0] || ''; }
         if (window.groupChoices) { window.groupChoices.setChoiceByValue(grpVals); } else { document.getElementById('group').value = grpVals[0] || ''; }
         if (window.segmentChoices) { window.segmentChoices.setChoiceByValue(segVals); } else { document.getElementById('segment').value = segVals[0] || ''; }
 
-        document.getElementById('text').value = r.text || '';
-        document.getElementById('start').value = r.start || '';
-        document.getElementById('end').value = r.end || '';
+        document.getElementById('text').value = f.text || '';
+        document.getElementById('start').value = f.start || '';
+        document.getElementById('end').value = f.end || '';
         runReport();
     });
 
-    document.getElementById('delete-report').addEventListener('click', function() {
+    document.getElementById('delete-report').addEventListener('click', async function() {
         const select = document.getElementById('saved-reports');
-        const idx = select.value;
-        if (idx === '') return;
-        const saved = JSON.parse(localStorage.getItem('reports') || '[]');
-        saved.splice(idx, 1);
-        localStorage.setItem('reports', JSON.stringify(saved));
+        const id = select.value;
+        if (id === '') return;
+        await fetch('../php_backend/public/saved_reports.php', {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id })
+        });
         loadSavedReports();
         select.value = '';
         if (window.savedChoices) { window.savedChoices.setChoiceByValue(''); }

--- a/php_backend/create_tables.php
+++ b/php_backend/create_tables.php
@@ -10,6 +10,7 @@ $db = Database::getConnection();
 $db->exec("SET FOREIGN_KEY_CHECKS=0");
 $dropSql = <<<SQL
 DROP TABLE IF EXISTS logs;
+DROP TABLE IF EXISTS saved_reports;
 DROP TABLE IF EXISTS totp_secrets;
 DROP TABLE IF EXISTS settings;
 DROP TABLE IF EXISTS users;
@@ -43,6 +44,14 @@ CREATE TABLE IF NOT EXISTS totp_secrets (
 CREATE TABLE IF NOT EXISTS settings (
     name VARCHAR(100) PRIMARY KEY,
     value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS saved_reports (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT DEFAULT NULL,
+    filters TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE TABLE IF NOT EXISTS accounts (

--- a/php_backend/models/SavedReport.php
+++ b/php_backend/models/SavedReport.php
@@ -1,0 +1,50 @@
+<?php
+// Model for persisting saved report filters and metadata.
+require_once __DIR__ . '/../Database.php';
+
+class SavedReport {
+    /**
+     * Store a new saved report and return its ID.
+     *
+     * @param string $name        Report name.
+     * @param string $description Optional report description.
+     * @param array  $filters     Filter criteria to save.
+     *
+     * @return int Inserted report ID.
+     */
+    public static function create(string $name, string $description, array $filters): int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('INSERT INTO saved_reports (name, description, filters) VALUES (:name, :description, :filters)');
+        $stmt->execute([
+            'name' => $name,
+            'description' => $description,
+            'filters' => json_encode($filters)
+        ]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Retrieve all saved reports with decoded filters.
+     *
+     * @return array<int, array{id:int, name:string, description:?string, filters:array}>
+     */
+    public static function all(): array {
+        $db = Database::getConnection();
+        $stmt = $db->query('SELECT id, name, description, filters FROM saved_reports ORDER BY name');
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($rows as &$row) {
+            $row['filters'] = json_decode($row['filters'], true) ?: [];
+        }
+        return $rows;
+    }
+
+    /**
+     * Delete a saved report by ID.
+     */
+    public static function delete(int $id): bool {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('DELETE FROM saved_reports WHERE id = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+}
+?>

--- a/php_backend/public/saved_reports.php
+++ b/php_backend/public/saved_reports.php
@@ -1,0 +1,58 @@
+<?php
+// API endpoint for managing saved transaction reports.
+require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../models/SavedReport.php';
+require_once __DIR__ . '/../models/Log.php';
+header('Content-Type: application/json');
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    try {
+        echo json_encode(SavedReport::all());
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Saved report fetch error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode([]);
+    }
+} elseif ($method === 'POST') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $name = $data['name'] ?? null;
+    $description = $data['description'] ?? '';
+    if (!$name) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Name required']);
+        exit;
+    }
+    $filters = $data;
+    unset($filters['name'], $filters['description']);
+    try {
+        $id = SavedReport::create($name, $description, $filters);
+        Log::write("Saved report $name");
+        echo json_encode(['id' => $id]);
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Saved report save error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode(['error' => 'Server error']);
+    }
+} elseif ($method === 'DELETE') {
+    $data = json_decode(file_get_contents('php://input'), true);
+    $id = $data['id'] ?? null;
+    if (!$id) {
+        http_response_code(400);
+        echo json_encode(['error' => 'ID required']);
+        exit;
+    }
+    try {
+        SavedReport::delete((int)$id);
+        Log::write("Deleted saved report $id");
+        echo json_encode(['status' => 'ok']);
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Saved report delete error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode(['error' => 'Server error']);
+    }
+} else {
+    http_response_code(405);
+}
+?>

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../php_backend/models/Category.php';
 require_once __DIR__ . '/../php_backend/models/Transaction.php';
 require_once __DIR__ . '/../php_backend/models/Segment.php';
 require_once __DIR__ . '/../php_backend/models/TransactionGroup.php';
+require_once __DIR__ . '/../php_backend/models/SavedReport.php';
 require_once __DIR__ . '/../php_backend/OfxParser.php';
 require_once __DIR__ . '/../php_backend/NaturalLanguageReportParser.php';
 
@@ -16,14 +17,15 @@ $db = Database::getConnection();
 $db->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);');
 $db->exec('CREATE TABLE accounts (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);');
 $db->exec('CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, keyword TEXT, description TEXT);');
-$db->exec('CREATE TABLE segments (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT);');
-$db->exec('CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, segment_id INTEGER);');
+$db->exec('CREATE TABLE segments (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, hue_deg REAL, base_l_pct REAL, base_c REAL, locked TINYINT);');
+$db->exec('CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, segment_id INTEGER, shade_index INTEGER);');
 $db->exec('CREATE TABLE category_tags (category_id INTEGER, tag_id INTEGER);');
 $db->exec('CREATE TABLE settings (name TEXT PRIMARY KEY, value TEXT);');
 $db->exec('CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTOINCREMENT, account_id INTEGER, date TEXT, amount REAL, description TEXT, memo TEXT, category_id INTEGER, segment_id INTEGER, tag_id INTEGER, group_id INTEGER, transfer_id INTEGER, ofx_id TEXT, ofx_type TEXT, bank_ofx_id TEXT);');
 $db->exec('CREATE TABLE transaction_groups (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, active TINYINT DEFAULT 1);');
 $db->exec('CREATE TABLE budgets (id INTEGER PRIMARY KEY AUTOINCREMENT, category_id INTEGER, amount REAL);');
 $db->exec('CREATE TABLE logs (id INTEGER PRIMARY KEY AUTOINCREMENT, level TEXT, message TEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP);');
+$db->exec('CREATE TABLE saved_reports (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, filters TEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP);');
 
 $results = [];
 
@@ -279,6 +281,14 @@ $parsedPunctTags = NaturalLanguageReportParser::parse('#fun bills!');
 sort($parsedPunctTags['tag']);
 assertEqual([1,2], $parsedPunctTags['tag'], 'Natural language parser handles tag names with symbols');
 
+
+$repId = SavedReport::create('Sample', 'Example', ['category' => [1]]);
+$reports = SavedReport::all();
+assertEqual('Sample', $reports[0]['name'] ?? null, 'SavedReport::create stores report');
+assertEqual('Example', $reports[0]['description'] ?? null, 'SavedReport description stored');
+SavedReport::delete($repId);
+$afterDel = SavedReport::all();
+assertEqual(0, count($afterDel), 'SavedReport::delete removes report');
 
 // Output results and set exit code
 $failed = false;


### PR DESCRIPTION
## Summary
- add database table and model for saved reports with descriptions
- expose API endpoints and use server-side storage for report saving
- document server persistence and update tests

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bafb9efd4c832ebbff79e178ef953b