### PR TITLE
Use report name and description as PDF title

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -449,7 +449,9 @@
         doc.setTextColor(255, 255, 255);
         doc.setFontSize(16);
         const siteTitle = document.querySelector('#site-title')?.textContent?.trim() || 'Accounts';
-        const reportTitle = `${siteTitle} - Transaction Report`;
+        const reportTitle = (currentReportName && currentReportDesc)
+            ? `${currentReportName} - ${currentReportDesc}`
+            : `${siteTitle} - Transaction Report`;
         doc.text(reportTitle, 14, 12);
         doc.setProperties({ title: reportTitle });
 


### PR DESCRIPTION
## Summary
- Use saved report's name and description as the PDF's title when exporting transaction reports.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c01612c3fc832ea11ca1d846ab73e3