### PR TITLE
Add accent font weight options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@
 
 ## Decisions
 - Sections use scroll-based fade-in; apply `opacity-0` initially and `frontend/js/scroll_animations.js` adds a `fade-in` class when in view.
-- Settings include an accent font weight option offering light (300) and very thin (100) styles.
+- Settings include an accent font weight option offering thin (100), light (300), and bold (700) styles.
 - Settings provide a table font option applied to all Tabulator tables.
 - Table font CSS variables (`--tabulator-*`) are set in the shared menu so Tabulator tables use the correct fonts during initial render.
 - Settings page offers additional funky font options: Bangers, Caveat, Dancing Script, Fredoka, Pacifico.

--- a/frontend/js/fonts.js
+++ b/frontend/js/fonts.js
@@ -25,6 +25,7 @@
       body { font-family: var(--body-font, inherit); }
       h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font, inherit); }
       table, .tabulator, .tabulator * { font-family: var(--table-font, inherit); }
+      .accent { font-family: var(--accent-font, inherit); font-weight: var(--accent-font-weight, 300); }
     `;
     document.head.appendChild(style);
   }
@@ -35,6 +36,7 @@
     const body    = opts.body_font    || opts.font_body    || '';
     const table   = opts.table_font   || opts.font_table   || '';
     const chart   = opts.chart_font   || opts.font_chart   || '';
+    const accentW = opts.accent_font_weight || opts.font_accent_weight || '';
 
     [heading, body, table, chart].forEach(loadFont);
 
@@ -48,6 +50,7 @@
       root.style.setProperty('--tabulator-header-font-family', table);
     }
     if (chart) root.style.setProperty('--chart-font', chart);
+    if (accentW) root.style.setProperty('--accent-font-weight', accentW);
 
     ensureStyle();
     document.dispatchEvent(new Event('fonts-applied'));

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -96,10 +96,6 @@ function tailwindTabulator(element, options) {
     }
 
     const table = new Tabulator(element, options);
-    const rootStyles = getComputedStyle(document.documentElement);
-    const accentFont = rootStyles.getPropertyValue('--table-font')
-        || rootStyles.getPropertyValue('--accent-font')
-        || getComputedStyle(document.body).fontFamily;
     const el = table.element;
     el.style.colorScheme = 'light';
 
@@ -121,9 +117,7 @@ function tailwindTabulator(element, options) {
         const searchInput = document.createElement('input');
         searchInput.type = 'text';
         searchInput.placeholder = 'Search';
-        searchInput.className = 'tabulator-search mb-2 p-2 border-0 rounded w-full';
-        searchInput.style.fontFamily = accentFont;
-        searchInput.style.fontWeight = '300';
+        searchInput.className = 'tabulator-search mb-2 p-2 border-0 rounded w-full accent';
         searchInput.style.colorScheme = 'light';
         tableEl.parentNode.insertBefore(searchInput, tableEl);
         searchInput.addEventListener('input', function() {

--- a/index.php
+++ b/index.php
@@ -16,6 +16,7 @@ $headingFont = $brand['heading_font'];
 $bodyFont = $brand['body_font'];
 $tableFont = $brand['table_font'];
 $chartFont = $brand['chart_font'];
+$accentWeight = $brand['accent_font_weight'];
 $error = '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -117,7 +118,8 @@ $needsToken = isset($_SESSION['pending_user_id']);
         heading_font: <?= json_encode($headingFont) ?>,
         body_font: <?= json_encode($bodyFont) ?>,
         table_font: <?= json_encode($tableFont) ?>,
-        chart_font: <?= json_encode($chartFont) ?>
+        chart_font: <?= json_encode($chartFont) ?>,
+        accent_font_weight: <?= json_encode($accentWeight) ?>
       });
     </script>
 </body>

--- a/logout.php
+++ b/logout.php
@@ -24,6 +24,7 @@ $headingFont = $brand['heading_font'];
 $bodyFont = $brand['body_font'];
 $tableFont = $brand['table_font'];
 $chartFont = $brand['chart_font'];
+$accentWeight = $brand['accent_font_weight'];
 $colorMap = [
     'indigo' => ['600' => '#4f46e5', '700' => '#4338ca'],
     'blue'   => ['600' => '#2563eb', '700' => '#1d4ed8'],
@@ -65,7 +66,8 @@ $bgHover = "hover:bg-{$colorScheme}-700";
         heading_font: <?= json_encode($headingFont) ?>,
         body_font: <?= json_encode($bodyFont) ?>,
         table_font: <?= json_encode($tableFont) ?>,
-        chart_font: <?= json_encode($chartFont) ?>
+        chart_font: <?= json_encode($chartFont) ?>,
+        accent_font_weight: <?= json_encode($accentWeight) ?>
       });
     </script>
 </body>

--- a/php_backend/models/Setting.php
+++ b/php_backend/models/Setting.php
@@ -32,7 +32,8 @@ class Setting {
      * Retrieve branding settings such as site name, colour scheme and fonts.
      *
      * @return array{site_name: string, color_scheme: string, heading_font: string,
-     *               body_font: string, table_font: string, chart_font: string}
+     *               body_font: string, table_font: string, chart_font: string,
+     *               accent_font_weight: string}
      */
     public static function getBrand(): array {
         return [
@@ -42,6 +43,7 @@ class Setting {
             'body_font'    => self::get('font_body')    ?? self::DEFAULT_FONT,
             'table_font'   => self::get('font_table')   ?? self::DEFAULT_FONT,
             'chart_font'   => self::get('font_chart')   ?? self::DEFAULT_FONT,
+            'accent_font_weight' => self::get('accent_font_weight') ?? '',
         ];
     }
 }

--- a/settings.php
+++ b/settings.php
@@ -25,6 +25,7 @@ $headingFont = $brand['heading_font'];
 $bodyFont = $brand['body_font'];
 $tableFont = $brand['table_font'];
 $chartFont = $brand['chart_font'];
+$accentWeight = $brand['accent_font_weight'];
 $fontOptions = ['' => 'Default',
     'Arial' => 'Arial',
     'Helvetica' => 'Helvetica',
@@ -46,6 +47,7 @@ $fontOptions = ['' => 'Default',
     'Fredoka' => 'Fredoka',
     'Pacifico' => 'Pacifico',
 ];
+$weightOptions = ['' => 'Default', '100' => 'Thin', '300' => 'Light', '700' => 'Bold'];
 $colorOptions = ['indigo', 'blue', 'green', 'red', 'purple', 'teal', 'orange'];
 $colorMap = [
     'indigo' => '#4f46e5',
@@ -71,6 +73,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $bodyFont = trim($_POST['font_body'] ?? '');
     $tableFont = trim($_POST['font_table'] ?? '');
     $chartFont = trim($_POST['font_chart'] ?? '');
+    $accentWeight = trim($_POST['accent_font_weight'] ?? '');
     Setting::set('openai_api_token', $openai);
     Log::write('Updated OpenAI API token');
     if ($batch !== '') {
@@ -110,6 +113,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     Setting::set('font_body', $bodyFont);
     Setting::set('font_table', $tableFont);
     Setting::set('font_chart', $chartFont);
+    Setting::set('accent_font_weight', $accentWeight);
     Log::write('Updated font settings');
     $message = 'Settings updated.';
 }
@@ -210,6 +214,13 @@ $bg600 = "bg-{$colorScheme}-600";
                     <?php endforeach; ?>
                 </select>
             </label>
+            <label class="block">Accent Font Weight:
+                <select name="accent_font_weight" class="border p-2 rounded w-full" data-help="Weight for accent text like search inputs">
+                    <?php foreach ($weightOptions as $k => $v): ?>
+                        <option value="<?= htmlspecialchars($k) ?>" <?= $k === $accentWeight ? 'selected' : '' ?>><?= htmlspecialchars($v) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </label>
             <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded md:col-span-2" aria-label="Save Settings"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
         </form>
     </div>
@@ -224,7 +235,8 @@ $bg600 = "bg-{$colorScheme}-600";
         heading_font: <?= json_encode($headingFont) ?>,
         body_font: <?= json_encode($bodyFont) ?>,
         table_font: <?= json_encode($tableFont) ?>,
-        chart_font: <?= json_encode($chartFont) ?>
+        chart_font: <?= json_encode($chartFont) ?>,
+        accent_font_weight: <?= json_encode($accentWeight) ?>
       });
       const fontChoices = <?= json_encode(array_keys($fontOptions)) ?>;
       fontChoices.forEach(f => { if (f) window.loadFont(f); });

--- a/users.php
+++ b/users.php
@@ -132,7 +132,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         heading_font: <?= json_encode($brand['heading_font']) ?>,
         body_font: <?= json_encode($brand['body_font']) ?>,
         table_font: <?= json_encode($brand['table_font']) ?>,
-        chart_font: <?= json_encode($brand['chart_font']) ?>
+        chart_font: <?= json_encode($brand['chart_font']) ?>,
+        accent_font_weight: <?= json_encode($brand['accent_font_weight']) ?>
       });
     </script>
 


### PR DESCRIPTION
## Summary
- Allow selection of thin, light, or bold accent font weights in settings
- Support accent font weight in font utility and Tabulator search fields
- Pass accent font weight through branding data and login/logout/user pages

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2e8645c2c832e8dc3e8af0d626983