### PR TITLE
Apply table fonts earlier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,4 @@
 - Sections use scroll-based fade-in; apply `opacity-0` initially and `frontend/js/scroll_animations.js` adds a `fade-in` class when in view.
 - Settings include an accent font weight option offering light (300) and very thin (100) styles.
 - Settings provide a table font option applied to all Tabulator tables.
+- Table font CSS variables (`--tabulator-*`) are set in the shared menu so Tabulator tables use the correct fonts during initial render.

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -128,10 +128,15 @@ window.fetchNoCache = fetchNoCache;
             --body-font: '${f.body}', sans-serif;
             --accent-font: '${f.accent}', sans-serif;
             --table-font: '${f.table}', sans-serif;
+            --tabulator-font-family: var(--table-font);
+            --tabulator-row-font-family: var(--table-font);
+            --tabulator-header-font-family: var(--table-font);
+            --tabulator-header-font-weight: 700;
           }
           body { font-family: var(--body-font); font-weight: 400; }
           h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }
           button, .accent { font-family: var(--accent-font); font-weight: ${f.accent_weight || 300}; }
+          .tabulator { font-family: var(--tabulator-font-family); }
         `;
       }
       siteName = f.site_name || siteName;
@@ -158,10 +163,15 @@ window.fetchNoCache = fetchNoCache;
             --body-font: 'Inter', sans-serif;
             --accent-font: 'Source Sans Pro', sans-serif;
             --table-font: 'Inter', sans-serif;
+            --tabulator-font-family: var(--table-font);
+            --tabulator-row-font-family: var(--table-font);
+            --tabulator-header-font-family: var(--table-font);
+            --tabulator-header-font-weight: 700;
           }
           body { font-family: var(--body-font); font-weight: 400; }
           h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }
           button, .accent { font-family: var(--accent-font); font-weight: 300; }
+          .tabulator { font-family: var(--tabulator-font-family); }
         `;
       }
       applyColorScheme();

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -97,15 +97,8 @@ function tailwindTabulator(element, options) {
 
     const table = new Tabulator(element, options);
     const rootStyles = getComputedStyle(document.documentElement);
-    const tableFont = rootStyles.getPropertyValue('--table-font') || getComputedStyle(document.body).fontFamily;
-    const accentEl = document.querySelector('button, .accent');
-    const accentFont = accentEl ? getComputedStyle(accentEl).fontFamily : tableFont;
+    const accentFont = rootStyles.getPropertyValue('--accent-font') || getComputedStyle(document.body).fontFamily;
     const el = table.element;
-    el.style.setProperty('--tabulator-font-family', tableFont);
-    el.style.setProperty('--tabulator-row-font-family', tableFont);
-    el.style.setProperty('--tabulator-header-font-family', tableFont);
-    el.style.setProperty('--tabulator-header-font-weight', '700');
-    el.style.fontFamily = tableFont;
     el.style.colorScheme = 'light';
 
 
@@ -146,11 +139,6 @@ function tailwindTabulator(element, options) {
         });
     }
     table.on('tableBuilt', function() {
-        const titles = el.querySelectorAll('.tabulator-col-title');
-        titles.forEach(title => {
-            title.style.fontFamily = tableFont;
-            title.style.fontWeight = '700';
-        });
         styleCalcRows(table);
     });
     table.on('dataProcessed', function() {

--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -6,10 +6,15 @@
     --body-font: 'Inter', sans-serif;
     --accent-font: 'Source Sans Pro', sans-serif;
     --table-font: 'Inter', sans-serif;
+    --tabulator-font-family: var(--table-font);
+    --tabulator-row-font-family: var(--table-font);
+    --tabulator-header-font-family: var(--table-font);
+    --tabulator-header-font-weight: 700;
   }
   body { font-family: var(--body-font); font-weight: 400; }
   h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }
   button, .accent { font-family: var(--accent-font); font-weight: 300; }
+  .tabulator { font-family: var(--tabulator-font-family); }
 </style>
 <!-- Navigation menu shared across pages -->
 <div class="flex items-center space-x-2 mb-4">


### PR DESCRIPTION
## Summary
- Move Tabulator font settings to shared menu styles so tables use the correct fonts as soon as they render
- Simplify Tabulator initialisation to rely on CSS variables instead of runtime font styling
- Document new table font behaviour

## Testing
- `php tests/run_tests.php`

------
https://chatgpt.com/codex/tasks/task_e_68c2b41f7538832ea76066f39fe663c8