### PR TITLE
Remove keyboard navigation tips

### DIFF
--- a/frontend/js/keyboard_hints.js
+++ b/frontend/js/keyboard_hints.js
@@ -1,8 +1,0 @@
-// Displays a brief keyboard navigation tip on each page.
-document.addEventListener('DOMContentLoaded', () => {
-  const hint = document.createElement('div');
-  hint.textContent = 'Tip: Use Tab to move around, Shift+Tab to move back, Enter to activate and ? for help.';
-  hint.className = 'fixed bottom-4 left-4 bg-indigo-600 text-white text-sm px-3 py-2 rounded shadow';
-  document.body.appendChild(hint);
-  setTimeout(() => hint.remove(), 8000);
-});

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -365,10 +365,6 @@ window.fetchNoCache = fetchNoCache;
   helpScript.src = 'js/page_help.js';
   document.body.appendChild(helpScript);
 
-  const hintScript = document.createElement('script');
-  hintScript.src = 'js/keyboard_hints.js';
-  document.body.appendChild(hintScript);
-
   const logoutScript = document.createElement('script');
   logoutScript.src = 'js/auto_logout.js';
   document.body.appendChild(logoutScript);

--- a/index.php
+++ b/index.php
@@ -114,7 +114,6 @@ $needsToken = isset($_SESSION['pending_user_id']);
         <?php endif; ?>
     </div>
     <script src="frontend/js/input_help.js"></script>
-    <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
 </body>
 </html>

--- a/logout.php
+++ b/logout.php
@@ -55,7 +55,6 @@ $bgHover = "hover:bg-{$colorScheme}-700";
         <p class="mb-4">You have been safely logged out of the <?= htmlspecialchars($siteName) ?>.</p>
         <a href="index.php" class="<?= $bg600 ?> <?= $bgHover ?> text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Return to Login</a>
     </div>
-    <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
 </body>
 </html>

--- a/settings.php
+++ b/settings.php
@@ -213,7 +213,6 @@ $bg600 = "bg-{$colorScheme}-600";
         </form>
     </div>
     <script src="frontend/js/input_help.js"></script>
-    <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
     <script src="frontend/js/overlay.js"></script>
 </body>

--- a/users.php
+++ b/users.php
@@ -124,7 +124,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </div>
     </div>
     <script src="frontend/js/input_help.js"></script>
-    <script src="frontend/js/keyboard_hints.js"></script>
     <script src="frontend/js/page_help.js"></script>
     <script src="frontend/js/overlay.js"></script>
 


### PR DESCRIPTION
## Summary
- Remove keyboard navigation hint script and its references to avoid redundant tabbing tips.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfdbb4cce8832ea523b93ed51d63dd