### PR TITLE
Allow editing tag category groups on transaction page

### DIFF
--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -40,8 +40,9 @@
     } else {
         Promise.all([
             fetch('../php_backend/public/transaction.php?id=' + id).then(r => r.json()),
-            fetch('../php_backend/public/groups.php').then(r => r.json())
-        ]).then(([tx, groups]) => {
+            fetch('../php_backend/public/groups.php').then(r => r.json()),
+            fetch('../php_backend/public/categories.php').then(r => r.json())
+        ]).then(([tx, groups, categories]) => {
             if (tx.error) {
                 container.textContent = 'Transaction not found.';
                 return;
@@ -93,6 +94,7 @@
                     <div class="flex justify-between"><span class="font-semibold">Category</span><span>${tx.category_name || 'None'}</span></div>
                 </div>
                 <label class="block">Tag: <input type="text" id="tag" class="border p-2 rounded w-full" data-help="Enter a new tag name to auto-tag similar transactions"></label>
+                <label class="block">Category Group: <select id="category" class="border p-2 rounded w-full" data-help="Assign a category group"></select></label>
                 <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Assign a group"></select></label>
                 <div class="flex space-x-2 justify-center no-print">
                     <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded" aria-label="Save transaction">Save</button>
@@ -110,6 +112,7 @@
                 tagInput.parentElement.classList.add('hidden');
             }
             const groupSel = form.querySelector('#group');
+            const catSel = form.querySelector('#category');
             tagInput.value = tx.tag_name || '';
             const blankGrp = document.createElement('option');
             blankGrp.value = '';
@@ -124,6 +127,25 @@
                     else if (!g.active) opt.disabled = true;
                     groupSel.appendChild(opt);
                 }
+            });
+            const blankCat = document.createElement('option');
+            blankCat.value = '';
+            blankCat.textContent = '-- None --';
+            catSel.appendChild(blankCat);
+            const segMap = {};
+            categories.forEach(c => {
+                const seg = c.segment_name || 'Unassigned';
+                if (!segMap[seg]) {
+                    const og = document.createElement('optgroup');
+                    og.label = seg;
+                    segMap[seg] = og;
+                    catSel.appendChild(og);
+                }
+                const opt = document.createElement('option');
+                opt.value = c.id;
+                opt.textContent = c.name;
+                if (c.id == tx.category_id) opt.selected = true;
+                segMap[seg].appendChild(opt);
             });
             const newGrp = document.createElement('option');
             newGrp.value = '__new';
@@ -165,7 +187,9 @@
                     description: tx.description
                 };
                 if (groupSel.value !== '') payload.group_id = groupSel.value;
-                if (tagInput.value.trim() !== '') payload.tag_name = tagInput.value.trim();
+                if (catSel.value !== '') payload.category_id = catSel.value;
+                if (tx.tag_id) payload.tag_id = tx.tag_id;
+                else if (tagInput.value.trim() !== '') payload.tag_name = tagInput.value.trim();
 
                 fetch('../php_backend/public/update_transaction.php', {
                     method: 'POST',

--- a/php_backend/models/CategoryTag.php
+++ b/php_backend/models/CategoryTag.php
@@ -27,6 +27,17 @@ class CategoryTag {
     }
 
     /**
+     * Return the category id currently linked to the given tag, or null if unassigned.
+     */
+    public static function getCategoryId(int $tagId): ?int {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT category_id FROM category_tags WHERE tag_id = :tag LIMIT 1');
+        $stmt->execute(['tag' => $tagId]);
+        $id = $stmt->fetchColumn();
+        return $id !== false ? (int)$id : null;
+    }
+
+    /**
      * Move a tag from one category to another atomically.
      */
     public static function move(int $oldCategoryId, int $newCategoryId, int $tagId): void {

--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -34,10 +34,6 @@ try {
     $tagChanged = false;
     $categoryChanged = false;
 
-    if ($categoryId !== null) {
-        Transaction::setCategory((int)$transactionId, $categoryId === '' ? null : (int)$categoryId);
-        $categoryChanged = true;
-    }
     if ($groupId !== null) {
 
         $newGroup = $groupId === '' ? null : (int)$groupId;
@@ -72,6 +68,24 @@ try {
         }
         Transaction::setTag((int)$transactionId, (int)$tagId);
         $tagChanged = true;
+    }
+
+    if ($categoryId !== null) {
+        $newCategory = $categoryId === '' ? null : (int)$categoryId;
+        if ($tagId) {
+            $current = CategoryTag::getCategoryId((int)$tagId);
+            if ($current !== $newCategory) {
+                if ($current !== null && $newCategory !== null) {
+                    CategoryTag::move($current, $newCategory, (int)$tagId);
+                } elseif ($current !== null && $newCategory === null) {
+                    CategoryTag::remove($current, (int)$tagId);
+                } elseif ($current === null && $newCategory !== null) {
+                    CategoryTag::add($newCategory, (int)$tagId);
+                }
+            }
+        }
+        Transaction::setCategory((int)$transactionId, $newCategory);
+        $categoryChanged = true;
     }
 
     $applied = $tagChanged ? Tag::applyToAccountTransactions((int)$accountId) : 0;


### PR DESCRIPTION
## Summary
- Let transaction details page edit tag's category group with a new dropdown
- Track category link for tags and update mapping when saving
- Add helper to fetch a tag's current category

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c00eb6bf30832e8c0ddb6d857fd04d