### PR TITLE
Make unscored project stars clearly visible

### DIFF
--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -57,8 +57,11 @@ function renderStars(score){
     const s = parseInt(score, 10) || 0;
     let stars = '';
     for(let i = 0; i < 5; i++){
-        const cls = i < s ? 'text-yellow-500' : 'text-gray-300';
-        stars += `<i class="fas fa-star ${cls} text-xs"></i>`;
+        if(i < s){
+            stars += '<i class="fas fa-star text-yellow-500 text-xs"></i>';
+        } else {
+            stars += '<i class="far fa-star text-gray-300 text-xs"></i>';
+        }
     }
     return stars;
 }


### PR DESCRIPTION
## Summary
- Use regular grey stars for unscored project ratings so missing points are visible

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf08057244832e8e56310c166f7357