### PR TITLE
Remove caching code

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Two-Factor Authentication</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -3,9 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Account Balance</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Account Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -3,9 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>AI Feedback</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -3,9 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>AI Tags</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>All Years Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Backup & Restore</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Budgets</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Manage Categories</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Duplicate Transactions</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/export.html
+++ b/frontend/export.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Exports</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -3,9 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Graphs</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Group Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Manage Groups</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -3,9 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Ignored Transactions</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Finance Manager</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Application Logs</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -1,8 +1,3 @@
-<?php
-header('Cache-Control: no-cache, no-store, must-revalidate');
-header('Pragma: no-cache');
-header('Expires: 0');
-?>
 <!-- Navigation menu shared across pages -->
 <div class="flex items-center space-x-2 mb-4">
   <img src="/favicon.png" alt="Finance Manager logo" class="h-8 w-8 rounded shadow" />

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -3,9 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Missing Tags</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Monthly Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Monthly Statement</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -3,9 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-  <meta http-equiv="Pragma" content="no-cache">
-  <meta http-equiv="Expires" content="0">
   <title>Palette Settings</title>
   <script>
       window.tailwind = window.tailwind || {};

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Pivot Analysis</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Run Processes</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Add Project</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Projects</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Archived Projects</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Project Board</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Recurring Spend Detection</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Transaction Reports</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Search Transactions</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Manage Segments</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Manage Tags</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -3,9 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Transaction Details</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -3,9 +3,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Account Transfers</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Upload OFX</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -4,9 +4,6 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Yearly Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/index.php
+++ b/index.php
@@ -85,9 +85,6 @@ $needsToken = isset($_SESSION['pending_user_id']);
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <meta name="application-name" content="<?= htmlspecialchars($siteName) ?>">
     <?php $origin = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' : 'http') . '://' . ($_SERVER['HTTP_HOST'] ?? ''); ?>
     <meta property="og:title" content="<?= htmlspecialchars($siteName) ?>">

--- a/logout.php
+++ b/logout.php
@@ -38,9 +38,6 @@ $bgHover = "hover:bg-{$colorScheme}-700";
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>Logged Out</title>
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
     <script>

--- a/php_backend/nocache.php
+++ b/php_backend/nocache.php
@@ -1,9 +1,4 @@
 <?php
-// Send headers to prevent caching
-header('Cache-Control: no-cache, no-store, must-revalidate');
-header('Pragma: no-cache');
-header('Expires: 0');
-
 // Allow cross-origin requests
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: GET, POST, OPTIONS');

--- a/sample_data/link_preview.html
+++ b/sample_data/link_preview.html
@@ -3,9 +3,6 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-<meta http-equiv="Pragma" content="no-cache">
-<meta http-equiv="Expires" content="0">
 <title>Sample Title</title>
 <meta property="og:title" content="OG Sample Title">
 <meta property="og:description" content="OG Sample Description">

--- a/settings.php
+++ b/settings.php
@@ -115,9 +115,6 @@ $bg600 = "bg-{$colorScheme}-600";
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>System Settings</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/users.php
+++ b/users.php
@@ -55,9 +55,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
-    <meta http-equiv="Pragma" content="no-cache">
-    <meta http-equiv="Expires" content="0">
     <title>User Management</title>
     <script>
         window.tailwind = window.tailwind || {};


### PR DESCRIPTION
## Summary
- drop cache-control headers from backend utility
- strip no-cache meta tags from HTML pages and menu include

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bee1de5fe0832ebd3ca65c29fe9b2b