### PR TITLE
Restrict NL report suggestions to tags and dates

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -236,16 +236,11 @@
             try {
                 const resp = await fetch('../php_backend/public/nl_report.php?' + new URLSearchParams({ q: nl }).toString());
                 const filters = await resp.json();
-                if (filters.category) window.catChoices.setChoiceByValue(String(filters.category));
                 if (filters.tag) {
                     window.tagChoices.removeActiveItems();
                     const t = Array.isArray(filters.tag) ? filters.tag : [filters.tag];
                     t.forEach(id => window.tagChoices.setChoiceByValue(String(id)));
                 }
-                if (filters.group) window.groupChoices.setChoiceByValue(String(filters.group));
-                if (filters.segment) window.segmentChoices.setChoiceByValue(String(filters.segment));
-                document.getElementById('text').value = filters.text || '';
-                document.getElementById('memo').value = filters.memo || '';
                 document.getElementById('start').value = filters.start || '';
                 document.getElementById('end').value = filters.end || '';
                 currentReportName = filters.name || '';

--- a/php_backend/NaturalLanguageReportParser.php
+++ b/php_backend/NaturalLanguageReportParser.php
@@ -53,9 +53,8 @@ class NaturalLanguageReportParser {
             $names[$table] = $list;
         }
 
-        $prompt = "Convert the following query into JSON {\"tag\",\"start\",\"end\",\"memo\",\"name\",\"description\",\"summary\"}. " .
+        $prompt = "Convert the following query into JSON {\"tag\",\"start\",\"end\",\"name\",\"description\",\"summary\"}. " .
             "Return tag as an array of tag names (use an empty array when none). " .
-            "Provide memo as text to match the memo field. " .
             "Include a short search name and a concise description. " .
             "The summary should be a short natural language description of the filters. " .
             "Use ISO dates and only the tag names listed.\n\n" .
@@ -142,7 +141,7 @@ class NaturalLanguageReportParser {
             'start' => $parsed['start'] ?? null,
             'end' => $parsed['end'] ?? null,
             'text' => null,
-            'memo' => $parsed['memo'] ?? null,
+            'memo' => null,
             'summary' => $parsed['summary'] ?? null,
             'name' => $parsed['name'] ?? null,
             'description' => $parsed['description'] ?? null,
@@ -215,12 +214,6 @@ class NaturalLanguageReportParser {
         } elseif (strpos($q, 'last month') !== false) {
             $filters['start'] = date('Y-m-d', strtotime('-1 month'));
             $filters['end'] = date('Y-m-d');
-        }
-
-        if (preg_match('/memo\s+"([^"]+)"/', $q, $m)) {
-            $filters['memo'] = $m[1];
-        } elseif (preg_match('/memo\s+([\w\s]+)/', $q, $m)) {
-            $filters['memo'] = trim($m[1]);
         }
 
         $filters['summary'] = self::makeSummary($filters);


### PR DESCRIPTION
## Summary
- Prevent natural language report suggestions from filling memo, category, group or segment fields.
- Update NL parser to ignore memo data and request only tag and date filters from AI.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68be8c65aad8832e9e109084a22af0da