### PR TITLE
Allow sections to opt out of card styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,7 +30,7 @@
     <div class="flex flex-col md:flex-row min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto shadow dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
-            <section class="mb-8">
+            <section class="mb-8" data-no-card>
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div class="relative rounded-lg overflow-hidden shadow">
                         <div id="landing-carousel" class="w-full h-72 md:h-96 relative">
@@ -54,7 +54,7 @@
                 <p id="version" class="text-gray-500 mt-2 text-center">Version: loading...</p>
             </section>
 
-            <section class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8 opacity-0 transition-opacity duration-700">
+            <section class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8 opacity-0 transition-opacity duration-700" data-no-card>
                 <div class="bg-white p-6 rounded shadow border border-gray-300 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg dark:bg-gray-800 dark:border-gray-700">
                     <i class="fas fa-chart-line fa-6x mb-2 text-indigo-600"></i>
                     <p class="text-gray-700">Visualise your spending trends with clear charts that highlight where your money goes.</p>
@@ -69,7 +69,7 @@
                 </div>
             </section>
 
-            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700">
+            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card>
                 <h2 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div class="flex items-start space-x-3">
@@ -143,7 +143,7 @@
                 </div>
             </section>
 
-            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700">
+            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card>
                 <h2 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">How Data Is Organised</h2>
                 <svg role="img" aria-label="Segments link to categories and tags while groups stand alone" class="mx-auto mb-4" width="360" height="120">
                     <defs>

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -376,7 +376,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const sections = main.querySelectorAll('section');
     if (sections.length > 0) {
       sections.forEach(section => {
-        section.classList.add('cards');
+        if (!section.hasAttribute('data-no-card')) {
+          section.classList.add('cards');
+        }
       });
     } else {
       const wrapper = document.createElement('section');


### PR DESCRIPTION
## Summary
- Skip applying automatic card styles to sections marked with `data-no-card`.
- Mark landing page hero and full-width sections with `data-no-card` to preserve design.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bedbf2d7bc832e8f7efee6861ddad7