### PR TITLE
Remove hardcoded fonts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 - Display monetary values with the pound symbol (£).
 - Style the frontend with Tailwind CSS. Wrap primary sections in white card components (`bg-white p-6 rounded shadow`).
 - Use Font Awesome for interface icons.
-- Headings should use bold Roboto, body text should use Inter, and buttons or highlights should use light Source Sans Pro.
+- Avoid hardcoding font families; rely on browser defaults.
 - Tabulator tables should apply Tailwind utility classes.
 - Provide popover help for form inputs using `data-help` attributes handled by `frontend/js/input_help.js`.
 - Ensure the site remains mobile-friendly: include `<meta name="viewport" content="width=device-width, initial-scale=1.0">` on

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Two PHP endpoints under `php_backend/public` handle TOTP setup and verification 
 - Highcharts is used for graphs, while Tabulator renders interactive tables.
 - Display all monetary values using the pound symbol (£) instead of the dollar sign ($).
 - Tailwind CSS provides the styling and Font Awesome supplies icons. Sections are wrapped in card components.
-- Headings use bold Roboto, body text uses Inter, and buttons or highlights use light Source Sans Pro.
+- The interface relies on browser-default fonts without specifying families.
 
 - Tabulator tables apply Tailwind utility classes for a consistent look and use the Simple theme.
 

--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -11,29 +11,26 @@
         window.tailwind.config = {};
     </script>
 
-    <script src="https://cdn.tailwindcss.com"></script>
+      <script src="https://cdn.tailwindcss.com"></script>
 
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
-
-    <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
-    <!-- Icons provided by Font Awesome loaded via menu.js -->
-    <!-- Custom fonts handled via Tailwind utility classes -->
+      <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
+      <!-- Icons provided by Font Awesome loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter']" data-api-base="../php_backend/public">
+<body class="bg-gradient-to-b from-indigo-50 to-white" data-api-base="../php_backend/public">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <div class="flex items-center mb-4">
-                <h1 class="font-['Montserrat'] text-2xl font-semibold flex-1 text-indigo-700"><i class="fas fa-shield-halved inline w-6 h-6 mr-2"></i>Two-Factor Authentication</h1>
-                <button id="help-btn" class="text-indigo-600 font-['Source_Sans_Pro'] font-light"><i class="fas fa-question-circle inline w-5 h-5"></i></button>
+                <h1 class="text-2xl font-semibold flex-1 text-indigo-700"><i class="fas fa-shield-halved inline w-6 h-6 mr-2"></i>Two-Factor Authentication</h1>
+                <button id="help-btn" class="text-indigo-600 font-light"><i class="fas fa-question-circle inline w-5 h-5"></i></button>
             </div>
             <p class="mb-4">Set up TOTP-based authentication and verify your one-time codes.</p>
 
             <div class="bg-white p-6 rounded shadow border border-gray-400 mb-6">
-                <h2 class="font-['Montserrat'] text-xl mb-4">Setup</h2>
+                  <h2 class="text-xl mb-4">Setup</h2>
                 <form id="generate-form" class="space-y-4">
                     <input id="gen-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">
-                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light"><i class="fas fa-qrcode inline w-4 h-4 mr-2"></i>Generate QR</button>
+                      <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded font-light"><i class="fas fa-qrcode inline w-4 h-4 mr-2"></i>Generate QR</button>
                 </form>
 
                 <div id="qr" class="mt-4 mx-auto"></div>
@@ -41,11 +38,11 @@
             </div>
 
             <div class="bg-white p-6 rounded shadow border border-gray-400">
-                <h2 class="font-['Montserrat'] text-xl mb-4">Verify</h2>
+                  <h2 class="text-xl mb-4">Verify</h2>
                 <form id="verify-form" class="space-y-4">
                     <input id="ver-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">
                     <input id="token" type="text" placeholder="TOTP Code" class="border p-2 rounded w-full" data-help="Enter the 6-digit code from your authenticator">
-                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light"><i class="fas fa-check inline w-4 h-4 mr-2"></i>Verify</button>
+                      <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded font-light"><i class="fas fa-check inline w-4 h-4 mr-2"></i>Verify</button>
                 </form>
             </div>
         </main>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,6 @@
     </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
     <meta property="og:title" content="Finance Manager">
     <meta property="og:description" content="Manage your finances with budgets, reports and more.">
