### PR TITLE
Add funky fonts to settings options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,3 +69,4 @@
 - Settings include an accent font weight option offering light (300) and very thin (100) styles.
 - Settings provide a table font option applied to all Tabulator tables.
 - Table font CSS variables (`--tabulator-*`) are set in the shared menu so Tabulator tables use the correct fonts during initial render.
+- Settings page offers additional funky font options: Bangers, Caveat, Dancing Script, Fredoka, Pacifico.

--- a/settings.php
+++ b/settings.php
@@ -30,7 +30,8 @@ $colorScheme = $brand['color_scheme'];
 $fontOptions = [
     'Roboto', 'Inter', 'Source Sans Pro', 'Montserrat', 'Open Sans', 'Lato',
     'Nunito', 'Poppins', 'Raleway', 'Work Sans', 'Quicksand',
-    'Karla', 'Fira Sans', 'Noto Sans'
+    'Karla', 'Fira Sans', 'Noto Sans', 'Bangers', 'Caveat', 'Dancing Script',
+    'Fredoka', 'Pacifico'
 ];
 $colorOptions = ['indigo', 'blue', 'green', 'red', 'purple', 'teal', 'orange'];
 $colorMap = [


### PR DESCRIPTION
## Summary
- extend settings font options with playful Google fonts like Bangers, Caveat, Dancing Script, Fredoka and Pacifico
- document availability of new fonts in project decisions

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2c74fab68832eb2d4871846c7b54a