### PR TITLE
Remove drop shadow from utility bar search icon

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -282,7 +282,7 @@ window.fetchNoCache = fetchNoCache;
   utility.id = 'utility-bar';
 
 
-  utility.className = 'fixed top-2 right-2 md:top-8 md:right-12 bg-white rounded border border-indigo-600 p-1 flex items-center space-x-2 z-50 transition-shadow hover:shadow-lg';
+  utility.className = 'fixed top-2 right-2 md:top-8 md:right-12 bg-white rounded border border-indigo-600 p-1 flex items-center space-x-2 z-50';
 
   utility.innerHTML = `
     <button id="quick-search-toggle" class="md:hidden p-1" aria-label="Search transactions">


### PR DESCRIPTION
## Summary
- Remove hover shadow from utility bar so search icon appears without drop shadow

## Testing
- `php tests/run_tests.php` *(fails: Parse error: syntax error, unexpected variable "$db" in tests/run_tests.php:235)*

------
https://chatgpt.com/codex/tasks/task_e_68c40ad6db60832e8fa37ac7b1a3f933