### PR TITLE
Update hero carousel with finance imagery

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -72,9 +72,9 @@
                             <div class="absolute -top-10 -left-10 h-32 w-32 rounded-full bg-white/10 blur-3xl"></div>
                             <div class="relative overflow-hidden rounded-3xl border border-white/30 bg-white/10 shadow-2xl">
                                 <div id="landing-carousel" class="relative h-72 w-full md:h-[28rem]">
-                                    <img src="laptop.png" alt="Laptop illustration" class="absolute inset-0 h-full w-full object-cover transition-all duration-700 opacity-100 translate-x-0">
-                                    <img src="coin_flower.png" alt="Coin plant illustration" class="absolute inset-0 h-full w-full object-cover transition-all duration-700 opacity-0 translate-x-full">
-                                    <img src="wallet.svg" alt="Wallet icon" class="absolute inset-0 h-full w-full object-cover transition-all duration-700 opacity-0 translate-x-full">
+                                    <img src="https://images.unsplash.com/photo-1556740749-887f6717d7e4?auto=format&fit=crop&w=1200&q=80" alt="Financial analyst reviewing data on a laptop" class="absolute inset-0 h-full w-full object-cover transition-all duration-700 opacity-100 translate-x-0">
+                                    <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1200&q=80" alt="Team collaborating over financial charts" class="absolute inset-0 h-full w-full object-cover transition-all duration-700 opacity-0 translate-x-full">
+                                    <img src="https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=1200&q=80" alt="Close-up of hands working on investment documents" class="absolute inset-0 h-full w-full object-cover transition-all duration-700 opacity-0 translate-x-full">
                                 </div>
                                 <div class="absolute inset-x-0 bottom-0 space-y-3 bg-gradient-to-t from-slate-950/80 via-slate-900/40 to-transparent p-6">
                                     <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- switch the landing page carousel assets to photorealistic finance-focused imagery using high-quality Unsplash photos
- enhance alt text for the carousel slides to better describe the finance scenarios shown

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca92a96dbc832ea90e41a6008f7630