### PR TITLE
Add configurable table font setting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,4 @@
 ## Decisions
 - Sections use scroll-based fade-in; apply `opacity-0` initially and `frontend/js/scroll_animations.js` adds a `fade-in` class when in view.
 - Settings include an accent font weight option offering light (300) and very thin (100) styles.
+- Settings provide a table font option applied to all Tabulator tables.

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -115,7 +115,8 @@ window.fetchNoCache = fetchNoCache;
       const families = [
         `family=${encodeURIComponent(f.heading)}:wght@700`,
         `family=${encodeURIComponent(f.body)}:wght@400`,
-        `family=${encodeURIComponent(f.accent)}:wght@${f.accent_weight || 300}`
+        `family=${encodeURIComponent(f.accent)}:wght@${f.accent_weight || 300}`,
+        `family=${encodeURIComponent(f.table)}:wght@400`
       ];
       if (fontLink) {
         fontLink.href = `https://fonts.googleapis.com/css2?${families.join('&')}&display=swap`;
@@ -126,6 +127,7 @@ window.fetchNoCache = fetchNoCache;
             --heading-font: '${f.heading}', sans-serif;
             --body-font: '${f.body}', sans-serif;
             --accent-font: '${f.accent}', sans-serif;
+            --table-font: '${f.table}', sans-serif;
           }
           body { font-family: var(--body-font); font-weight: 400; }
           h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }
@@ -155,6 +157,7 @@ window.fetchNoCache = fetchNoCache;
             --heading-font: 'Roboto', sans-serif;
             --body-font: 'Inter', sans-serif;
             --accent-font: 'Source Sans Pro', sans-serif;
+            --table-font: 'Inter', sans-serif;
           }
           body { font-family: var(--body-font); font-weight: 400; }
           h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -96,17 +96,16 @@ function tailwindTabulator(element, options) {
     }
 
     const table = new Tabulator(element, options);
-    const bodyFont = getComputedStyle(document.body).fontFamily;
-    const headingEl = document.querySelector('h1, h2, h3, h4, h5, h6');
-    const headingFont = headingEl ? getComputedStyle(headingEl).fontFamily : bodyFont;
+    const rootStyles = getComputedStyle(document.documentElement);
+    const tableFont = rootStyles.getPropertyValue('--table-font') || getComputedStyle(document.body).fontFamily;
     const accentEl = document.querySelector('button, .accent');
-    const accentFont = accentEl ? getComputedStyle(accentEl).fontFamily : bodyFont;
+    const accentFont = accentEl ? getComputedStyle(accentEl).fontFamily : tableFont;
     const el = table.element;
-    el.style.setProperty('--tabulator-font-family', bodyFont);
-    el.style.setProperty('--tabulator-row-font-family', bodyFont);
-    el.style.setProperty('--tabulator-header-font-family', headingFont);
+    el.style.setProperty('--tabulator-font-family', tableFont);
+    el.style.setProperty('--tabulator-row-font-family', tableFont);
+    el.style.setProperty('--tabulator-header-font-family', tableFont);
     el.style.setProperty('--tabulator-header-font-weight', '700');
-    el.style.fontFamily = bodyFont;
+    el.style.fontFamily = tableFont;
     el.style.colorScheme = 'light';
 
 
