### PR TITLE
Shade sunburst tags and categories

### DIFF
--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -155,7 +155,7 @@
                 }
                 const tagId = 'tag_' + makeId(t.name) + '_' + makeId(t.category);
                 const value = Math.abs(parseFloat(t.total));
-                const tagColor = Highcharts.color(catInfo.color).brighten(0.2).get();
+                const tagColor = getTagColor(t.name, t.category, catInfo.color);
                 data.push({ id: tagId, parent: catId, name: t.name, value, color: tagColor });
                 tagSums[catId] = (tagSums[catId] || 0) + value;
                 if (!catInfo.fromYearly) {
@@ -167,7 +167,7 @@
                 const tagged = tagSums[ct.id] || 0;
                 const diff = ct.total - tagged;
                 if (Math.abs(diff) > 0.01) {
-                    const otherColor = Highcharts.color(ct.color).brighten(-0.2).get();
+                    const otherColor = getTagColor('Other', ct.name, ct.color);
                     data.push({ id: 'tag_other_' + ct.id, parent: ct.id, name: 'Other', value: diff, color: otherColor });
                 }
             });

--- a/frontend/js/color_map.js
+++ b/frontend/js/color_map.js
@@ -11,6 +11,7 @@ const chartColors = [
 const segmentColorMap = {};
 const categoryColorMap = {};
 const categorySegmentMap = {};
+const tagColorMap = {};
 let nextSegmentIndex = 0;
 
 function hashString(str) {
@@ -78,22 +79,30 @@ function getCategoryColor(name, segmentName = null) {
     const seg = segmentName || categorySegmentMap[name];
     if (seg) {
         const base = getSegmentColor(seg);
-        const hsl = Highcharts.color(base).get('hsl');
         const hash = hashString(name);
-        const hueShift = (hash % 40) - 20; // -20..19
-        const lightShift = ((hash >> 3) % 30 - 15) / 100; // -0.15..0.14
-        hsl.h = (hsl.h + hueShift + 360) % 360;
-        hsl.l = Math.min(1, Math.max(0, hsl.l + lightShift));
-        const color = Highcharts.color(hsl).get();
+        const shift = ((hash % 40) - 20) / 100; // -0.20..0.19
+        const color = Highcharts.color(base).brighten(shift).get();
         categoryColorMap[name] = color;
         return color;
     }
     return chartColors[0];
 }
 
+function getTagColor(name, categoryName, categoryColor = null) {
+    const key = `${categoryName}|${name}`;
+    if (tagColorMap[key]) return tagColorMap[key];
+    const base = categoryColor || getCategoryColor(categoryName);
+    const hash = hashString(key);
+    const shift = ((hash % 40) - 20) / 100; // -0.20..0.19
+    const color = Highcharts.color(base).brighten(shift).get();
+    tagColorMap[key] = color;
+    return color;
+}
+
 window.chartColors = chartColors;
 window.getSegmentColor = getSegmentColor;
 window.getCategoryColor = getCategoryColor;
+window.getTagColor = getTagColor;
 
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('[data-chart-desc]').forEach(el => {


### PR DESCRIPTION
## Summary
- derive category colours by brightening/darkening their segment hues
- generate tag shades from their category colour and apply in sunburst charts

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb03d740d8832eb48866add7790bc6