### PR TITLE
Enable class-based Tailwind dark mode and run theme toggle on load

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Two-Factor Authentication</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -7,6 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Account Balance</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
 

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Account Dashboard</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -7,6 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>AI Feedback</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -7,6 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>AI Tags</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>All Years Dashboard</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Backup & Restore</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Budgets</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Manage Categories</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Duplicate Transactions</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>

--- a/frontend/export.html
+++ b/frontend/export.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Exports</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -7,6 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Graphs</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Group Dashboard</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Manage Groups</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -7,6 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Ignored Transactions</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Finance Manager</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -9,8 +9,6 @@ window.fetch = (input, init = {}) => {
   return originalFetch(input, init);
 };
 
-tailwind.config = { darkMode: 'class' };
-
 document.addEventListener('DOMContentLoaded', () => {
   document.body.classList.add('pt-4', 'dark:from-gray-900', 'dark:to-gray-800', 'dark:text-gray-100');
   let colorScheme = 'indigo';

--- a/frontend/js/theme_toggle.js
+++ b/frontend/js/theme_toggle.js
@@ -1,7 +1,6 @@
 // Handles toggling between light and dark themes and persists the choice.
-document.addEventListener('DOMContentLoaded', () => {
-  const button = document.getElementById('theme-toggle');
-  if (!button) return;
+const button = document.getElementById('theme-toggle');
+if (button) {
   const icon = button.querySelector('i');
 
   const applyTheme = theme => {
@@ -24,4 +23,4 @@ document.addEventListener('DOMContentLoaded', () => {
     applyTheme(newTheme);
     localStorage.setItem('theme', newTheme);
   });
-});
+}

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Application Logs</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -7,6 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Missing Tags</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Monthly Dashboard</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Monthly Statement</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -7,6 +7,8 @@
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
   <title>Palette Settings</title>
+  <script>tailwind.config={darkMode:"class"}</script>
+
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Pivot Analysis</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Run Processes</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Add Project</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <!-- Font Awesome icons loaded via menu.js -->

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Projects</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Archived Projects</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Project Board</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <!-- Font Awesome icons loaded via menu.js -->

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Recurring Spend Detection</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Transaction Reports</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Search Transactions</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Manage Segments</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Manage Tags</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -7,6 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Transaction Details</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -7,6 +7,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Account Transfers</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Upload OFX</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -8,6 +8,8 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Yearly Dashboard</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">

--- a/index.php
+++ b/index.php
@@ -95,6 +95,8 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <meta property="og:image" content="<?= htmlspecialchars($origin) ?>/favicon.svg">
     <meta property="og:url" content="<?= htmlspecialchars($origin . $_SERVER['REQUEST_URI']) ?>">
     <title><?= htmlspecialchars($siteName) ?> Login</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">

--- a/logout.php
+++ b/logout.php
@@ -43,6 +43,8 @@ $bgHover = "hover:bg-{$colorScheme}-700";
     <meta http-equiv="Expires" content="0">
     <title>Logged Out</title>
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
 </head>

--- a/settings.php
+++ b/settings.php
@@ -119,6 +119,8 @@ $bg600 = "bg-{$colorScheme}-600";
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>System Settings</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">

--- a/users.php
+++ b/users.php
@@ -59,6 +59,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>User Management</title>
+    <script>tailwind.config={darkMode:"class"}</script>
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/svg+xml" sizes="any" href="/favicon.svg">
 


### PR DESCRIPTION
## Summary
- Define Tailwind dark mode config before loading CDN so `.dark` classes apply
- Initialize theme toggle script immediately and remove no-op runtime config

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bafea12168832ea5fe13d8a239a0af