@@ -24,7 +23,7 @@
       }
     </style>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter']">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex flex-col md:flex-row min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto shadow"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
@@ -37,15 +36,15 @@
                             <img src="wallet.svg" alt="Wallet icon" class="absolute inset-0 w-full h-full object-cover transition-all duration-700 opacity-0 translate-x-full">
                         </div>
                         <div class="absolute inset-0 bg-indigo-700/60 flex flex-col items-center justify-center text-center p-6">
-                            <h1 class="font-['Roboto'] text-3xl md:text-4xl font-semibold mb-4 text-white">Welcome to <span id="landing-site-name">Finance Manager</span></h1>
+                            <h1 class="text-3xl md:text-4xl font-semibold mb-4 text-white">Welcome to <span id="landing-site-name">Finance Manager</span></h1>
                             <p class="text-indigo-100 mb-4">Select an option from the menu to get started exploring your finances. Each section opens tools and dashboards that help you understand where your money goes.</p>
-                            <a href="upload.html" class="inline-block bg-white text-indigo-700 px-4 py-2 rounded hover:bg-indigo-100 font-['Source_Sans_Pro'] font-light">Get Started</a>
+                              <a href="upload.html" class="inline-block bg-white text-indigo-700 px-4 py-2 rounded hover:bg-indigo-100 font-light">Get Started</a>
                         </div>
                     </div>
                     <div class="relative rounded-lg overflow-hidden shadow h-72 md:h-96">
                         <img src="coin_flower.png" alt="Coin plant illustration" class="absolute inset-0 w-full h-full object-cover">
                         <div class="absolute inset-0 bg-black/40 flex items-center justify-center p-6 text-center">
-                            <p class="text-white text-2xl font-['Roboto']">Track savings effortlessly</p>
+                            <p class="text-white text-2xl">Track savings effortlessly</p>
                         </div>
                     </div>
                 </div>
@@ -70,7 +69,7 @@
 
             <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card="true">
 
-                <h2 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
+                <h2 class="text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div class="flex items-start space-x-3">
                         <i class="fas fa-file-upload text-indigo-600 fa-2x"></i>
@@ -146,7 +145,7 @@
 
             <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card="true">
 
-                <h2 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">How Data Is Organised</h2>
+                <h2 class="text-2xl font-semibold mb-4 text-indigo-700">How Data Is Organised</h2>
                 <svg role="img" aria-label="Segments link to categories and tags while groups stand alone" class="mx-auto mb-4" width="360" height="120">
                     <defs>
                         <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
@@ -154,15 +153,15 @@
                         </marker>
                     </defs>
                     <rect x="10" y="20" width="100" height="40" fill="#e0e7ff" stroke="#4338ca"></rect>
-                    <text x="60" y="45" text-anchor="middle" font-family="Roboto" font-size="14" fill="#1f2937">Segment</text>
+                    <text x="60" y="45" text-anchor="middle" font-size="14" fill="#1f2937">Segment</text>
                     <rect x="130" y="20" width="100" height="40" fill="#e0e7ff" stroke="#4338ca"></rect>
-                    <text x="180" y="45" text-anchor="middle" font-family="Roboto" font-size="14" fill="#1f2937">Category</text>
+                    <text x="180" y="45" text-anchor="middle" font-size="14" fill="#1f2937">Category</text>
                     <rect x="250" y="20" width="100" height="40" fill="#e0e7ff" stroke="#4338ca"></rect>
-                    <text x="300" y="45" text-anchor="middle" font-family="Roboto" font-size="14" fill="#1f2937">Tag</text>
+                    <text x="300" y="45" text-anchor="middle" font-size="14" fill="#1f2937">Tag</text>
                     <line x1="110" y1="40" x2="130" y2="40" stroke="#4338ca" stroke-width="2" marker-end="url(#arrow)"></line>
                     <line x1="230" y1="40" x2="250" y2="40" stroke="#4338ca" stroke-width="2" marker-end="url(#arrow)"></line>
                     <rect x="130" y="80" width="100" height="40" fill="#d1fae5" stroke="#047857" stroke-dasharray="4 2"></rect>
