### PR TITLE
Add configurable fonts across site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,4 @@
 - Settings provide a table font option applied to all Tabulator tables.
 - Table font CSS variables (`--tabulator-*`) are set in the shared menu so Tabulator tables use the correct fonts during initial render.
 - Settings page offers additional funky font options: Bangers, Caveat, Dancing Script, Fredoka, Pacifico.
+- Settings allow selecting fonts for headings, body text, tables and charts with options ranging from modern to funky.

--- a/frontend/js/color_map.js
+++ b/frontend/js/color_map.js
@@ -55,14 +55,16 @@ try {
 
 function getChartTheme() {
     const text = '#000000';
+    const styles = getComputedStyle(document.documentElement);
+    const chartFont = styles.getPropertyValue('--chart-font').trim() || 'Inter, sans-serif';
     return {
         colors: chartColors,
-        chart: { style: { fontFamily: 'Inter, sans-serif', color: text }, backgroundColor: '#ffffff' },
+        chart: { style: { fontFamily: chartFont, color: text }, backgroundColor: '#ffffff' },
         credits: { enabled: false },
-        legend: { enabled: true, itemStyle: { fontSize: '10px', color: text } },
-        title: { style: { color: text } },
-        xAxis: { labels: { style: { color: text } }, title: { style: { color: text } } },
-        yAxis: { labels: { style: { color: text } }, title: { style: { color: text } } },
+        legend: { enabled: true, itemStyle: { fontSize: '10px', color: text, fontFamily: chartFont } },
+        title: { style: { color: text, fontFamily: chartFont } },
+        xAxis: { labels: { style: { color: text, fontFamily: chartFont } }, title: { style: { color: text, fontFamily: chartFont } } },
+        yAxis: { labels: { style: { color: text, fontFamily: chartFont } }, title: { style: { color: text, fontFamily: chartFont } } },
         plotOptions: {
             series: { showInLegend: true },
             pie: { showInLegend: true },
@@ -91,6 +93,10 @@ function applyChartTheme() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+    applyChartTheme();
+});
+
+document.addEventListener('fonts-applied', () => {
     applyChartTheme();
 });
 

--- a/frontend/js/fonts.js
+++ b/frontend/js/fonts.js
@@ -1,0 +1,55 @@
+(function(){
+  const systemFonts = new Set([
+    '', 'Arial', 'Helvetica', 'Times New Roman', 'Georgia', 'Courier New',
+    'Verdana', 'Trebuchet MS', 'Garamond', 'Comic Sans MS', 'serif',
+    'sans-serif', 'monospace', 'inherit', 'system-ui'
+  ]);
+
+  function loadFont(font) {
+    if (!font || systemFonts.has(font)) return;
+    const id = 'font-' + font.replace(/\s+/g, '-');
+    if (document.getElementById(id)) return;
+    const link = document.createElement('link');
+    link.id = id;
+    link.rel = 'stylesheet';
+    link.href = 'https://fonts.googleapis.com/css2?family=' +
+      encodeURIComponent(font).replace(/%20/g, '+') + '&display=swap';
+    document.head.appendChild(link);
+  }
+
+  function ensureStyle() {
+    if (document.getElementById('font-overrides')) return;
+    const style = document.createElement('style');
+    style.id = 'font-overrides';
+    style.textContent = `
+      body { font-family: var(--body-font, inherit); }
+      h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font, inherit); }
+      table, .tabulator, .tabulator * { font-family: var(--table-font, inherit); }
+    `;
+    document.head.appendChild(style);
+  }
+
+  window.applyFonts = function(opts){
+    opts = opts || {};
+    const heading = opts.heading_font || opts.font_heading || '';
+    const body    = opts.body_font    || opts.font_body    || '';
+    const table   = opts.table_font   || opts.font_table   || '';
+    const chart   = opts.chart_font   || opts.font_chart   || '';
+
+    [heading, body, table, chart].forEach(loadFont);
+
+    const root = document.documentElement;
+    if (heading) root.style.setProperty('--heading-font', heading);
+    if (body) root.style.setProperty('--body-font', body);
+    if (table) {
+      root.style.setProperty('--table-font', table);
+      root.style.setProperty('--accent-font', table);
+      root.style.setProperty('--tabulator-font-family', table);
+      root.style.setProperty('--tabulator-header-font-family', table);
+    }
+    if (chart) root.style.setProperty('--chart-font', chart);
+
+    ensureStyle();
+    document.dispatchEvent(new Event('fonts-applied'));
+  };
+})();

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -105,11 +105,20 @@ window.fetchNoCache = fetchNoCache;
   });
   ariaObserver.observe(document.body, {childList: true, subtree: true});
 
