### PR TITLE
Add thin accent font option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,4 @@
 
 ## Decisions
 - Sections use scroll-based fade-in; apply `opacity-0` initially and `frontend/js/scroll_animations.js` adds a `fade-in` class when in view.
+- Settings include an accent font weight option offering light (300) and very thin (100) styles.

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -115,7 +115,7 @@ window.fetchNoCache = fetchNoCache;
       const families = [
         `family=${encodeURIComponent(f.heading)}:wght@700`,
         `family=${encodeURIComponent(f.body)}:wght@400`,
-        `family=${encodeURIComponent(f.accent)}:wght@300`
+        `family=${encodeURIComponent(f.accent)}:wght@${f.accent_weight || 300}`
       ];
       if (fontLink) {
         fontLink.href = `https://fonts.googleapis.com/css2?${families.join('&')}&display=swap`;
@@ -129,7 +129,7 @@ window.fetchNoCache = fetchNoCache;
           }
           body { font-family: var(--body-font); font-weight: 400; }
           h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }
-          button, .accent { font-family: var(--accent-font); font-weight: 300; }
+          button, .accent { font-family: var(--accent-font); font-weight: ${f.accent_weight || 300}; }
         `;
       }
       siteName = f.site_name || siteName;

--- a/index.php
+++ b/index.php
@@ -12,6 +12,11 @@ $db = Database::getConnection();
 $brand = Setting::getBrand();
 $siteName = $brand['site_name'];
 $scheme = $brand['color_scheme'];
+$fonts = Setting::getFonts();
+$fontHeading = $fonts['heading'];
+$fontBody = $fonts['body'];
+$fontAccent = $fonts['accent'];
+$fontAccentWeight = $fonts['accent_weight'];
 $error = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -70,14 +75,19 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <script>window.tailwind = window.tailwind || {}; window.tailwind.config = {};</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        body { font-family: '<?= htmlspecialchars($fontBody, ENT_QUOTES) ?>', sans-serif; font-weight: 400; }
+        h1, h2, h3, h4, h5, h6 { font-family: '<?= htmlspecialchars($fontHeading, ENT_QUOTES) ?>', sans-serif; font-weight: 700; }
+        button { font-family: '<?= htmlspecialchars($fontAccent, ENT_QUOTES) ?>', sans-serif; font-weight: <?= htmlspecialchars($fontAccentWeight, ENT_QUOTES) ?>; }
+    </style>
 </head>
-<body class="min-h-screen flex items-center justify-center bg-gray-50 font-['Inter']">
+<body class="min-h-screen flex items-center justify-center bg-gray-50">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow border border-gray-400">
         <img src="favicon.png" alt="<?= htmlspecialchars($siteName) ?> logo" class="h-24 w-24 mb-4 block mx-auto rounded shadow" />
         <div class="uppercase text-<?= $scheme ?>-900 text-[0.6rem] mb-1 text-center">AUTHENTICATION / <?= $needsToken ? 'TWO-FACTOR' : 'LOGIN' ?></div>
-        <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 text-center text-<?= $scheme ?>-700"><?= $needsToken ? 'Enter Code' : 'Login' ?></h1>
+        <h1 class="text-2xl font-semibold mb-4 text-center text-<?= $scheme ?>-700"><?= $needsToken ? 'Enter Code' : 'Login' ?></h1>
         <p class="mb-4 text-center">
             <?= $needsToken ? 'Enter the 6-digit code from your authenticator.' : 'Use your account credentials to sign in and access the ' . htmlspecialchars($siteName) . '. Enter your username and password in the boxes below and press the login button to continue.' ?>
         </p>
@@ -89,7 +99,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
                 <label class="block">Code:
                     <input type="text" name="token" autocomplete="one-time-code" class="mt-1 w-full border p-2 rounded" data-help="Enter your 6-digit code">
                 </label>
-                <button type="submit" aria-label="Verify code" class="w-full bg-<?= $scheme ?>-600 hover:bg-<?= $scheme ?>-700 text-white py-2 rounded font-['Source_Sans_Pro'] font-light transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Verify</button>
+                <button type="submit" aria-label="Verify code" class="w-full bg-<?= $scheme ?>-600 hover:bg-<?= $scheme ?>-700 text-white py-2 rounded transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Verify</button>
             </form>
         <?php else: ?>
             <form method="post" class="space-y-4" id="login-form" autocomplete="on">
@@ -99,7 +109,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
                 <label class="block">Password:
                     <input type="password" name="password" autocomplete="current-password" class="mt-1 w-full border p-2 rounded" data-help="Enter your password">
                 </label>
-                <button type="submit" aria-label="Log in" class="w-full bg-<?= $scheme ?>-600 hover:bg-<?= $scheme ?>-700 text-white py-2 rounded font-['Source_Sans_Pro'] font-light transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Login</button>
+                <button type="submit" aria-label="Log in" class="w-full bg-<?= $scheme ?>-600 hover:bg-<?= $scheme ?>-700 text-white py-2 rounded transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Login</button>
             </form>
         <?php endif; ?>
     </div>

--- a/php_backend/models/Setting.php
+++ b/php_backend/models/Setting.php
@@ -7,6 +7,7 @@ class Setting {
     private const DEFAULT_HEADING_FONT = 'Roboto';
     private const DEFAULT_BODY_FONT = 'Inter';
     private const DEFAULT_ACCENT_FONT = 'Source Sans Pro';
+    private const DEFAULT_ACCENT_WEIGHT = '300';
     private const DEFAULT_SITE_NAME = 'Finance Manager';
     private const DEFAULT_COLOR_SCHEME = 'indigo';
 
@@ -34,13 +35,14 @@ class Setting {
     /**
      * Convenience accessor for the site's configured fonts with sensible defaults.
      *
-     * @return array{heading: string, body: string, accent: string}
+     * @return array{heading: string, body: string, accent: string, accent_weight: string}
      */
     public static function getFonts(): array {
         return [
-            'heading' => self::get('font_heading') ?? self::DEFAULT_HEADING_FONT,
-            'body'    => self::get('font_body') ?? self::DEFAULT_BODY_FONT,
-            'accent'  => self::get('font_accent') ?? self::DEFAULT_ACCENT_FONT,
+            'heading'       => self::get('font_heading') ?? self::DEFAULT_HEADING_FONT,
+            'body'          => self::get('font_body') ?? self::DEFAULT_BODY_FONT,
+            'accent'        => self::get('font_accent') ?? self::DEFAULT_ACCENT_FONT,
+            'accent_weight' => self::get('font_accent_weight') ?? self::DEFAULT_ACCENT_WEIGHT,
         ];
     }
 

--- a/settings.php
+++ b/settings.php
@@ -22,6 +22,7 @@ $fontSettings = Setting::getFonts();
 $fontHeading = $fontSettings['heading'];
 $fontBody = $fontSettings['body'];
 $fontAccent = $fontSettings['accent'];
+$fontAccentWeight = $fontSettings['accent_weight'];
 $brand = Setting::getBrand();
 $siteName = $brand['site_name'];
 $colorScheme = $brand['color_scheme'];
@@ -52,6 +53,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $fontHeading = trim($_POST['font_heading'] ?? '');
     $fontBody = trim($_POST['font_body'] ?? '');
     $fontAccent = trim($_POST['font_accent'] ?? '');
+    $fontAccentWeight = trim($_POST['font_accent_weight'] ?? '');
     $siteName = trim($_POST['site_name'] ?? '');
     $newColorScheme = trim($_POST['color_scheme'] ?? '');
     Setting::set('openai_api_token', $openai);
@@ -90,6 +92,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         Setting::set('font_accent', $fontAccent);
         Log::write('Updated accent font');
     }
+    if ($fontAccentWeight !== '') {
+        Setting::set('font_accent_weight', $fontAccentWeight);
+        Log::write('Updated accent font weight');
+    }
     if ($siteName !== '') {
         Setting::set('site_name', $siteName);
         Log::write('Updated site name');
@@ -123,11 +129,11 @@ $bg600 = "bg-{$colorScheme}-600";
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&display=swap" rel="stylesheet">
     <style>
-        body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
-        button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
+        body { font-family: '<?= htmlspecialchars($fontBody, ENT_QUOTES) ?>', sans-serif; }
+        h1, h2, h3, h4, h5, h6 { font-family: '<?= htmlspecialchars($fontHeading, ENT_QUOTES) ?>', sans-serif; font-weight: 700; }
+        button, .accent { font-family: '<?= htmlspecialchars($fontAccent, ENT_QUOTES) ?>', sans-serif; font-weight: <?= htmlspecialchars($fontAccentWeight, ENT_QUOTES) ?>; }
         a { transition: color 0.2s ease; }
         a:hover { color: <?= $colorHex ?>; }
         button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
@@ -195,6 +201,12 @@ $bg600 = "bg-{$colorScheme}-600";
                     <?php foreach ($fontOptions as $opt): ?>
                         <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontAccent ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
                     <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block">Accent Font Weight:
+                <select name="font_accent_weight" class="border p-2 rounded w-full" data-help="Weight for buttons and accents">
+                    <option value="300" <?= $fontAccentWeight === '300' ? 'selected' : '' ?>>Light (300)</option>
+                    <option value="100" <?= $fontAccentWeight === '100' ? 'selected' : '' ?>>Very Thin (100)</option>
                 </select>
             </label>
             <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded md:col-span-2" aria-label="Save Settings"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>


### PR DESCRIPTION
## Summary
- Allow accent font weight to be configured, adding a very thin (100) option alongside the existing light (300)
- Load and apply the selected accent weight across settings, login, and the shared menu script

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf0ed057fc832eb5cfe53402744b4c