### PR TITLE
Include missing tooltip scripts on authentication pages

### DIFF
--- a/frontend/js/aria_tooltips.js
+++ b/frontend/js/aria_tooltips.js
@@ -1,0 +1,25 @@
+(() => {
+  const apply = (root = document) => {
+    root.querySelectorAll('[aria-label]').forEach(el => {
+      if (!el.getAttribute('data-tooltip')) {
+        el.setAttribute('data-tooltip', el.getAttribute('aria-label'));
+      }
+    });
+  };
+  apply();
+  const observer = new MutationObserver(mutations => {
+    for (const m of mutations) {
+      m.addedNodes.forEach(node => {
+        if (node.nodeType === 1) {
+          if (node.hasAttribute && node.hasAttribute('aria-label') && !node.getAttribute('data-tooltip')) {
+            node.setAttribute('data-tooltip', node.getAttribute('aria-label'));
+          }
+          if (node.querySelectorAll) {
+            apply(node);
+          }
+        }
+      });
+    }
+  });
+  observer.observe(document.body, {childList: true, subtree: true});
+})();

--- a/index.php
+++ b/index.php
@@ -116,5 +116,8 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <script src="frontend/js/input_help.js"></script>
     <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
+    <script src="frontend/js/overlay.js"></script>
+    <script src="frontend/js/aria_tooltips.js"></script>
+    <script src="frontend/js/tooltips.js"></script>
 </body>
 </html>

--- a/settings.php
+++ b/settings.php
@@ -216,5 +216,7 @@ $bg600 = "bg-{$colorScheme}-600";
     <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
     <script src="frontend/js/overlay.js"></script>
+    <script src="frontend/js/aria_tooltips.js"></script>
+    <script src="frontend/js/tooltips.js"></script>
 </body>
 </html>

--- a/users.php
+++ b/users.php
@@ -127,6 +127,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
     <script src="frontend/js/overlay.js"></script>
+    <script src="frontend/js/aria_tooltips.js"></script>
+    <script src="frontend/js/tooltips.js"></script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 


### PR DESCRIPTION
## Summary
- Add shared script to mirror `aria-label` attributes into `data-tooltip`
- Load tooltip and overlay scripts on login, settings and user pages

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfdb4eb24c832ea3964361bb753786