### PR TITLE
Load Tailwind before configuring on project board

### DIFF
--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -8,12 +8,10 @@
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
     <title>Project Board</title>
-    <script>
-        window.tailwind = window.tailwind || {};
-        window.tailwind.config = { darkMode: "class" };
-    </script>
-
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = { darkMode: "class" };
+    </script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <!-- Font Awesome icons loaded via menu.js -->
     <style>


### PR DESCRIPTION
## Summary
- Load Tailwind CDN prior to configuring dark mode on the project board page to ensure side menu styles apply correctly.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bee1b36f60832ebffefda6aa9629c3