### PR TITLE
Widen settings page layout

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -135,7 +135,7 @@ $bg600 = "bg-{$colorScheme}-600";
     </style>
 </head>
 <body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
-    <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
+    <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
         <i class="fas fa-cogs <?= $text600 ?> text-6xl mb-4 block mx-auto"></i>
         <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1">ADMIN TOOLS / SYSTEM SETTINGS</div>
         <h1 class="text-2xl font-semibold mb-4 <?= $text700 ?>">System Settings</h1>
@@ -144,7 +144,7 @@ $bg600 = "bg-{$colorScheme}-600";
         <?php if ($message): ?>
             <p class="mb-4 text-green-600"><?= htmlspecialchars($message) ?></p>
         <?php endif; ?>
-        <form method="post" class="space-y-4">
+        <form method="post" class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <label class="block">OpenAI API Token:
                 <input type="text" name="openai_api_token" value="<?= htmlspecialchars($openai) ?>" class="border p-2 rounded w-full" data-help="Token used for AI tagging">
             </label>
@@ -197,7 +197,7 @@ $bg600 = "bg-{$colorScheme}-600";
                     <?php endforeach; ?>
                 </select>
             </label>
-            <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
+            <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded md:col-span-2" aria-label="Save Settings"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
         </form>
     </div>
     <script src="frontend/js/input_help.js"></script>


### PR DESCRIPTION
## Summary
- expand settings page card to `max-w-4xl`
- arrange settings form in a responsive two-column grid
- label save button for accessibility

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb08d32b74832eb3c6831db46195fb