@@ -149,7 +148,7 @@ function tailwindTabulator(element, options) {
     table.on('tableBuilt', function() {
         const titles = el.querySelectorAll('.tabulator-col-title');
         titles.forEach(title => {
-            title.style.fontFamily = headingFont;
+            title.style.fontFamily = tableFont;
             title.style.fontWeight = '700';
         });
         styleCalcRows(table);

--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -5,6 +5,7 @@
     --heading-font: 'Roboto', sans-serif;
     --body-font: 'Inter', sans-serif;
     --accent-font: 'Source Sans Pro', sans-serif;
+    --table-font: 'Inter', sans-serif;
   }
   body { font-family: var(--body-font); font-weight: 400; }
   h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }

--- a/index.php
+++ b/index.php
@@ -17,6 +17,7 @@ $fontHeading = $fonts['heading'];
 $fontBody = $fonts['body'];
 $fontAccent = $fonts['accent'];
 $fontAccentWeight = $fonts['accent_weight'];
+$fontTable = $fonts['table'];
 $error = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -75,7 +76,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <script>window.tailwind = window.tailwind || {}; window.tailwind.config = {};</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
-    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&family=<?= urlencode($fontTable) ?>:wght@400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
         body { font-family: '<?= htmlspecialchars($fontBody, ENT_QUOTES) ?>', sans-serif; font-weight: 400; }

--- a/php_backend/models/Setting.php
+++ b/php_backend/models/Setting.php
@@ -8,6 +8,7 @@ class Setting {
     private const DEFAULT_BODY_FONT = 'Inter';
     private const DEFAULT_ACCENT_FONT = 'Source Sans Pro';
     private const DEFAULT_ACCENT_WEIGHT = '300';
+    private const DEFAULT_TABLE_FONT = 'Inter';
     private const DEFAULT_SITE_NAME = 'Finance Manager';
     private const DEFAULT_COLOR_SCHEME = 'indigo';
 
@@ -35,7 +36,13 @@ class Setting {
     /**
      * Convenience accessor for the site's configured fonts with sensible defaults.
      *
-     * @return array{heading: string, body: string, accent: string, accent_weight: string}
+     * @return array{
+     *   heading: string,
+     *   body: string,
+     *   accent: string,
+     *   accent_weight: string,
+     *   table: string
+     * }
      */
     public static function getFonts(): array {
         return [
@@ -43,6 +50,7 @@ class Setting {
             'body'          => self::get('font_body') ?? self::DEFAULT_BODY_FONT,
             'accent'        => self::get('font_accent') ?? self::DEFAULT_ACCENT_FONT,
             'accent_weight' => self::get('font_accent_weight') ?? self::DEFAULT_ACCENT_WEIGHT,
+            'table'         => self::get('font_table') ?? self::DEFAULT_TABLE_FONT,
         ];
     }
 

--- a/settings.php
+++ b/settings.php
@@ -23,6 +23,7 @@ $fontHeading = $fontSettings['heading'];
 $fontBody = $fontSettings['body'];
 $fontAccent = $fontSettings['accent'];
 $fontAccentWeight = $fontSettings['accent_weight'];
+$fontTable = $fontSettings['table'];
 $brand = Setting::getBrand();
 $siteName = $brand['site_name'];
 $colorScheme = $brand['color_scheme'];
@@ -54,6 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $fontBody = trim($_POST['font_body'] ?? '');
     $fontAccent = trim($_POST['font_accent'] ?? '');
     $fontAccentWeight = trim($_POST['font_accent_weight'] ?? '');
+    $fontTable = trim($_POST['font_table'] ?? '');
     $siteName = trim($_POST['site_name'] ?? '');
     $newColorScheme = trim($_POST['color_scheme'] ?? '');
     Setting::set('openai_api_token', $openai);
@@ -96,6 +98,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         Setting::set('font_accent_weight', $fontAccentWeight);
         Log::write('Updated accent font weight');
     }
+    if ($fontTable !== '') {
+        Setting::set('font_table', $fontTable);
+        Log::write('Updated table font');
+    }
     if ($siteName !== '') {
         Setting::set('site_name', $siteName);
         Log::write('Updated site name');
@@ -129,7 +135,7 @@ $bg600 = "bg-{$colorScheme}-600";
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
-    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&family=<?= urlencode($fontTable) ?>:wght@400&display=swap" rel="stylesheet">
     <style>
         body { font-family: '<?= htmlspecialchars($fontBody, ENT_QUOTES) ?>', sans-serif; }
         h1, h2, h3, h4, h5, h6 { font-family: '<?= htmlspecialchars($fontHeading, ENT_QUOTES) ?>', sans-serif; font-weight: 700; }
@@ -200,6 +206,13 @@ $bg600 = "bg-{$colorScheme}-600";
                 <select name="font_accent" class="border p-2 rounded w-full" data-help="Font used for buttons and accents">
                     <?php foreach ($fontOptions as $opt): ?>
                         <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontAccent ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block">Table Font:
+                <select name="font_table" class="border p-2 rounded w-full" data-help="Font used for tables">
+                    <?php foreach ($fontOptions as $opt): ?>
+                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontTable ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
                     <?php endforeach; ?>
                 </select>
             </label>


### PR DESCRIPTION
## Summary
- allow configuring a font specifically for Tabulator tables
- surface the table font in shared menu resources and apply it through Tabulator
- document new table font option

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68c26b622df4832e876159ae15c2f292