### PR TITLE
Fix stray character in test suite

### DIFF
--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -231,7 +231,6 @@ assertEqual(300.0, (float)$recSpend[0]['total'], 'Recurring spend total summed')
 assertEqual(6300.0, (float)$recIncome[0]['total'], 'Recurring income total summed');
 assertEqual(90.0, (float)$recSpend[0]['last_amount'], 'Recurring spend last amount stored');
 assertEqual(2200.0, (float)$recIncome[0]['last_amount'], 'Recurring income last amount stored');
-n
 $db->exec('DELETE FROM transactions');
 
 // --- Duplicate FITID test ---


### PR DESCRIPTION
## Summary
- remove a stray character left in the recurring spend tests
- restore valid PHP syntax for the test runner

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca8400ef38832e9754abe2a109eac3