-                    <text x="180" y="105" text-anchor="middle" font-family="Roboto" font-size="14" fill="#1f2937">Group</text>
+                    <text x="180" y="105" text-anchor="middle" font-size="14" fill="#1f2937">Group</text>
                 </svg>
                 <p class="text-gray-700">Segments contain categories, and each category holds tags that label your transactions. Groups operate separately from this chain and are perfect for collecting transactions for holidays or projects, letting you see their total cost independently.</p>
             </section>

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -105,40 +105,9 @@ window.fetchNoCache = fetchNoCache;
   });
   ariaObserver.observe(document.body, {childList: true, subtree: true});
 
-  // References to font resources defined in shared template
-  const fontLink = document.getElementById('app-fonts');
-  const fontStyle = document.getElementById('font-style');
-
-  fetchNoCache('../php_backend/public/font_settings.php')
+  fetchNoCache('../php_backend/public/brand_settings.php')
     .then(r => r.json())
     .then(f => {
-      const families = [
-        `family=${encodeURIComponent(f.heading)}:wght@700`,
-        `family=${encodeURIComponent(f.body)}:wght@400`,
-        `family=${encodeURIComponent(f.accent)}:wght@${f.accent_weight || 300}`,
-        `family=${encodeURIComponent(f.table)}:wght@400`
-      ];
-      if (fontLink) {
-        fontLink.href = `https://fonts.googleapis.com/css2?${families.join('&')}&display=swap`;
-      }
-      if (fontStyle) {
-        fontStyle.textContent = `
-          :root {
-            --heading-font: '${f.heading}', sans-serif;
-            --body-font: '${f.body}', sans-serif;
-            --accent-font: '${f.accent}', sans-serif;
-            --table-font: '${f.table}', sans-serif;
-            --tabulator-font-family: var(--table-font);
-            --tabulator-row-font-family: var(--table-font);
-            --tabulator-header-font-family: var(--table-font);
-            --tabulator-header-font-weight: 700;
-          }
-          body { font-family: var(--body-font); font-weight: 400; }
-          h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }
-          button, .accent { font-family: var(--accent-font); font-weight: ${f.accent_weight || 300}; }
-          .tabulator { font-family: var(--tabulator-font-family); }
-        `;
-      }
       siteName = f.site_name || siteName;
       colorScheme = f.color_scheme || colorScheme;
       document.title = document.title.replace('Finance Manager', siteName);
@@ -152,28 +121,7 @@ window.fetchNoCache = fetchNoCache;
       });
     })
     .catch(err => {
-      console.error('Font load failed', err);
-      if (fontLink) {
-        fontLink.href = 'https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap';
-      }
-      if (fontStyle) {
-        fontStyle.textContent = `
-          :root {
-            --heading-font: 'Roboto', sans-serif;
-            --body-font: 'Inter', sans-serif;
-            --accent-font: 'Source Sans Pro', sans-serif;
-            --table-font: 'Inter', sans-serif;
-            --tabulator-font-family: var(--table-font);
-            --tabulator-row-font-family: var(--table-font);
-            --tabulator-header-font-family: var(--table-font);
-            --tabulator-header-font-weight: 700;
-          }
-          body { font-family: var(--body-font); font-weight: 400; }
-          h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }
-          button, .accent { font-family: var(--accent-font); font-weight: 300; }
-          .tabulator { font-family: var(--tabulator-font-family); }
-        `;
-      }
+      console.error('Brand load failed', err);
       applyColorScheme();
       applyIconColor();
     });

