### PR TITLE
Add quick transaction search to utility bar

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -284,7 +284,10 @@ window.fetchNoCache = fetchNoCache;
   utility.className = 'fixed top-4 right-8 md:top-8 md:right-12 bg-white rounded-full border border-indigo-600 p-2 flex items-center space-x-4 z-50 transition-shadow hover:shadow-lg';
 
   utility.innerHTML = `
-    <a id="latest-statement-link" href="monthly_statement.html" class="hidden md:flex items-center">
+    <form id="quick-search-form" class="hidden md:flex items-center">
+      <input id="quick-search" type="search" placeholder="Search" aria-label="Search transactions" class="w-32 text-sm" />
+    </form>
+    <a id="latest-statement-link" href="monthly_statement.html" class="hidden md:flex items-center" aria-label="Latest monthly statement">
       <i class="fas fa-file-invoice h-4 w-4"></i>
     </a>
   `;
@@ -296,14 +299,21 @@ window.fetchNoCache = fetchNoCache;
       .then(months => {
         if (months.length > 0) {
           const { year, month } = months[0];
-          const names = [
-            'January','February','March','April','May','June',
-            'July','August','September','October','November','December'
-          ];
           latestLink.href = `monthly_statement.html?year=${year}&month=${month}`;
         }
       })
       .catch(err => console.error('Latest statement load failed', err));
+  }
+
+  const quickSearchForm = document.getElementById('quick-search-form');
+  if (quickSearchForm) {
+    quickSearchForm.addEventListener('submit', e => {
+      e.preventDefault();
+      const term = document.getElementById('quick-search').value.trim();
+      if (term) {
+        window.location.href = `search.html?value=${encodeURIComponent(term)}`;
+      }
+    });
   }
 
   // Apply Tailwind card styling to all sections or wrap main content in a card


### PR DESCRIPTION
## Summary
- Add quick transaction search input to top-right utility bar and route to Search Transactions page
- Provide aria-label for monthly statement shortcut icon

## Testing
- `php tests/run_tests.php` (fails: Parse error in tests/run_tests.php: unexpected variable "$db")

------
https://chatgpt.com/codex/tasks/task_e_68c3f63fbc60832eb4fafbc4cf91cf97