### PR TITLE
Restyle navigation chrome with translucent gradient

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white" data-api-base="../php_backend/public">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <div class="flex items-center mb-4">
                 <h1 class="text-2xl font-semibold flex-1 text-indigo-700"><i class="fas fa-shield-halved inline w-6 h-6 mr-2"></i>Two-Factor Authentication</h1>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 id="account-name" class="text-2xl font-semibold mb-4 text-indigo-700">Account Balance</h1>
             <p id="account-details" class="mb-4 text-gray-600"></p>

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Account Dashboard</h1>
             <p class="mb-4">See an overview of account balances and recent activity. Charts and tables reveal how money flows through each account. Sort codes and account numbers are shown where applicable; credit cards list only their card number.</p>

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -15,7 +15,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">AI Feedback</h1>
         <p class="mb-4">Request an AI-generated overview of your finances for the last 12 months.</p>

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -15,7 +15,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">AI Tags</h1>
         <p class="mb-4">Configure OpenAI and automatically tag transactions.</p>

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">All Years Dashboard</h1>
             <p class="mb-4">Compare financial totals across every recorded year to reveal long-term trends and patterns in your finances.</p>

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -16,7 +16,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Backup &amp; Restore</h1>
             <p class="mb-4">Create backups of your data or restore from an earlier snapshot. Use the tools below to download a copy of your information or load a previous backup.</p>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -19,7 +19,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Budgets</h1>
         <p class="mb-4">Set monthly spending limits for categories and monitor progress. Use this page to plan ahead and see where you may need to adjust your spending.</p>

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -16,7 +16,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Categories</h1>
             <p class="mb-4">Create categories and assign tags to organise your transactions. A well-maintained list keeps reports clear and makes searching easier.</p>

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -16,7 +16,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Duplicate Transactions</h1>
             <p class="mb-4">Remove unwanted duplicate entries to keep your records accurate.</p>

--- a/frontend/export.html
+++ b/frontend/export.html
@@ -15,7 +15,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Exports</h1>
             <p class="mb-4">Download transactions for a chosen period in your preferred format.</p>

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -15,7 +15,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-4">
             <h1 class="text-2xl font-semibold text-indigo-700">Graphs</h1>
             <p class="mb-4">Explore a collection of charts that illustrate your income and spending patterns. Choose a year to see how your finances evolve and compare categories or tags visually.</p>

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Group Dashboard</h1>
             <p class="mb-4">Review group spending by month and year to see how different areas of your budget change over time.</p>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Groups</h1>
             <p class="mb-4">Create groups to collect related categories for reporting and analysis. Grouping similar categories helps you see broader spending patterns.</p>

--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -15,7 +15,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Ignored Transactions</h1>
             <p class="mb-4">Transactions tagged with <strong>IGNORE</strong> are hidden from dashboards and reports. Use this page to review and restore them.</p>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,7 +25,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex flex-col md:flex-row min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto shadow"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto shadow"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <section class="mb-8" data-no-card="true">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -75,9 +75,6 @@ window.fetchNoCache = fetchNoCache;
     });
   };
 
