### PR TITLE
Enable Tabulator tables for light and dark mode

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -108,6 +108,7 @@ function tailwindTabulator(element, options) {
     el.style.setProperty('--tabulator-header-font-family', headingFont);
     el.style.setProperty('--tabulator-header-font-weight', '700');
     el.style.fontFamily = bodyFont;
+    el.style.colorScheme = 'light dark';
 
 
     if (rowClickHandler) {
@@ -130,6 +131,7 @@ function tailwindTabulator(element, options) {
         searchInput.className = 'tabulator-search mb-2 p-2 border-0 rounded w-full dark:bg-gray-700 dark:text-gray-100';
         searchInput.style.fontFamily = accentFont;
         searchInput.style.fontWeight = '300';
+        searchInput.style.colorScheme = 'light dark';
         tableEl.parentNode.insertBefore(searchInput, tableEl);
         searchInput.addEventListener('input', function() {
             if (typeof table.search === 'function') {


### PR DESCRIPTION
## Summary
- Allow Tabulator tables to respect light and dark colour schemes
- Ensure table search inputs use the same colour scheme awareness

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bed6f22ba0832e8ee9fbf3cfcb781c