### PR TITLE
Use fetchNoCache helper instead of global fetch override

### DIFF
--- a/frontend/js/auto_logout.js
+++ b/frontend/js/auto_logout.js
@@ -1,5 +1,5 @@
 // Logs out the user after a period of inactivity based on server settings.
-fetch('../php_backend/public/session_timeout.php')
+fetchNoCache('../php_backend/public/session_timeout.php')
   .then(r => {
     if (r.status === 401) {
       window.location.href = '../logout.php?timeout=1';

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -1,13 +1,11 @@
 // Dynamically loads the shared navigation menu into pages and ensures icon support.
-// Override fetch globally to bypass browser caching.
-const originalFetch = window.fetch;
-window.fetch = (input, init = {}) => {
+// Helper to bypass browser caching when needed.
+function fetchNoCache(input, init = {}) {
   init = init || {};
-  if (!init.cache) {
-    init.cache = 'no-store';
-  }
-  return originalFetch(input, init);
-};
+  init.cache = 'no-store';
+  return window.fetch(input, init);
+}
+window.fetchNoCache = fetchNoCache;
 
 document.addEventListener('DOMContentLoaded', () => {
   if (!document.getElementById('cards-css')) {
@@ -119,7 +117,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const fontStyle = document.createElement('style');
   document.head.appendChild(fontStyle);
 
-  fetch('../php_backend/public/font_settings.php')
+  fetchNoCache('../php_backend/public/font_settings.php')
     .then(r => r.json())
     .then(f => {
       const families = [
@@ -200,7 +198,7 @@ document.addEventListener('DOMContentLoaded', () => {
       'z-40'
     );
 
-    fetch('menu.php')
+    fetchNoCache('menu.php')
       .then(resp => resp.text())
       .then(html => {
         menu.innerHTML = html;
@@ -214,7 +212,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const userEl = menu.querySelector('#current-user');
         const iconEl = menu.querySelector('#user-icon');
         if (userEl) {
-          fetch('../php_backend/public/current_user.php')
+          fetchNoCache('../php_backend/public/current_user.php')
             .then(r => (r.ok ? r.json() : Promise.reject()))
             .then(u => {
               userEl.textContent = u.username || 'Guest';
@@ -258,7 +256,7 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         }
         // Display counter for untagged transactions in menu
-        fetch('../php_backend/public/untagged_count.php')
+        fetchNoCache('../php_backend/public/untagged_count.php')
           .then(r => r.json())
           .then(data => {
             const total = Number(data.count || 0);
@@ -274,7 +272,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const releaseEls = document.querySelectorAll('#release-number');
         if (releaseEls.length > 0) {
-          fetch('../php_backend/public/version.php')
+          fetchNoCache('../php_backend/public/version.php')
             .then(r => r.json())
             .then(v => {
               const version = v.version || 'unknown';
@@ -335,7 +333,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.body.appendChild(utility);
   const latestLink = document.getElementById('latest-statement-link');
   if (latestLink) {
-    fetch('../php_backend/public/transaction_months.php')
+    fetchNoCache('../php_backend/public/transaction_months.php')
       .then(r => r.json())
       .then(months => {
         if (months.length > 0) {

--- a/frontend/js/palette_ui.js
+++ b/frontend/js/palette_ui.js
@@ -4,7 +4,7 @@ import {hexToOklch, oklchToHex} from './colour.js';
 const state = { segments: [] };
 
 document.addEventListener('DOMContentLoaded', async () => {
-  const res = await fetch('../php_backend/public/palette.php', {cache: 'no-store'});
+  const res = await window.fetchNoCache('../php_backend/public/palette.php');
   const data = await res.json();
   state.segments = data.segments;
   document.getElementById('segment-count').textContent = state.segments.length;

--- a/frontend/js/version.js
+++ b/frontend/js/version.js
@@ -2,7 +2,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const target = document.getElementById('version');
   if (!target) return;
-  fetch('../php_backend/public/version.php')
+  fetchNoCache('../php_backend/public/version.php')
     .then((response) => response.json())
     .then((data) => {
       const version = data.version || 'unknown';


### PR DESCRIPTION
## Summary
- replace global `window.fetch` override with a `fetchNoCache` helper
- call `fetchNoCache` only on requests that require `no-store`
- restore default browser caching behaviour for other requests

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68befbe54684832e9c888f40244ab7ee