### PR TITLE
Add dark mode support to card components

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -31,7 +31,7 @@
             </div>
             <p class="mb-4">Set up TOTP-based authentication and verify your one-time codes.</p>
 
-            <div class="bg-white p-6 rounded shadow border border-gray-400 mb-6">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 mb-6 dark:bg-gray-800 dark:border-gray-700">
                 <h2 class="font-['Montserrat'] text-xl mb-4">Setup</h2>
                 <form id="generate-form" class="space-y-4">
                     <input id="gen-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">
@@ -42,7 +42,7 @@
 
             </div>
 
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                 <h2 class="font-['Montserrat'] text-xl mb-4">Verify</h2>
                 <form id="verify-form" class="space-y-4">
                     <input id="ver-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -25,11 +25,11 @@
             <h1 id="account-name" class="text-2xl font-semibold mb-4 text-indigo-700">Account Balance</h1>
             <p id="account-details" class="mb-4 text-gray-600"></p>
             <p class="mb-4">View the balance over time based on the latest bank statement.</p>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                 <div id="balance-chart" style="height:400px" data-chart-desc="Line chart of account balance over time."></div>
             </div>
 
-            <div class="bg-white p-6 rounded shadow border border-gray-400 mt-6">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 mt-6 dark:bg-gray-800 dark:border-gray-700">
                 <div id="statement-table"></div>
             </div>
 

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -24,7 +24,7 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Account Dashboard</h1>
             <p class="mb-4">See an overview of account balances and recent activity. Charts and tables reveal how money flows through each account. Sort codes and account numbers are shown where applicable; credit cards list only their card number.</p>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                 <div id="accounts-table"></div>
                 <div id="accounts-chart" class="mt-4" style="height:400px" data-chart-desc="Waterfall chart showing balance changes per account."></div>
             </div>

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -27,7 +27,7 @@
             </button>
             <div id="result" class="mt-4"></div>
             <div id="debug" class="mt-4 hidden">
-                <div class="bg-white p-4 rounded shadow border border-gray-400">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                     <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
                     <p class="text-sm font-semibold">Prompt</p>
                     <pre id="debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
