### PR TITLE
Enable dark mode styling for tables, charts, and inputs

### DIFF
--- a/frontend/js/color_map.js
+++ b/frontend/js/color_map.js
@@ -53,17 +53,36 @@ try {
     console.error('Failed to load colour palette', e);
 }
 
-Highcharts.setOptions({
-    colors: chartColors,
-    chart: { style: { fontFamily: 'Inter, sans-serif' } },
-    credits: { enabled: false },
-    legend: { enabled: true, itemStyle: { fontSize: '10px' } },
-    plotOptions: {
-        series: { showInLegend: true },
-        pie: { showInLegend: true },
-        sunburst: { showInLegend: true }
-    }
+function getChartTheme(theme) {
+    const dark = theme === 'dark';
+    const text = dark ? '#f3f4f6' : '#000000';
+    return {
+        colors: chartColors,
+        chart: { style: { fontFamily: 'Inter, sans-serif', color: text }, backgroundColor: dark ? '#1f2937' : '#ffffff' },
+        credits: { enabled: false },
+        legend: { enabled: true, itemStyle: { fontSize: '10px', color: text } },
+        title: { style: { color: text } },
+        xAxis: { labels: { style: { color: text } }, title: { style: { color: text } } },
+        yAxis: { labels: { style: { color: text } }, title: { style: { color: text } } },
+        plotOptions: {
+            series: { showInLegend: true },
+            pie: { showInLegend: true },
+            sunburst: { showInLegend: true }
+        }
+    };
+}
+
+function applyChartTheme(theme) {
+    const opts = getChartTheme(theme);
+    Highcharts.setOptions(opts);
+    Highcharts.charts.forEach(c => { if (c) { c.update(opts, false); c.redraw(); } });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    applyChartTheme(document.body.classList.contains('dark') ? 'dark' : 'light');
 });
+
+document.addEventListener('themechange', e => applyChartTheme(e.detail));
 
 function getSegmentColor(name) {
     if (!name) name = 'Not Segmented';

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -62,6 +62,15 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   };
 
+  const styleInputs = (root = document) => {
+    root.querySelectorAll('input:not([type="checkbox"]):not([type="radio"]), select, textarea').forEach(el => {
+      if (!el.classList.contains('styled-input')) {
+        el.classList.add('styled-input', 'p-2', 'border', 'rounded', 'bg-white', 'border-gray-400',
+          'dark:bg-gray-700', 'dark:border-gray-600', 'dark:text-gray-100');
+      }
+    });
+  };
+
   // Apply 20% opacity to all page elements
   document.documentElement.style.opacity = '0.9';
 
@@ -74,6 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   };
   applyAriaTooltips();
