### PR TITLE
Ensure dark mode applies on standalone pages

### DIFF
--- a/frontend/js/theme_toggle.js
+++ b/frontend/js/theme_toggle.js
@@ -2,36 +2,38 @@
 
 const initThemeToggle = () => {
   const button = document.getElementById('theme-toggle');
-  if (!button) return;
-
-  const icon = button.querySelector('i');
+  const icon = button ? button.querySelector('i') : null;
 
   const applyTheme = theme => {
     if (theme === 'dark') {
       document.body.classList.add('dark');
-      icon.classList.remove('fa-moon');
-      icon.classList.add('fa-sun');
+      if (icon) {
+        icon.classList.remove('fa-moon');
+        icon.classList.add('fa-sun');
+      }
     } else {
       document.body.classList.remove('dark');
-      icon.classList.remove('fa-sun');
-      icon.classList.add('fa-moon');
+      if (icon) {
+        icon.classList.remove('fa-sun');
+        icon.classList.add('fa-moon');
+      }
     }
   };
 
   const saved = localStorage.getItem('theme') || 'light';
   applyTheme(saved);
 
-  button.addEventListener('click', () => {
-    const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
-    applyTheme(newTheme);
-    localStorage.setItem('theme', newTheme);
-  });
-
+  if (button) {
+    button.addEventListener('click', () => {
+      const newTheme = document.body.classList.contains('dark') ? 'light' : 'dark';
+      applyTheme(newTheme);
+      localStorage.setItem('theme', newTheme);
+    });
+  }
 };
 
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', initThemeToggle);
 } else {
   initThemeToggle();
-
 }

--- a/index.php
+++ b/index.php
@@ -105,8 +105,8 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
-<body class="min-h-screen flex items-center justify-center bg-gray-50 font-['Inter']">
-    <div class="w-full max-w-sm bg-white p-6 rounded shadow border border-gray-400">
+<body class="min-h-screen flex items-center justify-center bg-gray-50 font-['Inter'] dark:bg-gray-900 dark:text-gray-100">
+    <div class="w-full max-w-sm bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
         <img src="favicon.svg" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 block mx-auto" />
         <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1 text-center">AUTHENTICATION / <?= $needsToken ? 'TWO-FACTOR' : 'LOGIN' ?></div>
         <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 text-center <?= $text700 ?>"><?= $needsToken ? 'Enter Code' : 'Login' ?></h1>
@@ -135,6 +135,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
             </form>
         <?php endif; ?>
     </div>
+    <script src="frontend/js/theme_toggle.js"></script>
     <script src="frontend/js/input_help.js"></script>
     <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>

--- a/logout.php
+++ b/logout.php
@@ -51,13 +51,14 @@ $bgHover = "hover:bg-{$colorScheme}-700";
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
 </head>
-<body class="min-h-screen flex items-center justify-center bg-gray-50 font-['Inter']">
-    <div class="w-full max-w-sm bg-white p-6 rounded shadow border border-gray-400 text-center">
+<body class="min-h-screen flex items-center justify-center bg-gray-50 font-['Inter'] dark:bg-gray-900 dark:text-gray-100">
+    <div class="w-full max-w-sm bg-white p-6 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
         <img src="favicon.svg" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 mx-auto" />
         <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 <?= $text700 ?>">Logged Out</h1>
         <p class="mb-4">You have been safely logged out of the <?= htmlspecialchars($siteName) ?>.</p>
         <a href="index.php" class="<?= $bg600 ?> <?= $bgHover ?> text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Return to Login</a>
     </div>
+    <script src="frontend/js/theme_toggle.js"></script>
     <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
 </body>

--- a/settings.php
+++ b/settings.php
@@ -137,8 +137,8 @@ $bg600 = "bg-{$colorScheme}-600";
         button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
     </style>
 </head>
-<body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
-    <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
+<body class="min-h-screen bg-gray-50 p-6 dark:bg-gray-900 dark:text-gray-100" data-api-base="php_backend/public">
+    <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
         <i class="fas fa-cogs <?= $text600 ?> text-6xl mb-4 block mx-auto"></i>
         <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1">ADMIN TOOLS / SYSTEM SETTINGS</div>
         <h1 class="text-2xl font-semibold mb-4 <?= $text700 ?>">System Settings</h1>
@@ -203,6 +203,7 @@ $bg600 = "bg-{$colorScheme}-600";
             <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded md:col-span-2" aria-label="Save Settings"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
         </form>
     </div>
+    <script src="frontend/js/theme_toggle.js"></script>
     <script src="frontend/js/input_help.js"></script>
     <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>

--- a/users.php
+++ b/users.php
@@ -80,8 +80,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
     </style>
 </head>
-<body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
-    <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
+<body class="min-h-screen bg-gray-50 p-6 dark:bg-gray-900 dark:text-gray-100" data-api-base="php_backend/public">
+    <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
         <i class="fas fa-piggy-bank text-indigo-600 text-6xl mb-4 block mx-auto"></i>
         <div class="uppercase text-indigo-900 text-[0.6rem] mb-1">ADMIN TOOLS / MANAGE USERS</div>
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">User Management</h1>
@@ -108,7 +108,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         <h2 class="text-xl font-semibold mt-6 mb-2">Two-Factor Authentication</h2>
         <p class="mb-4"><?= $has2fa ? '2FA is enabled for your account.' : '2FA is not enabled. Generate a secret to enable it.' ?></p>
-        <div class="bg-white p-4 rounded shadow border border-gray-400 space-y-4 mb-6">
+        <div class="bg-white p-4 rounded shadow border border-gray-400 space-y-4 mb-6 dark:bg-gray-800 dark:border-gray-700">
             <form id="generate-form" class="space-y-4">
                 <input type="hidden" id="gen-username" value="<?= htmlspecialchars($username) ?>">
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-qrcode inline w-4 h-4 mr-2"></i>Generate QR</button>
@@ -126,6 +126,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </form>
         </div>
     </div>
+    <script src="frontend/js/theme_toggle.js"></script>
     <script src="frontend/js/input_help.js"></script>
     <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>


### PR DESCRIPTION
## Summary
- Apply stored dark mode preference even when pages lack a toggle button
- Add dark-mode styling and theme initialization to login, logout, user management and settings pages

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb66946c1c832eafd2c7f89dc62582