### PR TITLE
Add RAG score badges to project board

### DIFF
--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -42,6 +42,29 @@ function fmtMoney(v){
     return '£' + (parseFloat(v) || 0).toFixed(2);
 }
 
+function scoreBadge(score){
+    const s = parseInt(score, 10) || 0;
+    const colors = {
+        1: 'bg-green-500',
+        2: 'bg-lime-400',
+        3: 'bg-yellow-500',
+        4: 'bg-orange-500',
+        5: 'bg-red-600'
+    };
+    const colorClass = colors[s] || 'bg-gray-300';
+    return `<span class="inline-block px-2 py-0.5 rounded text-xs ${colorClass} text-black">${s}</span>`;
+}
+
+function renderStars(score){
+    const s = parseInt(score, 10) || 0;
+    let stars = '';
+    for(let i = 0; i < 5; i++){
+        const cls = i < s ? 'text-yellow-500' : 'text-gray-300';
+        stars += `<i class="fas fa-star ${cls} text-xs"></i>`;
+    }
+    return stars;
+}
+
 async function loadProjects(){
     const res = await fetch('../php_backend/public/projects.php');
     const projects = await res.json();
@@ -94,15 +117,15 @@ async function loadProjects(){
             </tr>
             <tr>
                 <td class="pr-2 font-semibold">Expected Lifespan:</td><td>${p.expected_lifespan || ''}</td>
-                <td class="pr-2 font-semibold">Financial Benefit:</td><td>${p.benefit_financial || 0}</td>
+                <td class="pr-2 font-semibold">Financial Benefit:</td><td>${scoreBadge(p.benefit_financial)}</td>
             </tr>
             <tr>
-                <td class="pr-2 font-semibold">Quality Benefit:</td><td>${p.benefit_quality || 0}</td>
-                <td class="pr-2 font-semibold">Risk Benefit:</td><td>${p.benefit_risk || 0}</td>
+                <td class="pr-2 font-semibold">Quality Benefit:</td><td>${scoreBadge(p.benefit_quality)}</td>
+                <td class="pr-2 font-semibold">Risk Benefit:</td><td>${scoreBadge(p.benefit_risk)}</td>
             </tr>
             <tr>
-                <td class="pr-2 font-semibold">Sustainability Benefit:</td><td>${p.benefit_sustainability || 0}</td>
-                <td class="pr-2 font-semibold">Score:</td><td>${p.score || 0}</td>
+                <td class="pr-2 font-semibold">Sustainability Benefit:</td><td>${scoreBadge(p.benefit_sustainability)}</td>
+                <td class="pr-2 font-semibold">Score:</td><td>${renderStars(p.score)}</td>
             </tr>
             <tr>
                 <td class="pr-2 font-semibold">Dependencies:</td><td>${p.dependencies || ''}</td>


### PR DESCRIPTION
## Summary
- Use RAG-coloured badges for financial, quality, risk and sustainability scores
- Show overall project score as a star rating rather than a RAG badge

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bedba20ba0832ea9740e9071a186ed