### PR TITLE
Enable cards class for light and dark modes

### DIFF
--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -1,0 +1,12 @@
+/* Shared card component styles extracted from Tailwind utilities */
+.cards {
+  background-color: #ffffff;
+  padding: 1.5rem;
+  border-radius: 0.25rem;
+  box-shadow: 0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1);
+  border: 1px solid #9ca3af;
+}
+.dark .cards {
+  background-color: #1f2937;
+  border-color: #374151;
+}

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -10,14 +10,13 @@ window.fetch = (input, init = {}) => {
 };
 
 document.addEventListener('DOMContentLoaded', () => {
-  const cardStyle = document.createElement('style');
-  cardStyle.type = 'text/tailwindcss';
-  cardStyle.textContent = `
-    @layer components {
-      .cards { @apply bg-white p-6 rounded shadow border border-gray-400 dark:bg-gray-800 dark:border-gray-700; }
-    }
-  `;
-  document.head.appendChild(cardStyle);
+  if (!document.getElementById('cards-css')) {
+    const cardLink = document.createElement('link');
+    cardLink.id = 'cards-css';
+    cardLink.rel = 'stylesheet';
+    cardLink.href = 'cards.css';
+    document.head.appendChild(cardLink);
+  }
 
   document.body.classList.add('pt-4', 'dark:from-gray-900', 'dark:to-gray-800', 'dark:text-gray-100');
   let colorScheme = 'indigo';


### PR DESCRIPTION
## Summary
- Define card component styles in a static stylesheet and load it up front
- Remove runtime Tailwind injection so `.cards` class renders properly

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bedf2c4100832e871e573f2ad0cf6b