### PR TITLE
Add secure API bootstrap and require authentication

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -1,8 +1,6 @@
 <?php
 // Log out the current user and show confirmation page.
-ini_set('session.cookie_secure', '1');
-session_start();
-require_once __DIR__ . '/php_backend/nocache.php';
+require_once __DIR__ . '/php_backend/auth.php';
 require_once __DIR__ . '/php_backend/models/Log.php';
 require_once __DIR__ . '/php_backend/models/Setting.php';
 
@@ -11,7 +9,11 @@ if (isset($_SESSION['user_id'])) {
     Log::write('User ' . $_SESSION['user_id'] . ' logged out' . $reason);
 }
 
-session_destroy();
+$_SESSION = [];
+if (session_status() === PHP_SESSION_ACTIVE) {
+    session_unset();
+    session_destroy();
+}
 
 if (isset($_GET['timeout'])) {
     header('Location: index.php');

--- a/php_backend/auth.php
+++ b/php_backend/auth.php
@@ -1,0 +1,86 @@
+<?php
+// Shared bootstrap for API endpoints to enforce secure sessions and same-origin access.
+
+if (PHP_SAPI === 'cli') {
+    if (!function_exists('require_api_auth')) {
+        function require_api_auth(): void {}
+    }
+} else {
+    if (session_status() !== PHP_SESSION_ACTIVE) {
+        ini_set('session.use_strict_mode', '1');
+        ini_set('session.cookie_secure', '1');
+        ini_set('session.cookie_httponly', '1');
+        if (defined('PHP_VERSION_ID') && PHP_VERSION_ID >= 70300) {
+            ini_set('session.cookie_samesite', 'Lax');
+        }
+        session_start();
+    }
+
+    $host = $_SERVER['HTTP_HOST'] ?? '';
+    $https = (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off') || (($_SERVER['SERVER_PORT'] ?? '') === '443');
+    $scheme = $https ? 'https' : 'http';
+    $appOrigin = $host !== '' ? $scheme . '://' . $host : null;
+
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    header('Expires: Thu, 01 Jan 1970 00:00:00 GMT');
+
+    if ($appOrigin !== null) {
+        header('Access-Control-Allow-Origin: ' . $appOrigin);
+        header('Access-Control-Allow-Credentials: true');
+        header('Vary: Origin');
+    }
+
+    $origin = $_SERVER['HTTP_ORIGIN'] ?? null;
+    if ($origin !== null && $appOrigin !== null && $origin !== $appOrigin) {
+        http_response_code(403);
+        header('Content-Type: application/json');
+        echo json_encode(['error' => 'Origin not allowed']);
+        exit;
+    }
+
+    if (($_SERVER['REQUEST_METHOD'] ?? '') === 'OPTIONS') {
+        if ($origin === null || $appOrigin === null || $origin !== $appOrigin) {
+            http_response_code(403);
+            exit;
+        }
+        header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
+        header('Access-Control-Allow-Headers: Content-Type, X-Requested-With');
+        http_response_code(204);
+        exit;
+    }
+
+    require_once __DIR__ . '/models/Setting.php';
+    require_once __DIR__ . '/models/Log.php';
+
+    if (!function_exists('require_api_auth')) {
+        function require_api_auth(): void {
+            $userId = $_SESSION['user_id'] ?? null;
+            if (!$userId) {
+                http_response_code(401);
+                header('Content-Type: application/json');
+                echo json_encode(['error' => 'Authentication required']);
+                exit;
+            }
+
+            $timeoutMinutes = (int)(Setting::get('session_timeout_minutes') ?? 0);
+            $now = time();
+            $lastActivity = $_SESSION['last_activity'] ?? $now;
+
+            if ($timeoutMinutes > 0 && ($now - $lastActivity) > $timeoutMinutes * 60) {
+                Log::write('Session expired for user ' . $userId, 'WARN');
+                $_SESSION = [];
+                if (session_status() === PHP_SESSION_ACTIVE) {
+                    session_unset();
+                    session_destroy();
+                }
+                http_response_code(403);
+                header('Content-Type: application/json');
+                echo json_encode(['error' => 'Session expired']);
+                exit;
+            }
+
+            $_SESSION['last_activity'] = $now;
+        }
+    }
+}

--- a/php_backend/nocache.php
+++ b/php_backend/nocache.php
@@ -1,12 +1,3 @@
 <?php
-// Allow cross-origin requests
-header('Access-Control-Allow-Origin: *');
-header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
-header('Access-Control-Allow-Headers: Content-Type');
-
-if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    http_response_code(200);
-    exit;
-}
-?>
-
+// Legacy include to maintain backwards compatibility. Delegates to the shared auth bootstrap.
+require_once __DIR__ . '/auth.php';

--- a/php_backend/public/account_balance.php
+++ b/php_backend/public/account_balance.php
@@ -1,6 +1,7 @@
 <?php
 // Returns running balance history for a single account starting from latest bank balance.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Account.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../Database.php';

--- a/php_backend/public/account_dashboard.php
+++ b/php_backend/public/account_dashboard.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning account summaries.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Account.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/account_statement.php
+++ b/php_backend/public/account_statement.php
@@ -1,6 +1,7 @@
 <?php
 // Returns a list of transactions for a single account.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/ai_budget.php
+++ b/php_backend/public/ai_budget.php
@@ -1,6 +1,7 @@
 <?php
 // Endpoint that uses AI to set budgets based on past spending and a savings goal.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Budget.php';
 require_once __DIR__ . '/../models/Tag.php';

--- a/php_backend/public/ai_debug.php
+++ b/php_backend/public/ai_debug.php
@@ -1,6 +1,7 @@
 <?php
 // Simple endpoint to expose whether AI debug mode is enabled.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Setting.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/ai_feedback.php
+++ b/php_backend/public/ai_feedback.php
@@ -1,6 +1,7 @@
 <?php
 // Endpoint that uses AI to summarise finances based on segment and category totals.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/Setting.php';

--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -1,6 +1,7 @@
 <?php
 // Use OpenAI to suggest tags and categories for untagged transactions.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';

--- a/php_backend/public/ai_token.php
+++ b/php_backend/public/ai_token.php
@@ -1,6 +1,7 @@
 <?php
 // Endpoint to manage OpenAI API token.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Setting.php';
 require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');

--- a/php_backend/public/all_years_dashboard.php
+++ b/php_backend/public/all_years_dashboard.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning totals across all available years for segments, tags, categories, and groups.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/assist_transfers.php
+++ b/php_backend/public/assist_transfers.php
@@ -2,7 +2,8 @@
 
 // API endpoint to search for transactions that look like transfers.
 
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -3,7 +3,8 @@
 // segments, transactions, budgets, projects, and settings via the `parts`
 // query parameter. User and account information is always included so a full
 // backup can be restored.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/brand_settings.php
+++ b/php_backend/public/brand_settings.php
@@ -1,6 +1,7 @@
 <?php
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Setting.php';
 header('Content-Type: application/json');
 
 echo json_encode(Setting::getBrand());
-?>

--- a/php_backend/public/budgets.php
+++ b/php_backend/public/budgets.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint for managing category budgets.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Budget.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/categories.php
+++ b/php_backend/public/categories.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint for managing categories and their tag assignments.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Category.php';
 require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/current_user.php
+++ b/php_backend/public/current_user.php
@@ -1,14 +1,13 @@
 <?php
 // Returns the username of the currently logged-in user.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Log.php';
-ini_set('session.cookie_secure', '1');
-session_start();
 
 header('Content-Type: application/json');
 
-if (isset($_SESSION['username'])) {
+if (isset($_SESSION['username']) && $_SESSION['username'] !== '') {
     $username = $_SESSION['username'];
     $db = Database::getConnection();
     $stmt = $db->prepare('SELECT 1 FROM totp_secrets WHERE username = :username');
@@ -17,7 +16,7 @@ if (isset($_SESSION['username'])) {
 
     echo json_encode(['username' => $username, 'has2fa' => $has2fa]);
 } else {
-    http_response_code(401);
-    Log::write('Unauthorized current_user request', 'WARN');
-    echo json_encode(['error' => 'Not logged in']);
+    http_response_code(500);
+    Log::write('Authenticated session missing username', 'ERROR');
+    echo json_encode(['error' => 'Username unavailable']);
 }

--- a/php_backend/public/dashboard.php
+++ b/php_backend/public/dashboard.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning monthly income and spending data for the dashboard.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/dedupe_transactions.php
+++ b/php_backend/public/dedupe_transactions.php
@@ -1,6 +1,7 @@
 <?php
 // Lists duplicate transactions and removes extras when requested.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Tag.php';

--- a/php_backend/public/export_data.php
+++ b/php_backend/public/export_data.php
@@ -1,6 +1,7 @@
 <?php
 // Returns transactions within a date range as JSON for client-side export
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/export_ofx.php
+++ b/php_backend/public/export_ofx.php
@@ -1,6 +1,7 @@
 <?php
 // Exports all transactions as a single OFX file
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/git_pull.php
+++ b/php_backend/public/git_pull.php
@@ -1,6 +1,7 @@
 <?php
 // Runs 'git pull' to update the application to the latest version.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');
 // Determine the repository root. Start from the web server's document root if

--- a/php_backend/public/group_dashboard.php
+++ b/php_backend/public/group_dashboard.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning group spending summaries.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/groups.php
+++ b/php_backend/public/groups.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint for creating, listing, updating, and deleting transaction groups.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/TransactionGroup.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/ignored_transactions.php
+++ b/php_backend/public/ignored_transactions.php
@@ -1,6 +1,7 @@
 <?php
 // List transactions tagged as IGNORE so they can be managed separately.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/index.php
+++ b/php_backend/public/index.php
@@ -1,6 +1,7 @@
 <?php
 // Simple script to insert a sample account for testing.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Account.php';
 

--- a/php_backend/public/link_preview.php
+++ b/php_backend/public/link_preview.php
@@ -1,7 +1,9 @@
 <?php
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
-$sent = headers_sent();
-if (!$sent) {
+
+if (!headers_sent()) {
     header('Content-Type: application/json');
 }
 $url = $_GET['url'] ?? '';
@@ -10,7 +12,7 @@ if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
     echo json_encode(['error' => 'Invalid URL']);
     exit;
 }
-// Fetch the URL content
+
 $context = stream_context_create([
     'http' => [
         'user_agent' => 'Mozilla/5.0'
@@ -19,12 +21,14 @@ $context = stream_context_create([
         'user_agent' => 'Mozilla/5.0'
     ]
 ]);
+
 $html = @file_get_contents($url, false, $context);
 if ($html === false) {
     Log::write('Link preview fetch failed: ' . $url, 'ERROR');
     echo json_encode(['error' => 'Unable to fetch URL']);
     exit;
 }
+
 libxml_use_internal_errors(true);
 $doc = new DOMDocument();
 $doc->loadHTML($html);
@@ -45,4 +49,3 @@ $desc = $meta['og:description'] ?? ($meta['description'] ?? '');
 $image = $meta['og:image'] ?? '';
 $data = ['title' => $title, 'description' => $desc, 'image' => $image];
 echo json_encode($data);
-

--- a/php_backend/public/link_transfer.php
+++ b/php_backend/public/link_transfer.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint to manually link two transactions as a transfer.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/logs.php
+++ b/php_backend/public/logs.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning recent application log entries.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Setting.php';
 

--- a/php_backend/public/mark_transfer.php
+++ b/php_backend/public/mark_transfer.php
@@ -2,7 +2,8 @@
 
 // API endpoint to mark transaction pairs as transfers.
 
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/monthly_dashboard.php
+++ b/php_backend/public/monthly_dashboard.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning monthly totals for segments, tags, categories, groups and income/outgoings.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/nl_report.php
+++ b/php_backend/public/nl_report.php
@@ -1,7 +1,8 @@
 <?php
 
 // API endpoint that accepts a natural language query and returns the derived filters.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 
 require_once __DIR__ . '/../NaturalLanguageReportParser.php';
 

--- a/php_backend/public/palette.php
+++ b/php_backend/public/palette.php
@@ -1,5 +1,6 @@
 <?php
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Segment.php';
 require_once __DIR__ . '/../models/Category.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/palette_css.php
+++ b/php_backend/public/palette_css.php
@@ -1,5 +1,6 @@
 <?php
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Segment.php';
 
 header('Content-Type: text/css');

--- a/php_backend/public/projects.php
+++ b/php_backend/public/projects.php
@@ -1,7 +1,8 @@
 <?php
 // REST API for managing home projects.
 require_once __DIR__ . '/../models/Project.php';
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/recurring_spend.php
+++ b/php_backend/public/recurring_spend.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint to analyse recurring income and spending over the past year.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/report.php
+++ b/php_backend/public/report.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint providing transaction reports filtered by various criteria.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -3,7 +3,8 @@
 // Restores users, accounts, settings, segments, categories, tags, groups,
 // transactions, budgets, and projects from an uploaded gzipped JSON backup.
 
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Database.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/run_processes.php
+++ b/php_backend/public/run_processes.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint to manually run tagging and categorisation processes.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../models/Segment.php';

--- a/php_backend/public/saved_reports.php
+++ b/php_backend/public/saved_reports.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint for managing saved transaction reports.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/SavedReport.php';
 require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');

--- a/php_backend/public/search_transactions.php
+++ b/php_backend/public/search_transactions.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint to search transactions across all fields.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/segments.php
+++ b/php_backend/public/segments.php
@@ -1,5 +1,6 @@
 <?php
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Segment.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/send_pdf.php
+++ b/php_backend/public/send_pdf.php
@@ -1,6 +1,7 @@
 <?php
 // Receives a PDF report upload and emails it to a configured address.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');

--- a/php_backend/public/session_timeout.php
+++ b/php_backend/public/session_timeout.php
@@ -1,16 +1,9 @@
 <?php
 // Returns inactivity timeout in minutes for the current user.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Setting.php';
-require_once __DIR__ . '/../models/Log.php';
-ini_set('session.cookie_secure', '1');
-session_start();
+
 header('Content-Type: application/json');
-if (!isset($_SESSION['user_id'])) {
-    http_response_code(401);
-    Log::write('Session timeout check without login', 'WARN');
-    echo json_encode(['error' => 'Not logged in']);
-    exit;
-}
 $minutes = (int) (Setting::get('session_timeout_minutes') ?? 0);
 echo json_encode(['minutes' => $minutes]);

--- a/php_backend/public/tags.php
+++ b/php_backend/public/tags.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint for creating, listing, updating, and deleting tags.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/totp_disable.php
+++ b/php_backend/public/totp_disable.php
@@ -1,20 +1,28 @@
 <?php
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../Totp.php';
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../Database.php';
 
-
-ini_set('session.cookie_secure', '1');
-session_start();
 header('Content-Type: application/json');
-$input = json_decode(file_get_contents('php://input'), true);
-$username = $input['username'] ?? ($_SESSION['username'] ?? '');
+$input = json_decode(file_get_contents('php://input'), true) ?: [];
+$sessionUsername = $_SESSION['username'] ?? '';
+$requestedUsername = trim($input['username'] ?? '');
 
-if ($username === '') {
-    Log::write('2FA disable missing username', 'ERROR');
-    echo json_encode(['disabled' => false, 'error' => 'Username required']);
+if ($sessionUsername === '') {
+    Log::write('2FA disable without session username', 'ERROR');
+    echo json_encode(['disabled' => false, 'error' => 'Authentication required']);
     exit;
 }
+
+if ($requestedUsername !== '' && $requestedUsername !== $sessionUsername) {
+    Log::write("2FA disable username mismatch for '$sessionUsername'", 'WARN');
+    echo json_encode(['disabled' => false, 'error' => 'Username mismatch']);
+    exit;
+}
+
+$username = $sessionUsername;
 
 try {
     $db = Database::getConnection();
@@ -30,6 +38,4 @@ try {
 } catch (Throwable $e) {
     Log::write("2FA disable DB error for '$username': " . $e->getMessage(), 'ERROR');
     echo json_encode(['disabled' => false, 'error' => 'Server error']);
-
 }
-?>

--- a/php_backend/public/transaction.php
+++ b/php_backend/public/transaction.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning a single transaction's details.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/transaction_months.php
+++ b/php_backend/public/transaction_months.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint listing months that contain transaction data.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/transactions.php
+++ b/php_backend/public/transactions.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning transactions for a selected month and year.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 

--- a/php_backend/public/transfers.php
+++ b/php_backend/public/transfers.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint to list transfer pairs and OFX-marked transfer transactions.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/unignore_transaction.php
+++ b/php_backend/public/unignore_transaction.php
@@ -1,6 +1,7 @@
 <?php
 // Remove the IGNORE tag from a transaction so it appears in reports again.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/unmark_transfer.php
+++ b/php_backend/public/unmark_transfer.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint to undo previously marked transfers.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/untagged_count.php
+++ b/php_backend/public/untagged_count.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning the total number of untagged transactions.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/untagged_transactions.php
+++ b/php_backend/public/untagged_transactions.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning most common untagged transactions grouped by description and memo.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/update_account.php
+++ b/php_backend/public/update_account.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint to update the name of an account.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Account.php';
 require_once __DIR__ . '/../models/Log.php';
 

--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint to update tag, category, and group of a transaction.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';

--- a/php_backend/public/update_transaction_tag.php
+++ b/php_backend/public/update_transaction_tag.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint to update a transaction's tag and apply auto-tagging.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';

--- a/php_backend/public/upload_ofx.php
+++ b/php_backend/public/upload_ofx.php
@@ -1,6 +1,7 @@
 <?php
 // Handles OFX file uploads and imports transactions into the database.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Account.php';
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Log.php';

--- a/php_backend/public/version.php
+++ b/php_backend/public/version.php
@@ -1,6 +1,7 @@
 <?php
 // Outputs the current git commit hash for version display without relying on shell_exec.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+// Public health-check endpoint intentionally skips require_api_auth().
 require_once __DIR__ . '/../models/Log.php';
 header('Content-Type: application/json');
 $rootDir = dirname(__DIR__, 2);

--- a/php_backend/public/yearly_dashboard.php
+++ b/php_backend/public/yearly_dashboard.php
@@ -1,6 +1,7 @@
 <?php
 // API endpoint returning yearly totals for segments, tags, categories, and groups.
-require_once __DIR__ . '/../nocache.php';
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
 require_once __DIR__ . '/../models/Log.php';
 require_once __DIR__ . '/../models/Transaction.php';
 


### PR DESCRIPTION
## Summary
- add a shared php_backend/auth.php bootstrap that configures secure sessions, blocks cross-origin requests, and exposes require_api_auth()
- replace legacy nocache usage so every php_backend/public endpoint includes the bootstrap, with stricter handling for TOTP helpers and link previews
- update login/admin pages to consume the bootstrap, record last activity timestamps, and harden logout cleanup

## Testing
- php tests/run_tests.php
- curl -i http://127.0.0.1:8000/php_backend/public/current_user.php
- curl -i -X OPTIONS -H "Origin: http://evil.com" http://127.0.0.1:8000/php_backend/public/current_user.php

------
https://chatgpt.com/codex/tasks/task_e_68ca6baee408832e8c0de4df69454fba