### PR TITLE
Show saved report descriptions in selector

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -205,7 +205,8 @@
             saved.forEach(r => {
                 const opt = document.createElement('option');
                 opt.value = r.id;
-                opt.textContent = r.name;
+                const label = r.description ? `${r.name} - ${r.description}` : r.name;
+                opt.textContent = label;
                 if (r.description) opt.title = r.description;
                 select.appendChild(opt);
             });


### PR DESCRIPTION
## Summary
- Include report descriptions in saved report dropdown labels for easier identification

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c013c6bab8832e850524e68323b4b5