### PR TITLE
Fix syntax error preventing menu.js from executing

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -293,8 +293,6 @@ document.addEventListener('DOMContentLoaded', () => {
               });
             });
         }
-
-        }
       })
       .catch(err => console.error('Menu load failed', err));
   }


### PR DESCRIPTION
## Summary
- remove stray closing brace from menu.js so script parses and runs

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bee85b1dc4832e924524be9dfb3b72