### PR TITLE
Add recurring spend forecast for next month

### DIFF
--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -23,8 +23,15 @@
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Recurring Spend Detection</h1>
             <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses. The results highlight ongoing commitments so you know where money leaves your account regularly.</p>
             <button id="run-analysis" class="bg-indigo-600 text-white px-4 py-2 rounded mb-4"><i class="fas fa-chart-line inline w-4 h-4 mr-2"></i>Run Analysis</button>
-            <div id="results-grid"></div>
-            <p id="total" class="mt-4 text-right"></p>
+            <h2 class="text-xl font-semibold mt-6 mb-2">Recurring Outgoings</h2>
+            <div id="outgoing-grid"></div>
+            <p id="outgoing-total" class="mt-2 text-right"></p>
+            <p id="outgoing-next" class="text-right"></p>
+
+            <h2 class="text-xl font-semibold mt-6 mb-2">Recurring Income</h2>
+            <div id="income-grid"></div>
+            <p id="income-total" class="mt-2 text-right"></p>
+            <p id="income-next" class="text-right"></p>
         </main>
     </div>
     <script src="js/menu.js"></script>
@@ -38,23 +45,49 @@
         fetch('../php_backend/public/recurring_spend.php')
             .then(resp => resp.json())
             .then(data => {
-                const gridEl = document.getElementById('results-grid');
-                gridEl.innerHTML = '';
-                if(data.results && data.results.length){
-                    tailwindTabulator(gridEl, {
-                        data: data.results,
+                const outEl = document.getElementById('outgoing-grid');
+                const inEl = document.getElementById('income-grid');
+                outEl.innerHTML = '';
+                inEl.innerHTML = '';
+
+                if(data.outgoings && data.outgoings.results.length){
+                    tailwindTabulator(outEl, {
+                        data: data.outgoings.results,
                         layout: 'fitDataStretch',
                         columns: [
                             { title: 'Description', field: 'description' },
+                            { title: 'Day', field: 'day', hozAlign: 'right' },
                             { title: 'Occurrences', field: 'occurrences', hozAlign: 'right' },
+                            { title: 'Avg Amount', field: 'average', hozAlign: 'right', formatter: 'money', formatterParams: { symbol: '£', precision: 2 } },
                             { title: 'Yearly Total', field: 'total', hozAlign: 'right', formatter: 'money', formatterParams: { symbol: '£', precision: 2 } }
                         ]
                     });
-                    const total = data.results.reduce((sum, row) => sum + parseFloat(row.total), 0);
-                    document.getElementById('total').textContent = 'Total: ' + formatCurrency(total);
+                    document.getElementById('outgoing-total').textContent = 'Yearly total: ' + formatCurrency(data.outgoings.total);
+                    document.getElementById('outgoing-next').textContent = 'Next month estimate: ' + formatCurrency(data.outgoings.next_month);
                 } else {
-                    gridEl.innerHTML = 'No recurring spend found.';
-                    document.getElementById('total').textContent = '';
+                    outEl.innerHTML = 'No recurring outgoings found.';
+                    document.getElementById('outgoing-total').textContent = '';
+                    document.getElementById('outgoing-next').textContent = '';
+                }
+
+                if(data.income && data.income.results.length){
+                    tailwindTabulator(inEl, {
+                        data: data.income.results,
+                        layout: 'fitDataStretch',
+                        columns: [
+                            { title: 'Description', field: 'description' },
+                            { title: 'Day', field: 'day', hozAlign: 'right' },
+                            { title: 'Occurrences', field: 'occurrences', hozAlign: 'right' },
+                            { title: 'Avg Amount', field: 'average', hozAlign: 'right', formatter: 'money', formatterParams: { symbol: '£', precision: 2 } },
+                            { title: 'Yearly Total', field: 'total', hozAlign: 'right', formatter: 'money', formatterParams: { symbol: '£', precision: 2 } }
+                        ]
+                    });
+                    document.getElementById('income-total').textContent = 'Yearly total: ' + formatCurrency(data.income.total);
+                    document.getElementById('income-next').textContent = 'Next month estimate: ' + formatCurrency(data.income.next_month);
+                } else {
+                    inEl.innerHTML = 'No recurring income found.';
+                    document.getElementById('income-total').textContent = '';
+                    document.getElementById('income-next').textContent = '';
                 }
             });
     });

--- a/php_backend/public/recurring_spend.php
+++ b/php_backend/public/recurring_spend.php
@@ -1,5 +1,5 @@
 <?php
-// API endpoint to analyse recurring spending over the past year.
+// API endpoint to analyse recurring income and spending over the past year.
 require_once __DIR__ . '/../nocache.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
@@ -7,12 +7,27 @@ require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');
 
 try {
-    $results = Transaction::getRecurringSpend();
-    $total = 0.0;
-    foreach ($results as $row) {
-        $total += (float)$row['total'];
+    $outgoings = Transaction::getRecurringSpend(false);
+    $income = Transaction::getRecurringSpend(true);
+
+    $outTotal = 0.0;
+    $outNext = 0.0;
+    foreach ($outgoings as $row) {
+        $outTotal += (float)$row['total'];
+        $outNext += (float)($row['last_amount'] ?? $row['average']);
     }
-    echo json_encode(['results' => $results, 'total' => $total]);
+
+    $inTotal = 0.0;
+    $inNext = 0.0;
+    foreach ($income as $row) {
+        $inTotal += (float)$row['total'];
+        $inNext += (float)($row['last_amount'] ?? $row['average']);
+    }
+
+    echo json_encode([
+        'outgoings' => ['results' => $outgoings, 'total' => $outTotal, 'next_month' => $outNext],
+        'income' => ['results' => $income, 'total' => $inTotal, 'next_month' => $inNext]
+    ]);
 } catch (Exception $e) {
     http_response_code(500);
     Log::write('Recurring spend error: ' . $e->getMessage(), 'ERROR');

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -3,6 +3,7 @@ use PHPUnit\Framework\TestCase;
 
 require_once __DIR__ . '/../php_backend/models/Transaction.php';
 require_once __DIR__ . '/../php_backend/models/Log.php';
+require_once __DIR__ . '/../php_backend/models/Tag.php';
 require_once __DIR__ . '/../php_backend/Database.php';
 
 class TransactionTest extends TestCase
@@ -20,6 +21,7 @@ class TransactionTest extends TestCase
         $this->db->exec('CREATE TABLE accounts (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);');
         $this->db->exec('INSERT INTO accounts (name) VALUES ("Checking");');
         $this->db->exec('CREATE TABLE logs (id INTEGER PRIMARY KEY AUTOINCREMENT, level TEXT, message TEXT, created_at DATETIME DEFAULT CURRENT_TIMESTAMP);');
+        $this->db->exec('CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, keyword TEXT, description TEXT);');
         $this->db->exec('CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTOINCREMENT, account_id INTEGER, date TEXT, amount REAL, description TEXT, memo TEXT, category_id INTEGER, segment_id INTEGER, tag_id INTEGER, group_id INTEGER, transfer_id INTEGER, ofx_id TEXT, ofx_type TEXT, bank_ofx_id TEXT);');
     }
 
@@ -41,5 +43,45 @@ class TransactionTest extends TestCase
         $this->assertSame(0, $second);
         $count = $this->db->query("SELECT COUNT(*) FROM transactions WHERE description = 'Dup'")->fetchColumn();
         $this->assertSame(1, (int)$count);
+    }
+
+    public function testRecurringIncomeAndSpendDetection(): void
+    {
+        $now = time();
+        $u1 = date('Y-m-15', strtotime('-3 months', $now));
+        $u2 = date('Y-m-15', strtotime('-2 months', $now));
+        $u3 = date('Y-m-15', strtotime('-1 month', $now));
+        $e1 = date('Y-m-25', strtotime('-3 months', $now));
+        $e2 = date('Y-m-25', strtotime('-2 months', $now));
+        $e3 = date('Y-m-25', strtotime('-1 month', $now));
+        $old1 = date('Y-m-d', strtotime('-7 months', $now));
+        $old2 = date('Y-m-d', strtotime('-6 months', $now));
+        $oneOff = date('Y-m-d', strtotime('-20 days', $now));
+
+        $this->db->exec("INSERT INTO transactions (account_id, date, amount, description) VALUES
+            (1, '$u1', -100, 'Utility Co'),
+            (1, '$u2', -110, 'Utility Co'),
+            (1, '$u3', -90, 'Utility Co'),
+            (1, '$e1', 2000, 'Employer'),
+            (1, '$e2', 2100, 'Employer'),
+            (1, '$e3', 2200, 'Employer'),
+            (1, '$old1', -30, 'OldService'),
+            (1, '$old2', -35, 'OldService'),
+            (1, '$oneOff', -50, 'One-off')
+        ");
+        $spend = Transaction::getRecurringSpend(false);
+        $income = Transaction::getRecurringSpend(true);
+        $this->assertSame(1, count($spend));
+        $this->assertSame(1, count($income));
+        $this->assertSame(15, $spend[0]['day']);
+        $this->assertSame(25, $income[0]['day']);
+        $this->assertSame(3, $spend[0]['occurrences']);
+        $this->assertSame(3, $income[0]['occurrences']);
+        $this->assertEquals(300.0, $spend[0]['total']);
+        $this->assertEquals(6300.0, $income[0]['total']);
+        $this->assertEquals(100.0, $spend[0]['average']);
+        $this->assertEquals(2100.0, $income[0]['average']);
+        $this->assertEquals(90.0, $spend[0]['last_amount']);
+        $this->assertEquals(2200.0, $income[0]['last_amount']);
     }
 }


### PR DESCRIPTION
## Summary
- Filter recurring transactions to those seen in the last 40 days and capture each item's latest amount
- Use these recent amounts to produce more conservative next-month forecasts for income and outgoings
- Extend tests to cover last-amount tracking and ignore outdated recurring entries

## Testing
- `php tests/run_tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c2e1037a54832eb37f7c4ae8e50bb3