### PR TITLE
Refresh hero gradients and call-to-action styling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,15 +35,15 @@
                             <img src="coin_flower.png" alt="Coin plant illustration" class="absolute inset-0 w-full h-full object-cover transition-all duration-700 opacity-0 translate-x-full">
                             <img src="wallet.svg" alt="Wallet icon" class="absolute inset-0 w-full h-full object-cover transition-all duration-700 opacity-0 translate-x-full">
                         </div>
-                        <div class="absolute inset-0 bg-indigo-700/60 flex flex-col items-center justify-center text-center p-6">
+                        <div class="absolute inset-0 bg-gradient-to-br from-indigo-600/70 via-purple-500/60 to-sky-500/60 backdrop-blur-lg border border-white/30 rounded-3xl flex flex-col items-center justify-center text-center p-6">
                             <h1 class="text-3xl md:text-4xl font-semibold mb-4 text-white">Welcome to <span id="landing-site-name">Finance Manager</span></h1>
                             <p class="text-indigo-100 mb-4">Select an option from the menu to get started exploring your finances. Each section opens tools and dashboards that help you understand where your money goes.</p>
-                              <a href="upload.html" class="inline-block bg-white text-indigo-700 px-4 py-2 rounded hover:bg-indigo-100 font-light">Get Started</a>
+                              <a href="upload.html" class="inline-block bg-gradient-to-r from-indigo-500 via-purple-500 to-sky-500 text-white font-medium px-6 py-2 rounded-full shadow-lg hover:from-indigo-400 hover:to-sky-400">Get Started</a>
                         </div>
                     </div>
                     <div class="relative rounded-lg overflow-hidden shadow h-72 md:h-96">
                         <img src="coin_flower.png" alt="Coin plant illustration" class="absolute inset-0 w-full h-full object-cover">
-                        <div class="absolute inset-0 bg-black/40 flex items-center justify-center p-6 text-center">
+                        <div class="absolute inset-0 bg-gradient-to-br from-slate-900/50 to-slate-700/30 backdrop-blur flex items-center justify-center p-6 text-center">
                             <p class="text-white text-2xl">Track savings effortlessly</p>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- replace the landing hero overlay with a glassmorphism gradient treatment and matching blur
- restyle the adjacent savings callout with a complementary translucent gradient backdrop
- modernise the Get Started button with a pill-shaped gradient action style

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca8a2def3c832e952cc1a5334c16f4