### PR TITLE
Enable dark mode across frontend pages

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -21,9 +21,9 @@
     <!-- Icons provided by Font Awesome loaded via menu.js -->
     <!-- Custom fonts handled via Tailwind utility classes -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter']" data-api-base="../php_backend/public">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter'] dark:from-gray-900 dark:to-gray-800 dark:text-gray-100" data-api-base="../php_backend/public">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <div class="flex items-center mb-4">
                 <h1 class="font-['Montserrat'] text-2xl font-semibold flex-1 text-indigo-700"><i class="fas fa-shield-halved inline w-6 h-6 mr-2"></i>Two-Factor Authentication</h1>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 id="account-name" class="text-2xl font-semibold mb-4 text-indigo-700">Account Balance</h1>
             <p id="account-details" class="mb-4 text-gray-600"></p>

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Account Dashboard</h1>
             <p class="mb-4">See an overview of account balances and recent activity. Charts and tables reveal how money flows through each account. Sort codes and account numbers are shown where applicable; credit cards list only their card number.</p>

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -15,9 +15,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">AI Feedback</h1>
         <p class="mb-4">Request an AI-generated overview of your finances for the last 12 months.</p>

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -15,9 +15,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">AI Tags</h1>
         <p class="mb-4">Configure OpenAI and automatically tag transactions.</p>

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">All Years Dashboard</h1>
             <p class="mb-4">Compare financial totals across every recorded year to reveal long-term trends and patterns in your finances.</p>

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -16,13 +16,13 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Backup &amp; Restore</h1>
             <p class="mb-4">Create backups of your data or restore from an earlier snapshot. Use the tools below to download a copy of your information or load a previous backup.</p>
-            <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-4">
+            <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-4 dark:bg-gray-800 dark:border-gray-700">
                 <h2 class="text-xl font-semibold">Download Backup</h2>
 
                 <p>Select which data to include in the compressed JSON backup file. User and account
@@ -43,7 +43,7 @@
 
                 <p class="mt-4">Need your transactions in another format? Visit the <a href="export.html" class="text-indigo-600 underline">Exports</a> page.</p>
             </section>
-            <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-4">
+            <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-4 dark:bg-gray-800 dark:border-gray-700">
                 <h2 class="text-xl font-semibold">Restore Backup</h2>
                 <p>Select a gzipped JSON backup file to restore any included transactions, categories, tags, groups, segments, projects, budgets, or settings.</p>
                 <form id="restore-form" action="../php_backend/public/restore.php" method="POST" enctype="multipart/form-data" class="space-y-4">

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -19,9 +19,9 @@
     <!-- Font Awesome icons loaded via menu.js -->
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Budgets</h1>
         <p class="mb-4">Set monthly spending limits for categories and monitor progress. Use this page to plan ahead and see where you may need to adjust your spending.</p>
@@ -33,7 +33,7 @@
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end">Set Budget</button>
             </form>
         </section>
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
+        <section class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
             <h2 class="text-xl font-semibold mb-4">AI Budgeting</h2>
 
             <p class="mb-4">Send your savings goal and the last 12 months of category totals to the AI to propose next month's budgets and provide a brief explanation.</p>
@@ -57,7 +57,7 @@
             <h2 class="text-xl font-semibold mb-4">Current Budgets</h2>
             <div id="budget-table"></div>
         </section>
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
+        <section class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
             <h2 class="text-xl font-semibold mb-4">Budget Progress</h2>
             <div id="budget-chart" style="height:400px" data-chart-desc="Bullet chart comparing spending to budgets."></div>
         </section>

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -16,9 +16,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Categories</h1>
             <p class="mb-4">Create categories and assign tags to organise your transactions. A well-maintained list keeps reports clear and makes searching easier.</p>

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -16,9 +16,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Duplicate Transactions</h1>
             <p class="mb-4">Remove unwanted duplicate entries to keep your records accurate.</p>

--- a/frontend/export.html
+++ b/frontend/export.html
@@ -15,9 +15,9 @@
 
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Exports</h1>
             <p class="mb-4">Download transactions for a chosen period in your preferred format.</p>

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -15,9 +15,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-4">
             <h1 class="text-2xl font-semibold text-indigo-700">Graphs</h1>
             <p class="mb-4">Explore a collection of charts that illustrate your income and spending patterns. Choose a year to see how your finances evolve and compare categories or tags visually.</p>

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Group Dashboard</h1>
             <p class="mb-4">Review group spending by month and year to see how different areas of your budget change over time.</p>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Groups</h1>
             <p class="mb-4">Create groups to collect related categories for reporting and analysis. Grouping similar categories helps you see broader spending patterns.</p>

--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -15,9 +15,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Ignored Transactions</h1>
             <p class="mb-4">Transactions tagged with <strong>IGNORE</strong> are hidden from dashboards and reports. Use this page to review and restore them.</p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,7 +41,7 @@
                         <div class="absolute inset-0 bg-indigo-700/60 flex flex-col items-center justify-center text-center p-6">
                             <h1 class="font-['Roboto'] text-3xl md:text-4xl font-semibold mb-4 text-white">Welcome to <span id="landing-site-name">Finance Manager</span></h1>
                             <p class="text-indigo-100 mb-4">Select an option from the menu to get started exploring your finances. Each section opens tools and dashboards that help you understand where your money goes.</p>
