### PR TITLE
Fix Safari floating search box placement

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -332,7 +332,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const utility = document.createElement('div');
   utility.id = 'utility-bar';
-  utility.className = 'fixed top-4 right-8 md:top-8 md:right-12 bg-white rounded-full border border-indigo-600 p-2 flex items-center space-x-4 z-50 transition-shadow hover:shadow-lg dark:bg-gray-800 dark:border-gray-500 dark:text-gray-100';
+  utility.className = 'fixed bg-white rounded-full border border-indigo-600 p-2 flex items-center space-x-4 z-50 transition-shadow hover:shadow-lg dark:bg-gray-800 dark:border-gray-500 dark:text-gray-100';
+  const positionUtility = () => {
+    const mq = window.matchMedia('(min-width: 768px)');
+    utility.style.top = mq.matches ? '2rem' : '1rem';
+    utility.style.right = mq.matches ? '3rem' : '2rem';
+  };
+  positionUtility();
+  window.addEventListener('resize', positionUtility);
   utility.innerHTML = `
     <form id="topbar-search" action="search.html" method="get" class="flex">
       <input type="text" name="value" placeholder="Search transactions" class="p-1 rounded text-black bg-white border-0 transition-shadow focus:shadow" />


### PR DESCRIPTION
## Summary
- Ensure utility search bar positions correctly on Safari by manually setting top/right offsets with JS and adjusting on resize.

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68bed66cd228832e9202615828193d56