### PR TITLE
Round favicon images and add subtle shadow

### DIFF
--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -5,7 +5,7 @@ header('Expires: 0');
 ?>
 <!-- Navigation menu shared across pages -->
 <div class="flex items-center space-x-2 mb-4">
-  <img src="/favicon.png" alt="Finance Manager logo" class="h-8 w-8" />
+  <img src="/favicon.png" alt="Finance Manager logo" class="h-8 w-8 rounded shadow" />
   <div class="flex flex-col">
     <span id="site-title" class="text-xl font-semibold text-indigo-700">Personal Finance Manager</span>
     <span id="release-number" class="bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded mt-1">v0.0.0</span>

--- a/index.php
+++ b/index.php
@@ -107,7 +107,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gray-50 font-['Inter'] dark:bg-gray-900 dark:text-gray-100">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
-        <img src="favicon.png" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 block mx-auto" />
+        <img src="favicon.png" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 block mx-auto rounded shadow" />
         <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1 text-center">AUTHENTICATION / <?= $needsToken ? 'TWO-FACTOR' : 'LOGIN' ?></div>
         <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 text-center <?= $text700 ?>"><?= $needsToken ? 'Enter Code' : 'Login' ?></h1>
         <p class="mb-4 text-center">

--- a/logout.php
+++ b/logout.php
@@ -53,7 +53,7 @@ $bgHover = "hover:bg-{$colorScheme}-700";
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gray-50 font-['Inter'] dark:bg-gray-900 dark:text-gray-100">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
-        <img src="favicon.png" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 mx-auto" />
+        <img src="favicon.png" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 mx-auto rounded shadow" />
         <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 <?= $text700 ?>">Logged Out</h1>
         <p class="mb-4">You have been safely logged out of the <?= htmlspecialchars($siteName) ?>.</p>
         <a href="index.php" class="<?= $bg600 ?> <?= $bgHover ?> text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Return to Login</a>


### PR DESCRIPTION
## Summary
- add rounded corners and shadow to favicon image in login and logout pages
- add rounded corner and shadow styling to favicon in shared menu

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd617374e0832e8070c3bb9c51b6dd