### PR TITLE
Fix accent font weight persistence

### DIFF
--- a/frontend/js/fonts.js
+++ b/frontend/js/fonts.js
@@ -50,7 +50,11 @@
       root.style.setProperty('--tabulator-header-font-family', table);
     }
     if (chart) root.style.setProperty('--chart-font', chart);
-    if (accentW) root.style.setProperty('--accent-font-weight', accentW);
+    if (accentW) {
+      root.style.setProperty('--accent-font-weight', accentW);
+    } else {
+      root.style.removeProperty('--accent-font-weight');
+    }
 
     ensureStyle();
     document.dispatchEvent(new Event('fonts-applied'));

--- a/php_backend/models/Setting.php
+++ b/php_backend/models/Setting.php
@@ -36,6 +36,15 @@ class Setting {
      *               accent_font_weight: string}
      */
     public static function getBrand(): array {
+        $accent = self::get('accent_font_weight');
+        if ($accent === null) {
+            $legacyAccent = self::get('font_accent_weight');
+            if ($legacyAccent !== null) {
+                $accent = $legacyAccent;
+                self::set('accent_font_weight', $legacyAccent);
+            }
+        }
+
         return [
             'site_name'    => self::get('site_name')    ?? self::DEFAULT_SITE_NAME,
             'color_scheme' => self::get('color_scheme') ?? self::DEFAULT_COLOR_SCHEME,
@@ -43,7 +52,7 @@ class Setting {
             'body_font'    => self::get('font_body')    ?? self::DEFAULT_FONT,
             'table_font'   => self::get('font_table')   ?? self::DEFAULT_FONT,
             'chart_font'   => self::get('font_chart')   ?? self::DEFAULT_FONT,
-            'accent_font_weight' => self::get('accent_font_weight') ?? '',
+            'accent_font_weight' => $accent ?? '',
         ];
     }
 }

--- a/settings.php
+++ b/settings.php
@@ -89,6 +89,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $tableFont = trim($_POST['font_table'] ?? '');
     $chartFont = trim($_POST['font_chart'] ?? '');
     $accentWeight = trim($_POST['accent_font_weight'] ?? '');
+    if (!array_key_exists($accentWeight, $weightOptions)) {
+        $accentWeight = '';
+    }
     Setting::set('openai_api_token', $openai);
     Log::write('Updated OpenAI API token');
     if ($batch !== '') {
@@ -129,6 +132,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     Setting::set('font_table', $tableFont);
     Setting::set('font_chart', $chartFont);
     Setting::set('accent_font_weight', $accentWeight);
+    Setting::set('font_accent_weight', $accentWeight);
     Log::write('Updated font settings');
     $message = 'Settings updated.';
 }


### PR DESCRIPTION
## Summary
- validate and persist the accent font weight setting while keeping the legacy key in sync
- migrate stored branding values that only used the legacy accent font weight field
- clear the accent font weight CSS override when reverting to the default weight so accents update correctly

## Testing
- php tests/run_tests.php *(fails: Parse error: syntax error, unexpected variable "$db" in tests/run_tests.php on line 235)*

------
https://chatgpt.com/codex/tasks/task_e_68ca78645710832e926ae8aef0110fb1