### PR TITLE
Remove Tailwind font-sans class from body tags

### DIFF
--- a/frontend/account.html
+++ b/frontend/account.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -13,7 +13,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -13,7 +13,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -14,7 +14,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -17,7 +17,7 @@
     <!-- Font Awesome icons loaded via menu.js -->
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -14,7 +14,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -14,7 +14,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/export.html
+++ b/frontend/export.html
@@ -13,7 +13,7 @@
 
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -13,7 +13,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-4">

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -13,7 +13,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -17,7 +17,7 @@
 
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -12,7 +12,7 @@
 
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
   <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
     <main class="flex-1 p-6">

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -14,7 +14,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -14,7 +14,7 @@
       <script src="https://cdn.tailwindcss.com"></script>
       <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -15,7 +15,7 @@
 
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -14,7 +14,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -20,7 +20,7 @@
     }
     </style>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -13,7 +13,7 @@
 
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="bg-gradient-to-b from-indigo-50 to-white font-sans">
+<body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">


### PR DESCRIPTION
## Summary
- remove `font-sans` from `<body>` classes across frontend pages
- rely on `fonts.js` and user brand settings to apply typography dynamically

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2eacfb9b4832e8f5d352f69200dec