### PR TITLE
Move dark mode toggle to sidebar

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,9 +22,6 @@
     </style>
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter'] dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
-    <button id="theme-toggle" aria-label="Toggle dark mode" class="fixed top-4 right-4 bg-indigo-600 text-white p-2 rounded-full shadow">
-        <i class="fas fa-moon"></i>
-    </button>
     <div class="flex flex-col md:flex-row min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto shadow"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
@@ -146,7 +143,6 @@
     </div>
 
     <script src="js/menu.js"></script>
-    <script src="js/theme_toggle.js"></script>
     <script src="js/version.js"></script>
     <script src="js/input_help.js"></script>
     <script src="js/overlay.js"></script>

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -279,6 +279,26 @@ document.addEventListener('DOMContentLoaded', () => {
               });
             });
         }
+
+        let themeToggle = document.getElementById('theme-toggle');
+        if (!themeToggle) {
+          themeToggle = document.createElement('button');
+          themeToggle.id = 'theme-toggle';
+          themeToggle.setAttribute('aria-label', 'Toggle dark mode');
+          themeToggle.className = 'ml-auto p-2 rounded-full bg-indigo-600 text-white dark:bg-gray-700';
+          themeToggle.innerHTML = '<i class="fas fa-moon"></i>';
+        }
+        const userInfo = menu.querySelector('#user-info');
+        if (userInfo && !userInfo.contains(themeToggle)) {
+          userInfo.appendChild(themeToggle);
+        } else if (menu && !menu.contains(themeToggle)) {
+          menu.appendChild(themeToggle);
+        }
+        if (!document.querySelector('script[src="js/theme_toggle.js"]')) {
+          const themeScript = document.createElement('script');
+          themeScript.src = 'js/theme_toggle.js';
+          document.body.appendChild(themeScript);
+        }
       })
       .catch(err => console.error('Menu load failed', err));
   }
@@ -314,23 +334,6 @@ document.addEventListener('DOMContentLoaded', () => {
     </a>
   `;
   document.body.appendChild(utility);
-
-  let themeToggle = document.getElementById('theme-toggle');
-  if (!themeToggle) {
-    themeToggle = document.createElement('button');
-    themeToggle.id = 'theme-toggle';
-    themeToggle.setAttribute('aria-label', 'Toggle dark mode');
-    themeToggle.className = 'p-2 rounded-full bg-indigo-600 text-white dark:bg-gray-700';
-    themeToggle.innerHTML = '<i class="fas fa-moon"></i>';
-  }
-  utility.appendChild(themeToggle);
-
-  if (!document.querySelector('script[src="js/theme_toggle.js"]')) {
-    const themeScript = document.createElement('script');
-    themeScript.src = 'js/theme_toggle.js';
-    document.body.appendChild(themeScript);
-  }
-
   const latestLink = document.getElementById('latest-statement-link');
   if (latestLink) {
     fetch('../php_backend/public/transaction_months.php')

--- a/frontend/js/theme_toggle.js
+++ b/frontend/js/theme_toggle.js
@@ -1,5 +1,5 @@
 // Handles toggling between light and dark themes and persists the choice.
-document.addEventListener('DOMContentLoaded', () => {
+const initThemeToggle = () => {
   const button = document.getElementById('theme-toggle');
   if (!button) return;
   const icon = button.querySelector('i');
@@ -24,4 +24,10 @@ document.addEventListener('DOMContentLoaded', () => {
     applyTheme(newTheme);
     localStorage.setItem('theme', newTheme);
   });
-});
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initThemeToggle);
+} else {
+  initThemeToggle();
+}


### PR DESCRIPTION
## Summary
- Move dark mode toggle into sidebar user section and load toggle script automatically
- Remove standalone theme toggle from landing page
- Ensure theme script initializes even when loaded after DOM ready

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb002528bc832ebedc664a87660e74