### PR TITLE
Remove topbar transaction search component

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -314,10 +314,6 @@ window.fetchNoCache = fetchNoCache;
   utility.className = 'fixed top-4 right-8 md:top-8 md:right-12 bg-white rounded-full border border-indigo-600 p-2 flex items-center space-x-4 z-50 transition-shadow hover:shadow-lg';
 
   utility.innerHTML = `
-    <form id="topbar-search" action="search.html" method="get" class="flex">
-      <input type="text" name="value" placeholder="Search transactions" class="p-1 rounded text-black bg-white border-0 transition-shadow focus:shadow" />
-      <button type="submit" class="ml-2"><i class="fas fa-search h-4 w-4"></i></button>
-    </form>
     <a id="latest-statement-link" href="monthly_statement.html" class="hidden md:flex items-center">
       <i class="fas fa-file-invoice h-4 w-4"></i>
     </a>


### PR DESCRIPTION
## Summary
- remove topbar transaction search box from menu utility bar

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfddb27f14832ebbeb002c1dcb80f2