+  styleInputs();
   const ariaObserver = new MutationObserver(mutations => {
     for (const m of mutations) {
       m.addedNodes.forEach(node => {
@@ -83,6 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
           }
           if (node.querySelectorAll) {
             applyAriaTooltips(node);
+            styleInputs(node);
           }
         }
       });

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -38,11 +38,11 @@ function badgeFormatter(colorClasses) {
 function styleCalcRows(table) {
     const rows = table.element.querySelectorAll('.tabulator-calcs-row');
     rows.forEach(row => {
-        row.classList.add('bg-white');
-        row.style.backgroundColor = 'white';
+        row.classList.add('bg-white', 'dark:bg-gray-800');
+        row.style.backgroundColor = '';
         row.querySelectorAll('.tabulator-cell').forEach(cell => {
-            cell.classList.add('bg-white');
-            cell.style.backgroundColor = 'white';
+            cell.classList.add('bg-white', 'dark:bg-gray-800', 'dark:text-gray-100');
+            cell.style.backgroundColor = '';
         });
     });
 }
@@ -70,7 +70,8 @@ function tailwindTabulator(element, options) {
     options.rowFormatter = function(row) {
         if (userRowFormatter) userRowFormatter(row);
         const rowEl = row.getElement();
-        rowEl.classList.add('bg-white', 'hover:bg-white', 'border-b', 'border-gray-200', 'border-b-[0.5px]');
+        rowEl.classList.add('bg-white', 'hover:bg-white', 'border-b', 'border-gray-200', 'border-b-[0.5px]',
+            'dark:bg-gray-800', 'dark:hover:bg-gray-700', 'dark:border-gray-700', 'dark:text-gray-100');
         rowEl.classList.remove('tabulator-row-even', 'tabulator-row-odd');
         rowEl.style.borderTop = '0';
         rowEl.querySelectorAll('.tabulator-cell').forEach(cell => {
@@ -126,7 +127,7 @@ function tailwindTabulator(element, options) {
         const searchInput = document.createElement('input');
         searchInput.type = 'text';
         searchInput.placeholder = 'Search';
-        searchInput.className = 'tabulator-search mb-2 p-2 border rounded w-full';
+        searchInput.className = 'tabulator-search mb-2 p-2 border rounded w-full dark:bg-gray-700 dark:border-gray-600 dark:text-gray-100';
         searchInput.style.fontFamily = accentFont;
         searchInput.style.fontWeight = '300';
         tableEl.parentNode.insertBefore(searchInput, tableEl);
@@ -155,11 +156,12 @@ function tailwindTabulator(element, options) {
     table.on('dataProcessed', function() {
         styleCalcRows(table);
     });
-    el.classList.add('border-0', 'rounded-lg', 'overflow-hidden', 'bg-white', 'shadow-sm', 'dark:bg-gray-800');
+    el.classList.add('border-0', 'rounded-lg', 'overflow-hidden', 'bg-white', 'shadow-sm', 'dark:bg-gray-800', 'dark:text-gray-100');
     const header = el.querySelector('.tabulator-header');
     if (header) {
-        header.classList.add('bg-white', 'border-b', 'border-gray-200', 'border-b-[0.5px]', 'rounded-t-lg');
-        header.style.backgroundColor = 'white';
+        header.classList.add('bg-white', 'border-b', 'border-gray-200', 'border-b-[0.5px]', 'rounded-t-lg',
+            'dark:bg-gray-800', 'dark:border-gray-700', 'dark:text-gray-100');
+        header.style.backgroundColor = '';
         header.querySelectorAll('.tabulator-col').forEach(col => {
             col.style.borderRight = '0';
             col.style.borderLeft = '0';
@@ -169,8 +171,9 @@ function tailwindTabulator(element, options) {
     if (tableHolder) tableHolder.classList.add('rounded-b-lg');
     const paginator = el.querySelector('.tabulator-paginator');
     if (paginator) {
-        paginator.classList.add('bg-white', 'border-t', 'border-gray-200', 'border-t-[0.5px]', 'p-2', 'rounded-b-lg');
-        paginator.style.backgroundColor = 'white';
+        paginator.classList.add('bg-white', 'border-t', 'border-gray-200', 'border-t-[0.5px]', 'p-2', 'rounded-b-lg',
+            'dark:bg-gray-800', 'dark:border-gray-700', 'dark:text-gray-100');
+        paginator.style.backgroundColor = '';
     }
     return table;
 }

--- a/frontend/js/theme_toggle.js
+++ b/frontend/js/theme_toggle.js
@@ -18,6 +18,7 @@ const initThemeToggle = () => {
         icon.classList.add('fa-moon');
       }
     }
+    document.dispatchEvent(new CustomEvent('themechange', { detail: theme }));
   };
 
   const saved = localStorage.getItem('theme') || 'light';


### PR DESCRIPTION
## Summary
- Add dark-mode styles for Tabulator tables including rows, headers, and pagination.
- Style form inputs for dark theme and apply automatically across pages.
- Apply dynamic Highcharts theming and trigger updates on theme changes.
- Dispatch global `themechange` events when toggling themes.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68be01e09cbc832e9dc72fadac023b73