### PR TITLE
Ensure static frontend pages disable caching

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Two-Factor Authentication</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Account Balance</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Account Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>AI Feedback</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>AI Tags</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>All Years Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Backup & Restore</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Budgets</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Manage Categories</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Duplicate Transactions</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/export.html
+++ b/frontend/export.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Exports</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Graphs</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Group Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Manage Groups</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Ignored Transactions</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Finance Manager</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Application Logs</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Missing Tags</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Monthly Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Monthly Statement</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <title>Palette Settings</title>
   <script>
       window.tailwind = window.tailwind || {};

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Pivot Analysis</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Run Processes</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Add Project</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Projects</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Project Board</title>
 
     <script>

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Recurring Spend Detection</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Transaction Reports</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Search Transactions</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Manage Segments</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Manage Tags</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Transaction Details</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Account Transfers</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Upload OFX</title>
     <script>
         window.tailwind = window.tailwind || {};

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -4,6 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <title>Yearly Dashboard</title>
     <script>
         window.tailwind = window.tailwind || {};


### PR DESCRIPTION
## Summary
- Add `<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">` to `projects.html`
- Add the same Cache-Control meta tag to all other static frontend HTML pages

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0ef1da34832eadb5808afcf2d41c