--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -1,21 +1,4 @@
-<link id="app-fonts" rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-<style id="font-style">
-  :root {
-    --heading-font: 'Roboto', sans-serif;
-    --body-font: 'Inter', sans-serif;
-    --accent-font: 'Source Sans Pro', sans-serif;
-    --table-font: 'Inter', sans-serif;
-    --tabulator-font-family: var(--table-font);
-    --tabulator-row-font-family: var(--table-font);
-    --tabulator-header-font-family: var(--table-font);
-    --tabulator-header-font-weight: 700;
-  }
-  body { font-family: var(--body-font); font-weight: 400; }
-  h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font); font-weight: 700; }
-  button, .accent { font-family: var(--accent-font); font-weight: 300; }
-  .tabulator { font-family: var(--tabulator-font-family); }
-</style>
 <!-- Navigation menu shared across pages -->
 <div class="flex items-center space-x-2 mb-4">
   <img src="/favicon.png" alt="Finance Manager logo" class="h-8 w-8 rounded shadow" />

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -11,14 +11,8 @@
         window.tailwind.config = {};
     </script>
 
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
-    <!-- Font Awesome icons loaded via menu.js -->
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: 'Roboto', sans-serif; font-weight: 700; }
-        button, .accent { font-family: 'Source Sans Pro', sans-serif; font-weight: 300; }
-    </style>
+      <script src="https://cdn.tailwindcss.com"></script>
+      <!-- Font Awesome icons loaded via menu.js -->
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
 <div class="flex min-h-screen">

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -11,30 +11,29 @@
         window.tailwind.config = {};
     </script>
 
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@700&family=Inter:wght@400&family=Source+Sans+Pro:wght@300&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+      <script src="https://cdn.tailwindcss.com"></script>
+      <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/highcharts-more.js"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-['Inter']">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
-        <h1 class="font-['Roboto'] text-2xl font-semibold mb-4 text-indigo-700">Projects</h1>
+        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Projects</h1>
         <p class="mb-4">Review your planned projects, explore costs and compare their priorities.</p>
 
         <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-6">
             <div>
-                <h2 class="font-['Roboto'] text-xl font-semibold mb-4">Budget Planning</h2>
+                <h2 class="text-xl font-semibold mb-4">Budget Planning</h2>
                 <div class="flex items-end space-x-4">
                     <label class="block">Annual Budget (£)<br><input type="number" id="annual-budget" class="border p-2 rounded" data-help="Total funds available"></label>
-                    <button id="apply-budget" class="bg-indigo-600 text-white px-4 py-2 rounded font-['Source_Sans_Pro'] font-light"><i class="fas fa-filter mr-1"></i>Apply Budget</button>
+                    <button id="apply-budget" class="bg-indigo-600 text-white px-4 py-2 rounded font-light"><i class="fas fa-filter mr-1"></i>Apply Budget</button>
                 </div>
             </div>
             <div>
-                <h2 class="font-['Roboto'] text-xl font-semibold mb-4">Project Comparison</h2>
+                <h2 class="text-xl font-semibold mb-4">Project Comparison</h2>
                 <div class="flex items-end space-x-4 mb-4">
                     <label class="block">X Axis<br>
                         <select id="x-axis" class="border p-2 rounded" data-help="Field used for horizontal axis">
@@ -64,7 +63,7 @@
                 <div id="project-bubble-chart" style="height:800px" data-chart-desc="Bubble chart plotting chosen fields with bubble size representing score."></div>
             </div>
             <div>
-                <h2 class="font-['Roboto'] text-xl font-semibold mb-4">Project Priorities</h2>
+                <h2 class="text-xl font-semibold mb-4">Project Priorities</h2>
                 <div id="projects-table"></div>
             </div>
         </section>

--- a/index.php
+++ b/index.php
@@ -12,12 +12,6 @@ $db = Database::getConnection();
 $brand = Setting::getBrand();
 $siteName = $brand['site_name'];
 $scheme = $brand['color_scheme'];
-$fonts = Setting::getFonts();
-$fontHeading = $fonts['heading'];
-$fontBody = $fonts['body'];
-$fontAccent = $fonts['accent'];
-$fontAccentWeight = $fonts['accent_weight'];
-$fontTable = $fonts['table'];
 $error = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -76,13 +70,7 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <script>window.tailwind = window.tailwind || {}; window.tailwind.config = {};</script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
-    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&family=<?= urlencode($fontTable) ?>:wght@400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    <style>
-        body { font-family: '<?= htmlspecialchars($fontBody, ENT_QUOTES) ?>', sans-serif; font-weight: 400; }
-        h1, h2, h3, h4, h5, h6 { font-family: '<?= htmlspecialchars($fontHeading, ENT_QUOTES) ?>', sans-serif; font-weight: 700; }
-        button { font-family: '<?= htmlspecialchars($fontAccent, ENT_QUOTES) ?>', sans-serif; font-weight: <?= htmlspecialchars($fontAccentWeight, ENT_QUOTES) ?>; }
-    </style>
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gray-50">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow border border-gray-400">

