### PR TITLE
Allow sections to opt out of card styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,7 +30,7 @@
     <div class="flex flex-col md:flex-row min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto shadow dark:bg-gray-800 dark:border-gray-700"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
-            <section class="mb-8" data-no-card>
+            <section class="mb-8" data-no-card="true">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div class="relative rounded-lg overflow-hidden shadow">
                         <div id="landing-carousel" class="w-full h-72 md:h-96 relative">
@@ -54,7 +54,7 @@
                 <p id="version" class="text-gray-500 mt-2 text-center">Version: loading...</p>
             </section>
 
-            <section class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8 opacity-0 transition-opacity duration-700" data-no-card>
+            <section class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8 opacity-0 transition-opacity duration-700" data-no-card="true">
                 <div class="bg-white p-6 rounded shadow border border-gray-300 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg dark:bg-gray-800 dark:border-gray-700">
                     <i class="fas fa-chart-line fa-6x mb-2 text-indigo-600"></i>
                     <p class="text-gray-700">Visualise your spending trends with clear charts that highlight where your money goes.</p>
@@ -70,7 +70,7 @@
             </section>
 
 
-            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card>
+            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card="true">
 
                 <h2 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -146,7 +146,7 @@
             </section>
 
 
-            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card>
+            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card="true">
 
                 <h2 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">How Data Is Organised</h2>
                 <svg role="img" aria-label="Segments link to categories and tags while groups stand alone" class="mx-auto mb-4" width="360" height="120">

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -373,10 +373,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Apply Tailwind card styling to all sections or wrap main content in a card
   document.querySelectorAll('main').forEach(main => {
-    const sections = main.querySelectorAll('section');
+    // Only style direct child sections and allow explicit opt-out via data-no-card
+    const sections = main.querySelectorAll(':scope > section');
     if (sections.length > 0) {
       sections.forEach(section => {
-        if (!section.hasAttribute('data-no-card')) {
+        if (!section.dataset.noCard) {
           section.classList.add('cards');
         }
       });


### PR DESCRIPTION
## Summary
- Skip applying card styling to sections marked with `data-no-card` and only target direct children of `<main>`.
- Mark hero and other full-width sections on the landing page with `data-no-card` to preserve layout.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bedd3de44c832ebfe4d0f4abcd7db0