### PR TITLE
Configure Tailwind before loading CDN on project board

### DIFF
--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -5,10 +5,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Project Board</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <script>
-        tailwind.config = {};
+        window.tailwind = window.tailwind || {};
+        window.tailwind.config = { darkMode: 'class' };
     </script>
+    <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <!-- Font Awesome icons loaded via menu.js -->
     <style>


### PR DESCRIPTION
## Summary
- Configure Tailwind with dark mode before loading the CDN on the project board page
- Add cache-control metadata to prevent caching of the project board page

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bee847d524832ebb55969995346746