--- a/logout.php
+++ b/logout.php
@@ -20,12 +20,6 @@ if (isset($_GET['timeout'])) {
 $brand = Setting::getBrand();
 $siteName = $brand['site_name'];
 $colorScheme = $brand['color_scheme'];
-$fonts = Setting::getFonts();
-$fontHeading = $fonts['heading'];
-$fontBody = $fonts['body'];
-$fontAccent = $fonts['accent'];
-$fontAccentWeight = $fonts['accent_weight'];
-$fontTable = $fonts['table'];
 $colorMap = [
     'indigo' => ['600' => '#4f46e5', '700' => '#4338ca'],
     'blue'   => ['600' => '#2563eb', '700' => '#1d4ed8'],
@@ -52,12 +46,6 @@ $bgHover = "hover:bg-{$colorScheme}-700";
     </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
-    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&family=<?= urlencode($fontTable) ?>:wght@400&display=swap" rel="stylesheet">
-    <style>
-        body { font-family: '<?= htmlspecialchars($fontBody, ENT_QUOTES) ?>', sans-serif; font-weight: 400; }
-        h1, h2, h3, h4, h5, h6 { font-family: '<?= htmlspecialchars($fontHeading, ENT_QUOTES) ?>', sans-serif; font-weight: 700; }
-        button, .accent { font-family: '<?= htmlspecialchars($fontAccent, ENT_QUOTES) ?>', sans-serif; font-weight: <?= htmlspecialchars($fontAccentWeight, ENT_QUOTES) ?>; }
-    </style>
 </head>
 <body class="min-h-screen flex items-center justify-center bg-gray-50">
     <div class="w-full max-w-sm bg-white p-6 rounded shadow border border-gray-400 text-center">

--- a/php_backend/models/Setting.php
+++ b/php_backend/models/Setting.php
@@ -3,12 +3,6 @@
 require_once __DIR__ . '/../Database.php';
 
 class Setting {
-    /** Default fonts used when none have been configured. */
-    private const DEFAULT_HEADING_FONT = 'Roboto';
-    private const DEFAULT_BODY_FONT = 'Inter';
-    private const DEFAULT_ACCENT_FONT = 'Source Sans Pro';
-    private const DEFAULT_ACCENT_WEIGHT = '300';
-    private const DEFAULT_TABLE_FONT = 'Inter';
     private const DEFAULT_SITE_NAME = 'Finance Manager';
     private const DEFAULT_COLOR_SCHEME = 'indigo';
 
@@ -31,27 +25,6 @@ class Setting {
         $stmt = $db->prepare('INSERT INTO `settings` (`name`, `value`) VALUES (:name, :value)
             ON DUPLICATE KEY UPDATE `value` = VALUES(`value`)');
         $stmt->execute(['name' => $name, 'value' => $value]);
-    }
-
-    /**
-     * Convenience accessor for the site's configured fonts with sensible defaults.
-     *
-     * @return array{
-     *   heading: string,
-     *   body: string,
-     *   accent: string,
-     *   accent_weight: string,
-     *   table: string
-     * }
-     */
-    public static function getFonts(): array {
-        return [
-            'heading'       => self::get('font_heading') ?? self::DEFAULT_HEADING_FONT,
-            'body'          => self::get('font_body') ?? self::DEFAULT_BODY_FONT,
-            'accent'        => self::get('font_accent') ?? self::DEFAULT_ACCENT_FONT,
-            'accent_weight' => self::get('font_accent_weight') ?? self::DEFAULT_ACCENT_WEIGHT,
-            'table'         => self::get('font_table') ?? self::DEFAULT_TABLE_FONT,
-        ];
     }
 
     /**

--- a/php_backend/public/brand_settings.php
+++ b/php_backend/public/brand_settings.php
@@ -1,0 +1,6 @@
+<?php
+require_once __DIR__ . '/../models/Setting.php';
+header('Content-Type: application/json');
+
+echo json_encode(Setting::getBrand());
+?>

--- a/php_backend/public/font_settings.php
+++ b/php_backend/public/font_settings.php
@@ -1,7 +1,0 @@
-<?php
-require_once __DIR__ . '/../models/Setting.php';
-require_once __DIR__ . '/../models/Log.php';
-header('Content-Type: application/json');
-
-echo json_encode(array_merge(Setting::getFonts(), Setting::getBrand()));
-?>

--- a/settings.php
+++ b/settings.php
@@ -18,21 +18,9 @@ $aiTemp = Setting::get('ai_temperature') ?? '1';
 $aiDebug = Setting::get('ai_debug') === '1';
 $retention = Setting::get('log_retention_days') ?? '30';
 $timeout = Setting::get('session_timeout_minutes') ?? '0';
-$fontSettings = Setting::getFonts();
-$fontHeading = $fontSettings['heading'];
-$fontBody = $fontSettings['body'];
-$fontAccent = $fontSettings['accent'];
-$fontAccentWeight = $fontSettings['accent_weight'];
-$fontTable = $fontSettings['table'];
 $brand = Setting::getBrand();
 $siteName = $brand['site_name'];
 $colorScheme = $brand['color_scheme'];
-$fontOptions = [
-    'Roboto', 'Inter', 'Source Sans Pro', 'Montserrat', 'Open Sans', 'Lato',
-    'Nunito', 'Poppins', 'Raleway', 'Work Sans', 'Quicksand',
-    'Karla', 'Fira Sans', 'Noto Sans', 'Bangers', 'Caveat', 'Dancing Script',
-    'Fredoka', 'Pacifico'
-];
 $colorOptions = ['indigo', 'blue', 'green', 'red', 'purple', 'teal', 'orange'];
 $colorMap = [
     'indigo' => '#4f46e5',
@@ -52,11 +40,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $aiDebug = isset($_POST['ai_debug']);
     $retention = trim($_POST['log_retention_days'] ?? '');
     $timeout = trim($_POST['session_timeout_minutes'] ?? '');
-    $fontHeading = trim($_POST['font_heading'] ?? '');
-    $fontBody = trim($_POST['font_body'] ?? '');
-    $fontAccent = trim($_POST['font_accent'] ?? '');
-    $fontAccentWeight = trim($_POST['font_accent_weight'] ?? '');
-    $fontTable = trim($_POST['font_table'] ?? '');
     $siteName = trim($_POST['site_name'] ?? '');
     $newColorScheme = trim($_POST['color_scheme'] ?? '');
     Setting::set('openai_api_token', $openai);
@@ -82,26 +65,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($timeout !== '') {
         Setting::set('session_timeout_minutes', $timeout);
         Log::write('Updated session timeout minutes');
-    }
-    if ($fontHeading !== '') {
-        Setting::set('font_heading', $fontHeading);
-        Log::write('Updated heading font');
-    }
-    if ($fontBody !== '') {
-        Setting::set('font_body', $fontBody);
-        Log::write('Updated body font');
-    }
-    if ($fontAccent !== '') {
-        Setting::set('font_accent', $fontAccent);
-        Log::write('Updated accent font');
-    }
-    if ($fontAccentWeight !== '') {
-        Setting::set('font_accent_weight', $fontAccentWeight);
-        Log::write('Updated accent font weight');
-    }
-    if ($fontTable !== '') {
-        Setting::set('font_table', $fontTable);
-        Log::write('Updated table font');
     }
     if ($siteName !== '') {
         Setting::set('site_name', $siteName);
@@ -134,18 +97,14 @@ $bg600 = "bg-{$colorScheme}-600";
         window.tailwind.config = {};
     </script>
 
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
-    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&family=<?= urlencode($fontTable) ?>:wght@400&display=swap" rel="stylesheet">
-    <style>
-        body { font-family: '<?= htmlspecialchars($fontBody, ENT_QUOTES) ?>', sans-serif; }
-        h1, h2, h3, h4, h5, h6 { font-family: '<?= htmlspecialchars($fontHeading, ENT_QUOTES) ?>', sans-serif; font-weight: 700; }
-        button, .accent { font-family: '<?= htmlspecialchars($fontAccent, ENT_QUOTES) ?>', sans-serif; font-weight: <?= htmlspecialchars($fontAccentWeight, ENT_QUOTES) ?>; }
-        a { transition: color 0.2s ease; }
-        a:hover { color: <?= $colorHex ?>; }
-        button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
-        button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
-    </style>
+      <script src="https://cdn.tailwindcss.com"></script>
+      <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
+      <style>
+          a { transition: color 0.2s ease; }
+          a:hover { color: <?= $colorHex ?>; }
+          button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
+          button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
+      </style>
 </head>
 <body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
     <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
@@ -187,40 +146,6 @@ $bg600 = "bg-{$colorScheme}-600";
                     <?php foreach ($colorOptions as $opt): ?>
                         <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $colorScheme ? 'selected' : '' ?>><?= ucfirst($opt) ?></option>
                     <?php endforeach; ?>
-                </select>
-            </label>
-            <label class="block">Heading Font:
-                <select name="font_heading" class="border p-2 rounded w-full" data-help="Font used for headings">
-                    <?php foreach ($fontOptions as $opt): ?>
-                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontHeading ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
-            <label class="block">Body Font:
-                <select name="font_body" class="border p-2 rounded w-full" data-help="Font used for body text">
-                    <?php foreach ($fontOptions as $opt): ?>
-                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontBody ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
-            <label class="block">Accent Font:
-                <select name="font_accent" class="border p-2 rounded w-full" data-help="Font used for buttons and accents">
-                    <?php foreach ($fontOptions as $opt): ?>
-                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontAccent ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
-            <label class="block">Table Font:
-                <select name="font_table" class="border p-2 rounded w-full" data-help="Font used for tables">
-                    <?php foreach ($fontOptions as $opt): ?>
-                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $fontTable ? 'selected' : '' ?>><?= htmlspecialchars($opt) ?></option>
-                    <?php endforeach; ?>
-                </select>
-            </label>
-            <label class="block">Accent Font Weight:
-                <select name="font_accent_weight" class="border p-2 rounded w-full" data-help="Weight for buttons and accents">
-                    <option value="300" <?= $fontAccentWeight === '300' ? 'selected' : '' ?>>Light (300)</option>
-                    <option value="100" <?= $fontAccentWeight === '100' ? 'selected' : '' ?>>Very Thin (100)</option>
                 </select>
             </label>
             <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded md:col-span-2" aria-label="Save Settings"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>

--- a/users.php
+++ b/users.php
@@ -24,12 +24,6 @@ if ($username !== '') {
 }
 
 $message = '';
-$fonts = Setting::getFonts();
-$fontHeading = $fonts['heading'];
-$fontBody = $fonts['body'];
-$fontAccent = $fonts['accent'];
-$fontAccentWeight = $fonts['accent_weight'];
-$fontTable = $fonts['table'];
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
     if ($action === 'add') {
@@ -71,18 +65,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
 
-    <link href="https://fonts.googleapis.com/css2?family=<?= urlencode($fontHeading) ?>:wght@700&family=<?= urlencode($fontBody) ?>:wght@400&family=<?= urlencode($fontAccent) ?>:wght@<?= urlencode($fontAccentWeight) ?>&family=<?= urlencode($fontTable) ?>:wght@400&display=swap" rel="stylesheet">
-
-    <!-- Font Awesome icons loaded via frontend/js/menu.js -->
-    <style>
-        body { font-family: '<?= htmlspecialchars($fontBody, ENT_QUOTES) ?>', sans-serif; font-weight: 400; }
-        h1, h2, h3, h4, h5, h6 { font-family: '<?= htmlspecialchars($fontHeading, ENT_QUOTES) ?>', sans-serif; font-weight: 700; }
-        button, .accent { font-family: '<?= htmlspecialchars($fontAccent, ENT_QUOTES) ?>', sans-serif; font-weight: <?= htmlspecialchars($fontAccentWeight, ENT_QUOTES) ?>; }
-        a { transition: color 0.2s ease; }
-        a:hover { color: #4f46e5; }
-        button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
-        button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
-    </style>
+      <!-- Font Awesome icons loaded via frontend/js/menu.js -->
+      <style>
+          a { transition: color 0.2s ease; }
+          a:hover { color: #4f46e5; }
+          button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
+          button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
+      </style>
 </head>
 <body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
     <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow border border-gray-400">


### PR DESCRIPTION
## Summary
- Strip all Google Font imports and font-family declarations from pages and backend.
- Introduce a simple branding endpoint and update menu script to fetch only brand settings.
- Update docs to emphasize using browser-default fonts.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2e034e414832e911530939e9b460f