### PR TITLE
Remove duplicate page_help.js includes

### DIFF
--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -111,6 +111,5 @@ async function initDebug(){
 
 initDebug();
 </script>
-<script src="js/page_help.js"></script>
 </body>
 </html>

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -116,6 +116,5 @@ async function initDebug(){
 loadToken();
 initDebug();
 </script>
-<script src="js/page_help.js"></script>
 </body>
 </html>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -226,6 +226,5 @@ loadCategories().then(loadBudgets);
 initDebug();
 </script>
 <script src="js/overlay.js"></script>
-<script src="js/page_help.js"></script>
 </body>
 </html>

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -114,7 +114,6 @@
 
     loadDupes();
     </script>
-    <script src="js/page_help.js"></script>
     <script src="js/overlay.js"></script>
 </body>
 </html>

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -149,6 +149,5 @@ document.getElementById('project-form').addEventListener('submit', async e => {
 loadProject();
 </script>
 <script src="js/overlay.js"></script>
-<script src="js/page_help.js"></script>
 </body>
 </html>

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -192,6 +192,5 @@ document.getElementById('y-axis').addEventListener('change', drawBubble);
 loadProjects();
 </script>
 <script src="js/overlay.js"></script>
-<script src="js/page_help.js"></script>
 </body>
 </html>

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -69,6 +69,5 @@ async function loadArchived(){
 loadArchived();
 </script>
 <script src="js/overlay.js"></script>
-<script src="js/page_help.js"></script>
 </body>
 </html>

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -170,6 +170,5 @@ async function loadProjects(){
 loadProjects();
 </script>
 <script src="js/overlay.js"></script>
-<script src="js/page_help.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove redundant `page_help.js` script tags from frontend pages, avoiding duplicate global `init` definitions

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf05878784832eae2ad2a77f40e2f8