### PR TITLE
Fix side menu visibility

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -190,7 +190,6 @@ document.addEventListener('DOMContentLoaded', () => {
   if (menu) {
     // Add responsive classes so the navigation can toggle on small screens
     menu.classList.add(
-      'hidden',
       'flex',
       'flex-col',
       'fixed',


### PR DESCRIPTION
## Summary
- Prevent side navigation from being permanently hidden by removing an extra `hidden` class applied in `menu.js`

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bee6a84c40832e9c9bc8505732f6b9