### PR TITLE
Add fullscreen toggle for dashboard charts

### DIFF
--- a/frontend/js/chart_fullscreen.js
+++ b/frontend/js/chart_fullscreen.js
@@ -1,0 +1,37 @@
+// Adds a fullscreen toggle button to Highcharts graphs.
+// Buttons use Font Awesome icons and include aria-labels for accessibility.
+document.addEventListener('DOMContentLoaded', () => {
+    if (!window.Highcharts || !Highcharts.addEvent) return;
+
+    Highcharts.addEvent(Highcharts.Chart, 'load', function () {
+        const container = this.renderTo;
+        if (!container || !container.dataset || !container.dataset.chartDesc) return;
+
+        container.classList.add('relative');
+        const btn = document.createElement('button');
+        btn.className = 'absolute top-2 right-2 z-10 bg-white border border-gray-300 rounded p-1 text-gray-600 hover:bg-gray-50';
+        btn.innerHTML = '<i class="fas fa-expand"></i>';
+        btn.setAttribute('aria-label', 'View chart full screen');
+
+        const update = () => {
+            if (document.fullscreenElement === container) {
+                btn.innerHTML = '<i class="fas fa-compress"></i>';
+                btn.setAttribute('aria-label', 'Exit full screen');
+            } else {
+                btn.innerHTML = '<i class="fas fa-expand"></i>';
+                btn.setAttribute('aria-label', 'View chart full screen');
+            }
+        };
+
+        btn.addEventListener('click', () => {
+            if (document.fullscreenElement === container) {
+                document.exitFullscreen();
+            } else if (container.requestFullscreen) {
+                container.requestFullscreen();
+            }
+        });
+
+        document.addEventListener('fullscreenchange', update);
+        container.appendChild(btn);
+    });
+});

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -338,3 +338,7 @@ window.fetchNoCache = fetchNoCache;
   const tooltipScript = document.createElement('script');
   tooltipScript.src = 'js/tooltips.js';
   document.body.appendChild(tooltipScript);
+
+  const fullscreenScript = document.createElement('script');
+  fullscreenScript.src = 'js/chart_fullscreen.js';
+  document.body.appendChild(fullscreenScript);


### PR DESCRIPTION
## Summary
- Add reusable script to attach fullscreen toggle buttons to Highcharts charts.
- Load the fullscreen script across pages via the shared menu.

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2ef1dacfc832eac40795a21f3825f