+  function loadFontsModule(cb) {
+    if (window.applyFonts) { cb(); return; }
+    const s = document.createElement('script');
+    s.src = 'js/fonts.js';
+    s.onload = cb;
+    document.head.appendChild(s);
+  }
+
   fetchNoCache('../php_backend/public/brand_settings.php')
     .then(r => r.json())
     .then(f => {
       siteName = f.site_name || siteName;
       colorScheme = f.color_scheme || colorScheme;
+      loadFontsModule(() => applyFonts(f));
       document.title = document.title.replace('Finance Manager', siteName);
       const landing = document.getElementById('landing-site-name');
       if (landing) landing.textContent = siteName;

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -97,7 +97,9 @@ function tailwindTabulator(element, options) {
 
     const table = new Tabulator(element, options);
     const rootStyles = getComputedStyle(document.documentElement);
-    const accentFont = rootStyles.getPropertyValue('--accent-font') || getComputedStyle(document.body).fontFamily;
+    const accentFont = rootStyles.getPropertyValue('--table-font')
+        || rootStyles.getPropertyValue('--accent-font')
+        || getComputedStyle(document.body).fontFamily;
     const el = table.element;
     el.style.colorScheme = 'light';
 

--- a/index.php
+++ b/index.php
@@ -12,6 +12,10 @@ $db = Database::getConnection();
 $brand = Setting::getBrand();
 $siteName = $brand['site_name'];
 $scheme = $brand['color_scheme'];
+$headingFont = $brand['heading_font'];
+$bodyFont = $brand['body_font'];
+$tableFont = $brand['table_font'];
+$chartFont = $brand['chart_font'];
 $error = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -107,5 +111,14 @@ $needsToken = isset($_SESSION['pending_user_id']);
     <script src="frontend/js/overlay.js"></script>
     <script src="frontend/js/aria_tooltips.js"></script>
     <script src="frontend/js/tooltips.js"></script>
+    <script src="frontend/js/fonts.js"></script>
+    <script>
+      applyFonts({
+        heading_font: <?= json_encode($headingFont) ?>,
+        body_font: <?= json_encode($bodyFont) ?>,
+        table_font: <?= json_encode($tableFont) ?>,
+        chart_font: <?= json_encode($chartFont) ?>
+      });
+    </script>
 </body>
 </html>

--- a/logout.php
+++ b/logout.php
@@ -20,6 +20,10 @@ if (isset($_GET['timeout'])) {
 $brand = Setting::getBrand();
 $siteName = $brand['site_name'];
 $colorScheme = $brand['color_scheme'];
+$headingFont = $brand['heading_font'];
+$bodyFont = $brand['body_font'];
+$tableFont = $brand['table_font'];
+$chartFont = $brand['chart_font'];
 $colorMap = [
     'indigo' => ['600' => '#4f46e5', '700' => '#4338ca'],
     'blue'   => ['600' => '#2563eb', '700' => '#1d4ed8'],
@@ -55,5 +59,14 @@ $bgHover = "hover:bg-{$colorScheme}-700";
         <a href="index.php" class="<?= $bg600 ?> <?= $bgHover ?> text-white px-4 py-2 rounded accent transition duration-100 transform hover:-translate-y-0.5 hover:shadow-lg">Return to Login</a>
     </div>
     <script src="frontend/js/page_help.js"></script>
+    <script src="frontend/js/fonts.js"></script>
+    <script>
+      applyFonts({
+        heading_font: <?= json_encode($headingFont) ?>,
+        body_font: <?= json_encode($bodyFont) ?>,
+        table_font: <?= json_encode($tableFont) ?>,
+        chart_font: <?= json_encode($chartFont) ?>
+      });
+    </script>
 </body>
 </html>

--- a/php_backend/models/Setting.php
+++ b/php_backend/models/Setting.php
@@ -5,6 +5,7 @@ require_once __DIR__ . '/../Database.php';
 class Setting {
     private const DEFAULT_SITE_NAME = 'Finance Manager';
     private const DEFAULT_COLOR_SCHEME = 'indigo';
+    private const DEFAULT_FONT       = '';
 
     /**
      * Retrieve a setting value by name.
@@ -28,14 +29,19 @@ class Setting {
     }
 
     /**
-     * Retrieve branding settings such as site name and color scheme.
+     * Retrieve branding settings such as site name, colour scheme and fonts.
      *
-     * @return array{site_name: string, color_scheme: string}
+     * @return array{site_name: string, color_scheme: string, heading_font: string,
+     *               body_font: string, table_font: string, chart_font: string}
      */
     public static function getBrand(): array {
         return [
-            'site_name'    => self::get('site_name') ?? self::DEFAULT_SITE_NAME,
+            'site_name'    => self::get('site_name')    ?? self::DEFAULT_SITE_NAME,
             'color_scheme' => self::get('color_scheme') ?? self::DEFAULT_COLOR_SCHEME,
+            'heading_font' => self::get('font_heading') ?? self::DEFAULT_FONT,
+            'body_font'    => self::get('font_body')    ?? self::DEFAULT_FONT,
+            'table_font'   => self::get('font_table')   ?? self::DEFAULT_FONT,
+            'chart_font'   => self::get('font_chart')   ?? self::DEFAULT_FONT,
         ];
     }
 }

--- a/settings.php
+++ b/settings.php
@@ -21,6 +21,31 @@ $timeout = Setting::get('session_timeout_minutes') ?? '0';
 $brand = Setting::getBrand();
 $siteName = $brand['site_name'];
 $colorScheme = $brand['color_scheme'];
+$headingFont = $brand['heading_font'];
+$bodyFont = $brand['body_font'];
+$tableFont = $brand['table_font'];
+$chartFont = $brand['chart_font'];
+$fontOptions = ['' => 'Default',
+    'Arial' => 'Arial',
+    'Helvetica' => 'Helvetica',
+    'Times New Roman' => 'Times New Roman',
+    'Georgia' => 'Georgia',
+    'Courier New' => 'Courier New',
+    'Verdana' => 'Verdana',
+    'Trebuchet MS' => 'Trebuchet MS',
+    'Garamond' => 'Garamond',
+    'Roboto' => 'Roboto',
+    'Open Sans' => 'Open Sans',
+    'Lato' => 'Lato',
+    'Montserrat' => 'Montserrat',
+    'Poppins' => 'Poppins',
+    'Comic Sans MS' => 'Comic Sans MS',
+    'Bangers' => 'Bangers',
+    'Caveat' => 'Caveat',
+    'Dancing Script' => 'Dancing Script',
+    'Fredoka' => 'Fredoka',
+    'Pacifico' => 'Pacifico',
+];
 $colorOptions = ['indigo', 'blue', 'green', 'red', 'purple', 'teal', 'orange'];
 $colorMap = [
     'indigo' => '#4f46e5',
@@ -42,6 +67,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $timeout = trim($_POST['session_timeout_minutes'] ?? '');
     $siteName = trim($_POST['site_name'] ?? '');
     $newColorScheme = trim($_POST['color_scheme'] ?? '');
+    $headingFont = trim($_POST['font_heading'] ?? '');
+    $bodyFont = trim($_POST['font_body'] ?? '');
+    $tableFont = trim($_POST['font_table'] ?? '');
+    $chartFont = trim($_POST['font_chart'] ?? '');
     Setting::set('openai_api_token', $openai);
     Log::write('Updated OpenAI API token');
     if ($batch !== '') {
@@ -77,6 +106,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $colorScheme = $newColorScheme;
         }
     }
+    Setting::set('font_heading', $headingFont);
+    Setting::set('font_body', $bodyFont);
+    Setting::set('font_table', $tableFont);
+    Setting::set('font_chart', $chartFont);
+    Log::write('Updated font settings');
     $message = 'Settings updated.';
 }
 
@@ -148,6 +182,34 @@ $bg600 = "bg-{$colorScheme}-600";
                     <?php endforeach; ?>
                 </select>
             </label>
+            <label class="block">Heading Font:
+                <select name="font_heading" class="border p-2 rounded w-full" data-help="Font for headings">
+                    <?php foreach ($fontOptions as $k => $v): ?>
+                        <option value="<?= htmlspecialchars($k) ?>" <?= $k === $headingFont ? 'selected' : '' ?>><?= htmlspecialchars($v) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block">Body Font:
+                <select name="font_body" class="border p-2 rounded w-full" data-help="Font for body text">
+                    <?php foreach ($fontOptions as $k => $v): ?>
+                        <option value="<?= htmlspecialchars($k) ?>" <?= $k === $bodyFont ? 'selected' : '' ?>><?= htmlspecialchars($v) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block">Table Font:
+                <select name="font_table" class="border p-2 rounded w-full" data-help="Font for tables">
+                    <?php foreach ($fontOptions as $k => $v): ?>
+                        <option value="<?= htmlspecialchars($k) ?>" <?= $k === $tableFont ? 'selected' : '' ?>><?= htmlspecialchars($v) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
+            <label class="block">Chart Font:
+                <select name="font_chart" class="border p-2 rounded w-full" data-help="Font for charts">
+                    <?php foreach ($fontOptions as $k => $v): ?>
+                        <option value="<?= htmlspecialchars($k) ?>" <?= $k === $chartFont ? 'selected' : '' ?>><?= htmlspecialchars($v) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
             <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded md:col-span-2" aria-label="Save Settings"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
         </form>
     </div>
@@ -156,5 +218,14 @@ $bg600 = "bg-{$colorScheme}-600";
     <script src="frontend/js/overlay.js"></script>
     <script src="frontend/js/aria_tooltips.js"></script>
     <script src="frontend/js/tooltips.js"></script>
+    <script src="frontend/js/fonts.js"></script>
+    <script>
+      applyFonts({
+        heading_font: <?= json_encode($headingFont) ?>,
+        body_font: <?= json_encode($bodyFont) ?>,
+        table_font: <?= json_encode($tableFont) ?>,
+        chart_font: <?= json_encode($chartFont) ?>
+      });
+    </script>
 </body>
 </html>

--- a/users.php
+++ b/users.php
@@ -14,6 +14,8 @@ if (!isset($_SESSION['user_id'])) {
     exit;
 }
 
+$brand = Setting::getBrand();
+
 $username = $_SESSION['username'] ?? '';
 $db = Database::getConnection();
 $has2fa = false;
@@ -124,6 +126,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script src="frontend/js/overlay.js"></script>
     <script src="frontend/js/aria_tooltips.js"></script>
     <script src="frontend/js/tooltips.js"></script>
+    <script src="frontend/js/fonts.js"></script>
+    <script>
+      applyFonts({
+        heading_font: <?= json_encode($brand['heading_font']) ?>,
+        body_font: <?= json_encode($brand['body_font']) ?>,
+        table_font: <?= json_encode($brand['table_font']) ?>,
+        chart_font: <?= json_encode($brand['chart_font']) ?>
+      });
+    </script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 


### PR DESCRIPTION
## Summary
- allow selecting fonts for headings, body text, tables and charts
- apply selected fonts globally via new `fonts.js` utility
- ensure charts and tables respect the chosen typefaces

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2e43d4510832e9de040734f6cb813