@@ -52,7 +52,7 @@ function renderFeedback(data){
     const highlights = data.highlights.map(h=>`<li>${escapeHtml(h)}</li>`).join('');
     const actions = data.actions.map(a=>`<li>${escapeHtml(a)}</li>`).join('');
     return `
-        <div class="bg-white p-4 rounded shadow space-y-4">
+        <div class="bg-white p-4 rounded shadow border border-gray-400 space-y-4 dark:bg-gray-800 dark:border-gray-700">
             <p>${escapeHtml(data.summary)}</p>
             <div>
                 <h3 class="font-semibold">Highlights</h3>

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -36,7 +36,7 @@
             <button id="run" class="bg-green-600 text-white px-4 py-2 rounded"><i class="fas fa-robot inline w-4 h-4 mr-1"></i>Run AI Tagging</button>
             <div id="result" class="mt-4"></div>
             <div id="debug" class="mt-4 hidden">
-                <div class="bg-white p-4 rounded shadow border border-gray-400">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                     <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
                     <p class="text-sm font-semibold">Prompt</p>
                     <pre id="debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -43,7 +43,7 @@
             </form>
             <div id="ai-result" class="mt-4"></div>
             <div id="ai-debug" class="mt-4 hidden">
-                <div class="bg-white p-4 rounded shadow border border-gray-400">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                     <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
                     <p class="text-sm font-semibold">Prompt</p>
                     <pre id="ai-debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -22,7 +22,7 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Duplicate Transactions</h1>
             <p class="mb-4">Remove unwanted duplicate entries to keep your records accurate.</p>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                 <div class="mb-4 space-x-2">
                     <button id="refresh" class="bg-indigo-600 text-white px-3 py-1 rounded"><i class="fas fa-rotate inline w-4 h-4 mr-1"></i>Refresh</button>
                     <button id="dedupe-all" class="bg-red-600 text-white px-3 py-1 rounded"><i class="fas fa-clone inline w-4 h-4 mr-1"></i>Dedupe All</button>

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -43,22 +43,22 @@
                 </nav>
             </div>
 
-            <div id="income-sunburst" class="tab-content bg-white p-6 rounded shadow border border-gray-400"><div id="income-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of income by segment, category and tag."></div></div>
-            <div id="outgoing-sunburst" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="outgoing-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of outgoings by segment, category and tag."></div></div>
-            <div id="monthly-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="monthly-chart" class="h-[80vh]" data-chart-desc="Column chart of monthly spending totals."></div></div>
-            <div id="cumulative-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="cumulative-chart" class="h-[80vh]" data-chart-desc="Line chart of cumulative spending through the year."></div></div>
-            <div id="pie-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="pie-chart" class="h-[80vh]" data-chart-desc="Pie chart of spending by category."></div></div>
-            <div id="income-tag-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="income-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of income totals by tag."></div></div>
-            <div id="outgoing-tag-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="outgoing-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of outgoing totals by tag."></div></div>
-            <div id="scatter-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="scatter-chart" class="h-[80vh]" data-chart-desc="Bubble chart comparing monthly income and outgoings."></div></div>
-            <div id="stream-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="stream-chart" class="h-[80vh]" data-chart-desc="Stream graph of category spending over the year."></div></div>
+            <div id="income-sunburst" class="tab-content bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700"><div id="income-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of income by segment, category and tag."></div></div>
+            <div id="outgoing-sunburst" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="outgoing-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of outgoings by segment, category and tag."></div></div>
+            <div id="monthly-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="monthly-chart" class="h-[80vh]" data-chart-desc="Column chart of monthly spending totals."></div></div>
+            <div id="cumulative-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="cumulative-chart" class="h-[80vh]" data-chart-desc="Line chart of cumulative spending through the year."></div></div>
+            <div id="pie-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="pie-chart" class="h-[80vh]" data-chart-desc="Pie chart of spending by category."></div></div>
+            <div id="income-tag-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="income-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of income totals by tag."></div></div>
+            <div id="outgoing-tag-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="outgoing-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of outgoing totals by tag."></div></div>
+            <div id="scatter-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="scatter-chart" class="h-[80vh]" data-chart-desc="Bubble chart comparing monthly income and outgoings."></div></div>
+            <div id="stream-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="stream-chart" class="h-[80vh]" data-chart-desc="Stream graph of category spending over the year."></div></div>
 
-            <div id="area-range-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="area-range-chart" class="h-[80vh]" data-chart-desc="Area spline chart of min and max monthly spending."></div></div>
-            <div id="network-graph-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="network-graph" class="h-[80vh]" data-chart-desc="Network graph linking segments and categories."></div></div>
+            <div id="area-range-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="area-range-chart" class="h-[80vh]" data-chart-desc="Area spline chart of min and max monthly spending."></div></div>
+            <div id="network-graph-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="network-graph" class="h-[80vh]" data-chart-desc="Network graph linking segments and categories."></div></div>
 
-            <div id="treegraph-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="treegraph-chart" data-chart-desc="Tree graph of segments and categories."></div></div>
+            <div id="treegraph-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden dark:bg-gray-800 dark:border-gray-700"><div id="treegraph-chart" data-chart-desc="Tree graph of segments and categories."></div></div>
 
-            <div id="segment-section" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden space-y-4">
+            <div id="segment-section" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden space-y-4 dark:bg-gray-800 dark:border-gray-700">
                 <h2 class="text-xl font-semibold">Segment Totals</h2>
                 <div id="segment-table"></div>
                 <div id="segment-chart" class="h-[80vh]" data-chart-desc="Column chart of segment totals."></div>

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -29,13 +29,13 @@
             </label>
 
             <h2 class="text-xl font-semibold mt-6 mb-2">Monthly Totals</h2>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                 <div id="month-table"></div>
                 <div id="month-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of monthly totals for each group."></div>
             </div>
 
             <h2 class="text-xl font-semibold mt-6 mb-2">Yearly Totals</h2>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                 <div id="year-table"></div>
                 <div id="year-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of yearly totals for each group."></div>
             </div>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -29,7 +29,7 @@
                 <label class="block">Description<br><textarea id="group-description" class="border p-2 rounded w-full" data-help="Description for the group"></textarea></label>
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Group</button>
             </form>
-            <div class="mt-6 bg-white p-4 rounded shadow border border-gray-400">
+            <div class="mt-6 bg-white p-4 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                 <h2 class="text-xl font-semibold mb-2">Existing Groups</h2>
                 <div id="group-table"></div>
             </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,7 +28,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter'] dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex flex-col md:flex-row min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto shadow"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto shadow dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <section class="mb-8">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -55,15 +55,15 @@
             </section>
 
             <section class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8 opacity-0 transition-opacity duration-700">
-                <div class="bg-white p-6 rounded shadow border border-gray-300 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg">
+                <div class="bg-white p-6 rounded shadow border border-gray-300 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg dark:bg-gray-800 dark:border-gray-700">
                     <i class="fas fa-chart-line fa-6x mb-2 text-indigo-600"></i>
                     <p class="text-gray-700">Visualise your spending trends with clear charts that highlight where your money goes.</p>
                 </div>
-                <div class="bg-white p-6 rounded shadow border border-gray-300 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg">
+                <div class="bg-white p-6 rounded shadow border border-gray-300 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg dark:bg-gray-800 dark:border-gray-700">
                     <i class="fas fa-piggy-bank fa-6x mb-2 text-indigo-600"></i>
                     <p class="text-gray-700">Track savings effortlessly to see how your balance grows over time.</p>
                 </div>
-                <div class="bg-white p-6 rounded shadow border border-gray-300 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg">
+                <div class="bg-white p-6 rounded shadow border border-gray-300 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg dark:bg-gray-800 dark:border-gray-700">
                     <i class="fas fa-wallet fa-6x mb-2 text-indigo-600"></i>
                     <p class="text-gray-700">Manage budgets with ease by setting targets and watching your progress.</p>
                 </div>

--- a/frontend/js/category_drag.js
+++ b/frontend/js/category_drag.js
@@ -59,7 +59,7 @@
   function createCategoryCard(cat){
     const card = document.createElement('div');
 
-    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-full flex gap-4 items-start';
+    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-full flex gap-4 items-start dark:bg-gray-800 dark:border-gray-700';
 
     card.dataset.categoryId = cat.id;
 
@@ -134,7 +134,7 @@
 
   function createUnassignedCard(tags){
     const card = document.createElement('div');
-    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-full';
+    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-full dark:bg-gray-800 dark:border-gray-700';
     const title = document.createElement('h2');
     title.className = 'font-semibold mb-2';
     title.textContent = 'Unassigned Tags';

--- a/frontend/js/input_help.js
+++ b/frontend/js/input_help.js
@@ -2,7 +2,7 @@
 document.addEventListener('DOMContentLoaded', () => {
     const helpBox = document.createElement('div');
     helpBox.id = 'input-help';
-    helpBox.className = 'absolute bg-white border p-2 rounded shadow hidden z-50 text-sm';
+    helpBox.className = 'absolute bg-white border p-2 rounded shadow hidden z-50 text-sm dark:bg-gray-800 dark:border-gray-700 dark:text-gray-100';
     document.body.appendChild(helpBox);
 
     // Display the help popover near the focused input

--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -55,7 +55,7 @@ const init = () => {
   overlay.className = 'fixed inset-0 bg-black bg-opacity-50 hidden flex items-center justify-center p-4';
 
   const box = document.createElement('div');
-  box.className = 'bg-white p-6 rounded shadow border border-gray-400 max-w-md text-center';
+  box.className = 'bg-white p-6 rounded shadow border border-gray-400 max-w-md text-center dark:bg-gray-800 dark:border-gray-700';
   const text = document.createElement('p');
   text.textContent = helpText;
   const close = document.createElement('button');

--- a/frontend/js/segment_drag.js
+++ b/frontend/js/segment_drag.js
@@ -52,7 +52,7 @@
 
   function createSegmentCard(seg){
     const card = document.createElement('div');
-    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-64 flex-shrink-0';
+    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-64 flex-shrink-0 dark:bg-gray-800 dark:border-gray-700';
     card.dataset.segmentId = seg.id;
 
     const header = document.createElement('div');
@@ -123,7 +123,7 @@
 
   function createUnassignedCard(categories){
     const card = document.createElement('div');
-    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-64 flex-shrink-0';
+    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-64 flex-shrink-0 dark:bg-gray-800 dark:border-gray-700';
     const title = document.createElement('h2');
     title.className = 'font-semibold mb-2';
     title.textContent = 'Unassigned Categories';

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -155,7 +155,7 @@ function tailwindTabulator(element, options) {
     table.on('dataProcessed', function() {
         styleCalcRows(table);
     });
-    el.classList.add('border-0', 'rounded-lg', 'overflow-hidden', 'bg-white', 'shadow-sm');
+    el.classList.add('border-0', 'rounded-lg', 'overflow-hidden', 'bg-white', 'shadow-sm', 'dark:bg-gray-800');
     const header = el.querySelector('.tabulator-header');
     if (header) {
         header.classList.add('bg-white', 'border-b', 'border-gray-200', 'border-b-[0.5px]', 'rounded-t-lg');

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -32,15 +32,15 @@
             </label>
 
             <div id="totals" class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Income</p>
                     <p id="income-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Outgoings</p>
                     <p id="outgoings-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Delta</p>
                     <p id="delta-total" class="text-3xl font-bold">£0.00</p>
                 </div>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -25,7 +25,7 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Statement</h1>
             <p class="mb-4">Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.</p>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                 <form id="statement-form" class="flex flex-wrap items-end gap-4">
                     <div class="w-full sm:w-auto">
                         <label for="year" class="block text-sm font-medium text-gray-700 mb-1">Year</label>
@@ -43,44 +43,44 @@
                 </form>
             </div>
             <div id="totals" class="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                <div id="income-card" class="bg-white p-4 rounded shadow border border-gray-400 text-center cursor-pointer">
+                <div id="income-card" class="bg-white p-4 rounded shadow border border-gray-400 text-center cursor-pointer dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Income</p>
                     <p id="income-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div id="outgoings-card" class="bg-white p-4 rounded shadow border border-gray-400 text-center cursor-pointer">
+                <div id="outgoings-card" class="bg-white p-4 rounded shadow border border-gray-400 text-center cursor-pointer dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Outgoings</p>
                     <p id="outgoings-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Delta</p>
                     <p id="delta-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Savings Rate</p>
                     <p id="savings-rate" class="text-3xl font-bold">0%</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Largest Expense Category</p>
                     <p id="largest-category" class="text-3xl font-bold">N/A</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Recurring vs One-off</p>
                     <p id="recurring-ratio" class="text-lg font-bold">Recurring: £0.00 (0%)<br>One-off: £0.00 (0%)</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Average Transaction Size</p>
                     <p id="avg-transaction" class="text-lg font-bold">Income: £0.00<br>Expenses: £0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center dark:bg-gray-800 dark:border-gray-700">
                     <p class="text-gray-500">Days Until Negative Balance</p>
                     <p id="days-negative" class="text-3xl font-bold">N/A</p>
                 </div>
             </div>
-            <div class="bg-white p-6 rounded shadow border border-gray-400 mt-4">
+            <div class="bg-white p-6 rounded shadow border border-gray-400 mt-4 dark:bg-gray-800 dark:border-gray-700">
                 <div id="transactions-grid"></div>
             </div>
             <div class="mt-4">
-                <div class="bg-white p-6 rounded shadow border border-gray-400">
+                <div class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
 
                     <div id="category-donut" style="height:500px;" data-chart-desc="Donut chart of spending by category for the selected month."></div>
 

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -20,7 +20,7 @@
     <main class="flex-1 p-6">
       <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Palette Settings</h1>
 
-      <div class="bg-white p-6 rounded shadow border border-gray-400 space-y-4">
+      <div class="bg-white p-6 rounded shadow border border-gray-400 space-y-4 dark:bg-gray-800 dark:border-gray-700">
         <ul class="list-disc pl-5 text-gray-700">
           <li>Set segment colours using the picker beside each name. Ticking <em>Lock</em> keeps your choice.</li>
           <li>To reset a segment, untick its <em>Lock</em> box and press <strong>Refresh</strong>.</li>

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -49,7 +49,7 @@ async function loadProjects(){
     board.innerHTML = '';
     projects.forEach(p => {
         const card = document.createElement('div');
-        card.className = 'bg-white p-4 rounded shadow border border-gray-400 flex flex-col space-y-2';
+        card.className = 'bg-white p-4 rounded shadow border border-gray-400 flex flex-col space-y-2 dark:bg-gray-800 dark:border-gray-700';
 
         const header = document.createElement('div');
         header.className = 'flex justify-between items-start';

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -25,13 +25,13 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Reports</h1>
             <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>
-            <form id="report-form" class="bg-white p-4 rounded shadow border border-gray-400 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <form id="report-form" class="bg-white p-4 rounded shadow border border-gray-400 grid grid-cols-1 md:grid-cols-3 gap-4 dark:bg-gray-800 dark:border-gray-700">
                 <label class="block md:col-span-3">Ask in plain English:
                     <input type="text" id="nl-query" class="border p-2 rounded w-full" placeholder="e.g., costs for cars in the last 12 months" data-help="Describe the report you want in plain English">
                 </label>
                 <div id="ai-status" class="md:col-span-3 text-sm text-gray-600 hidden" aria-live="polite"></div>
                 <div id="ai-debug" class="md:col-span-3 hidden">
-                    <div class="bg-white p-4 rounded shadow border border-gray-400">
+                    <div class="bg-white p-4 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                         <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
                         <p class="text-sm font-semibold">Prompt</p>
                         <pre id="ai-debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
@@ -58,8 +58,8 @@
                 <button type="button" id="delete-report" class="bg-red-600 text-white px-3 py-2 rounded" aria-label="Delete saved report"><i class="fas fa-trash inline w-4 h-4"></i></button>
             </div>
             <div id="results-grid" class="mt-4"></div>
-            <div id="chart" class="mt-6 bg-white p-6 rounded shadow border border-gray-400" style="height:400px;" data-chart-desc="Column chart of transaction amounts grouped by your criteria."></div>
-            <div id="category-chart" class="mt-6 bg-white p-6 rounded shadow border border-gray-400" style="height:400px;" data-chart-desc="Pie chart of transaction totals by category."></div>
+            <div id="chart" class="mt-6 bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700" style="height:400px;" data-chart-desc="Column chart of transaction amounts grouped by your criteria."></div>
+            <div id="category-chart" class="mt-6 bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700" style="height:400px;" data-chart-desc="Pie chart of transaction totals by category."></div>
         </main>
     </div>
     <script src="js/menu.js"></script>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -30,7 +30,7 @@
                 <label class="block">Description<br><textarea id="tag-description" class="border p-2 rounded w-full" data-help="Description for the tag"></textarea></label>
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Tag</button>
             </form>
-            <div class="mt-6 bg-white p-4 rounded shadow border border-gray-400">
+            <div class="mt-6 bg-white p-4 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
                 <h2 class="text-xl font-semibold mb-2">Existing Tags</h2>
                 <div id="tag-table"></div>
             </div>

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -43,7 +43,7 @@
             }
 
             const card = document.createElement('div');
-            card.className = 'relative bg-white p-6 rounded shadow border border-gray-400';
+            card.className = 'relative bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700';
 
             function createBadge(text, colorClasses) {
                 const span = document.createElement('span');


### PR DESCRIPTION
## Summary
- ensure project and drag-and-drop cards apply Tailwind dark classes so card backgrounds and borders adapt to dark mode
- extend dark theme styling to help overlays, tooltips, and landing page feature cards
- apply dark-friendly backgrounds to report, statement, and other card-based sections

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68bddcbab7d8832e8ef5125ca2fa18a2