### PR TITLE
Preview font styles in settings dropdowns

### DIFF
--- a/frontend/js/fonts.js
+++ b/frontend/js/fonts.js
@@ -52,4 +52,5 @@
     ensureStyle();
     document.dispatchEvent(new Event('fonts-applied'));
   };
+  window.loadFont = loadFont;
 })();

--- a/settings.php
+++ b/settings.php
@@ -226,6 +226,11 @@ $bg600 = "bg-{$colorScheme}-600";
         table_font: <?= json_encode($tableFont) ?>,
         chart_font: <?= json_encode($chartFont) ?>
       });
+      const fontChoices = <?= json_encode(array_keys($fontOptions)) ?>;
+      fontChoices.forEach(f => { if (f) window.loadFont(f); });
+      document.querySelectorAll('select[name^="font_"] option').forEach(opt => {
+        if (opt.value) opt.style.fontFamily = opt.value;
+      });
     </script>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `loadFont` globally
- show each font option using its own typeface and preload available fonts

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2e7c0c4cc832e86ccc377f49e9414