### PR TITLE
Enable cards class for light and dark modes

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -10,6 +10,15 @@ window.fetch = (input, init = {}) => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
+  const cardStyle = document.createElement('style');
+  cardStyle.type = 'text/tailwindcss';
+  cardStyle.textContent = `
+    @layer components {
+      .cards { @apply bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700; }
+    }
+  `;
+  document.head.appendChild(cardStyle);
+
   document.body.classList.add('pt-4', 'dark:from-gray-900', 'dark:to-gray-800', 'dark:text-gray-100');
   let colorScheme = 'indigo';
   let siteName = 'Finance Manager';
@@ -365,11 +374,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const sections = main.querySelectorAll('section');
     if (sections.length > 0) {
       sections.forEach(section => {
-        section.classList.add('bg-white', 'p-6', 'rounded', 'shadow', 'border', 'border-gray-400', 'dark:bg-gray-800', 'dark:border-gray-700');
+        section.classList.add('cards');
       });
     } else {
       const wrapper = document.createElement('section');
-      wrapper.className = 'bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700';
+      wrapper.className = 'cards';
       while (main.firstChild) {
         wrapper.appendChild(main.firstChild);
       }


### PR DESCRIPTION
## Summary
- Define reusable `cards` Tailwind component with light and dark theme styles.
- Apply `cards` class to main sections via menu script for consistent card layout.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bed701fe64832ea7a5ed99e05ab437