-  // Apply 20% opacity to all page elements
-  document.documentElement.style.opacity = '0.9';
-
   // Copy aria-labels to data-tooltip attributes for custom tooltips
   const applyAriaTooltips = (root = document) => {
     root.querySelectorAll('[aria-label]').forEach(el => {
@@ -158,6 +155,16 @@ window.fetchNoCache = fetchNoCache;
       'left-0',
       'overflow-y-auto',
       'z-40'
+    );
+    menu.classList.remove('bg-white', 'border-r');
+    menu.classList.add(
+      'bg-gradient-to-b',
+      'from-white/80',
+      `to-${colorScheme}-100/30`,
+      'backdrop-blur-xl',
+      'border',
+      'border-white/40',
+      'shadow-2xl'
     );
 
     fetchNoCache('menu.php')
@@ -271,7 +278,7 @@ window.fetchNoCache = fetchNoCache;
 
   const toggle = document.createElement('button');
   toggle.id = 'menu-toggle';
-  toggle.className = 'fixed top-2 left-2 md:top-8 md:left-12 z-50 md:hidden bg-white rounded border border-indigo-600 p-2 shadow transition-shadow hover:shadow-lg';
+  toggle.className = `fixed top-2 left-2 md:top-8 md:left-12 z-50 md:hidden bg-gradient-to-r from-white/80 to-${colorScheme}-100/40 backdrop-blur border border-white/40 text-${colorScheme}-700 p-2 rounded-xl shadow-lg transition-all hover:from-white/90 hover:to-${colorScheme}-100/60 hover:shadow-2xl focus:outline-none focus:ring-2 focus:ring-${colorScheme}-200`;
   toggle.innerHTML = '<i class="fas fa-bars"></i>';
   toggle.addEventListener('click', () => {
     if (menu) menu.classList.toggle('hidden');
@@ -282,7 +289,7 @@ window.fetchNoCache = fetchNoCache;
   utility.id = 'utility-bar';
 
 
-  utility.className = 'fixed top-2 right-2 md:top-8 md:right-12 bg-white rounded border border-indigo-600 p-1 flex items-center space-x-2 z-50';
+  utility.className = `fixed top-2 right-2 md:top-8 md:right-12 bg-gradient-to-r from-white/80 to-${colorScheme}-100/40 backdrop-blur border border-white/40 text-${colorScheme}-700 p-1 flex items-center space-x-2 z-50 rounded-xl shadow-lg transition-all hover:from-white/90 hover:to-${colorScheme}-100/60 hover:shadow-2xl`;
 
   utility.innerHTML = `
     <button id="quick-search-toggle" class="md:hidden p-1" aria-label="Search transactions">

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Application Logs</h1>
             <p class="mb-4">Review recent log entries to monitor system activity. Filtering by time or keyword helps you trace what happened during a specific event.</p>

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -17,7 +17,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Missing Tags</h1>
             <p class="mb-4">Identify transactions that have not yet been tagged so you can assign categories before they slip through your reports.</p>

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Dashboard</h1>
             <p class="mb-4">View income and outgoings for a chosen month. Compare different months to spot trends and track progress toward your goals.</p>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -19,7 +19,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Statement</h1>
             <p class="mb-4">Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.</p>

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -14,7 +14,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
   <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="flex-1 p-6">
       <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Palette Settings</h1>
 

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Pivot Analysis</h1>
             <p class="mb-4">Explore transactions using a flexible pivot table. Choose a year or analyse all recorded data.</p>

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -16,7 +16,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Run Processes</h1>
             <p class="mb-4">Run background tasks like auto-tagging, category or segment assignment. These automated processes tidy your data so reports stay accurate without manual effort.</p>

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -16,7 +16,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Add Project</h1>
         <p class="mb-4">Capture ideas for home projects and detail their costs and benefits.</p>

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -19,7 +19,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Projects</h1>
         <p class="mb-4">Review your planned projects, explore costs and compare their priorities.</p>

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -17,7 +17,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Archived Projects</h1>
         <p class="mb-4">Review projects that have been archived. Restore any project to make it active again.</p>

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -17,7 +17,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
 <div class="flex min-h-screen">
-    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+    <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Project Board</h1>
         <p class="mb-4">Browse all active projects in a card layout.</p>

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Recurring Spend Detection</h1>
             <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses. The results highlight ongoing commitments so you know where money leaves your account regularly.</p>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -19,7 +19,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Reports</h1>
             <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Search Transactions</h1>
             <p class="mb-4">Find specific transactions using keywords and view the results below. Quick searches help you jump straight to the entries you need.</p>

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -16,7 +16,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Segments</h1>
             <p class="mb-4">Create segments to group categories for broader analysis. Drag categories between segments to adjust their grouping.</p>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Tags</h1>
             <p class="mb-4">Create new tags and manage existing ones for categorising transactions. Tags act like labels that make reports and searches more meaningful.</p>

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -22,7 +22,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Details</h1>
             <p class="mb-4">Review or edit the information for a single transaction. Changes here immediately update dashboards, reports and budgets.</p>

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -17,7 +17,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <section>
                 <h1 class="text-2xl font-semibold mb-4 flex items-center justify-between text-indigo-700">

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -15,7 +15,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Upload OFX Files</h1>
         <p class="mb-4">Upload one or more OFX statements from your bank to import transactions into the system. The file contents will be processed and your data added to the database for review.</p>

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -18,7 +18,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-50 to-white">
     <div class="flex min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-white border-r p-6 overflow-y-auto"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Yearly Dashboard</h1>
             <p class="mb-4">Analyse totals for a single year through charts and tables to understand how income and spending evolved month by month.</p>


### PR DESCRIPTION
## Summary
- restyle the shared navigation container with translucent gradient, blur, and accent-aware border treatments while dropping the global opacity dimmer
- refresh the floating toggle and utility controls to share the same translucent palette for consistent chrome
- switch HTML nav placeholders to transparent backgrounds to avoid flashing the old white sidebar before menu.js applies styling

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca8a2e93dc832ebd1bb38497b58dbc