### PR TITLE
Make report descriptions link to transaction details

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -296,7 +296,16 @@
                 layout: 'fitDataStretch',
                 columns: [
                     { title: 'Date', field: 'date' },
-                    { title: 'Description', field: 'description', bottomCalc: function() { return 'Total'; } },
+                    { title: 'Description', field: 'description', formatter: function(cell){
+                            const data = cell.getRow().getData();
+                            const value = cell.getValue();
+                            if (!data.id) return value;
+                            const link = document.createElement('a');
+                            link.href = `transaction.html?id=${data.id}`;
+                            link.textContent = value;
+                            link.className = 'text-indigo-600 hover:underline';
+                            return link;
+                        }, bottomCalc: function() { return 'Total'; } },
                     { title: 'Category', field: 'category_name', formatter: badgeFormatter('bg-green-200 text-green-800') },
                     { title: 'Tag', field: 'tag_name', formatter: badgeFormatter('bg-indigo-200 text-indigo-800') },
                     { title: 'Group', field: 'group_name', formatter: badgeFormatter('bg-purple-200 text-purple-800') },

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -209,7 +209,7 @@ class Transaction {
 
         $db = Database::getConnection();
         $ignore = Tag::getIgnoreId();
-        $sql = 'SELECT t.`date`, t.`amount`, t.`description`, t.`memo`, '
+        $sql = 'SELECT t.`id`, t.`date`, t.`amount`, t.`description`, t.`memo`, '
              . 'c.`name` AS category_name, tg.`name` AS tag_name, g.`name` AS group_name, s.`name` AS segment_name '
              . 'FROM `transactions` t '
              . 'LEFT JOIN `categories` c ON t.`category_id` = c.`id` '


### PR DESCRIPTION
## Summary
- Include transaction IDs in report filter results
- Link report descriptions to the transaction details page

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c00cd5319c832eb086c78db7ec1e72