-                            <a href="upload.html" class="inline-block bg-white text-indigo-700 px-4 py-2 rounded hover:bg-indigo-100 font-['Source_Sans_Pro'] font-light">Get Started</a>
+                            <a href="upload.html" class="inline-block bg-white text-indigo-700 px-4 py-2 rounded hover:bg-indigo-100 font-['Source_Sans_Pro'] font-light dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">Get Started</a>
                         </div>
                     </div>
                     <div class="relative rounded-lg overflow-hidden shadow h-72 md:h-96">
@@ -69,7 +69,7 @@
                 </div>
             </section>
 
-            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700">
+            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700 dark:bg-gray-800 dark:border-gray-700">
                 <h2 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div class="flex items-start space-x-3">
@@ -143,7 +143,7 @@
                 </div>
             </section>
 
-            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700">
+            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700 dark:bg-gray-800 dark:border-gray-700">
                 <h2 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">How Data Is Organised</h2>
                 <svg role="img" aria-label="Segments link to categories and tags while groups stand alone" class="mx-auto mb-4" width="360" height="120">
                     <defs>

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Application Logs</h1>
             <p class="mb-4">Review recent log entries to monitor system activity. Filtering by time or keyword helps you trace what happened during a specific event.</p>

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -17,9 +17,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Missing Tags</h1>
             <p class="mb-4">Identify transactions that have not yet been tagged so you can assign categories before they slip through your reports.</p>

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Dashboard</h1>
             <p class="mb-4">View income and outgoings for a chosen month. Compare different months to spot trends and track progress toward your goals.</p>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -19,9 +19,9 @@
 
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Statement</h1>
             <p class="mb-4">Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.</p>

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -14,9 +14,9 @@
 
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
   <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
     <main class="flex-1 p-6">
       <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Palette Settings</h1>
 

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Pivot Analysis</h1>
             <p class="mb-4">Explore transactions using a flexible pivot table. Choose a year or analyse all recorded data.</p>
@@ -43,7 +43,7 @@
 
             </section>
 
-            <section id="detail-card" class="hidden bg-white p-6 rounded shadow border border-gray-400 space-y-4">
+            <section id="detail-card" class="hidden bg-white p-6 rounded shadow border border-gray-400 space-y-4 dark:bg-gray-800 dark:border-gray-700">
 
                 <div class="flex justify-between items-center">
                     <h2 id="detail-title" class="text-xl font-semibold text-indigo-700"></h2>

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -16,9 +16,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Run Processes</h1>
             <p class="mb-4">Run background tasks like auto-tagging, category or segment assignment. These automated processes tidy your data so reports stay accurate without manual effort.</p>

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -22,14 +22,14 @@
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
     </style>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Add Project</h1>
         <p class="mb-4">Capture ideas for home projects and detail their costs and benefits.</p>
 
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
+        <section class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
             <h2 class="text-xl font-semibold mb-4">Project Details</h2>
             <form id="project-form" class="grid md:grid-cols-2 gap-4">
                 <input type="hidden" id="project_id">

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -20,14 +20,14 @@
     <script src="https://code.highcharts.com/highcharts-more.js"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter']">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter'] dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">Projects</h1>
         <p class="mb-4">Review your planned projects, explore costs and compare their priorities.</p>
 
-        <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-6">
+        <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-6 dark:bg-gray-800 dark:border-gray-700">
             <div>
                 <h2 class="font-['Roboto'] text-xl font-semibold mb-4">Budget Planning</h2>
                 <div class="flex items-end space-x-4">

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -23,13 +23,13 @@
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
     </style>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Archived Projects</h1>
         <p class="mb-4">Review projects that have been archived. Restore any project to make it active again.</p>
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
+        <section class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
             <div id="archived-projects-table"></div>
         </section>
     </main>

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -22,14 +22,14 @@
         button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
     </style>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Project Board</h1>
         <p class="mb-4">Browse all active projects in a card layout.</p>
 
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
+        <section class="bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700">
             <div id="projects-board" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
         </section>
     </main>

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Recurring Spend Detection</h1>
             <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses. The results highlight ongoing commitments so you know where money leaves your account regularly.</p>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -19,9 +19,9 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Reports</h1>
             <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Search Transactions</h1>
             <p class="mb-4">Find specific transactions using keywords and view the results below. Quick searches help you jump straight to the entries you need.</p>

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -16,9 +16,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Segments</h1>
             <p class="mb-4">Create segments to group categories for broader analysis. Drag categories between segments to adjust their grouping.</p>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Tags</h1>
             <p class="mb-4">Create new tags and manage existing ones for categorising transactions. Tags act like labels that make reports and searches more meaningful.</p>

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -15,9 +15,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Details</h1>
             <p class="mb-4">Review or edit the information for a single transaction. Changes here immediately update dashboards, reports and budgets.</p>

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -17,9 +17,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <section>
                 <h1 class="text-2xl font-semibold mb-4 flex items-center justify-between text-indigo-700">

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -15,9 +15,9 @@
 
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Upload OFX Files</h1>
         <p class="mb-4">Upload one or more OFX statements from your bank to import transactions into the system. The file contents will be processed and your data added to the database for review.</p>

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -18,9 +18,9 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white font-sans dark:from-gray-900 dark:to-gray-800 dark:text-gray-100">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Yearly Dashboard</h1>
             <p class="mb-4">Analyse totals for a single year through charts and tables to understand how income and spending evolved month by month.</p>


### PR DESCRIPTION
## Summary
- Add Tailwind dark mode classes to all frontend pages
- Ensure navigation and sections/cards style correctly in dark theme
- Include dark styles for interactive elements like buttons

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bedb097e60832eaf82d0b4d96b06eb