### PR TITLE
Adopt glassmorphism cards across frontend

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -26,7 +26,7 @@
             </div>
             <p class="mb-4">Set up TOTP-based authentication and verify your one-time codes.</p>
 
-            <div class="bg-white p-6 rounded shadow border border-gray-400 mb-6">
+            <div class="cards mb-6">
                   <h2 class="text-xl mb-4">Setup</h2>
                 <form id="generate-form" class="space-y-4">
                     <input id="gen-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">
@@ -37,7 +37,7 @@
 
             </div>
 
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="cards">
                   <h2 class="text-xl mb-4">Verify</h2>
                 <form id="verify-form" class="space-y-4">
                     <input id="ver-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -23,11 +23,11 @@
             <h1 id="account-name" class="text-2xl font-semibold mb-4 text-indigo-700">Account Balance</h1>
             <p id="account-details" class="mb-4 text-gray-600"></p>
             <p class="mb-4">View the balance over time based on the latest bank statement.</p>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="cards">
                 <div id="balance-chart" style="height:400px" data-chart-desc="Line chart of account balance over time."></div>
             </div>
 
-            <div class="bg-white p-6 rounded shadow border border-gray-400 mt-6">
+            <div class="cards mt-6">
                 <div id="statement-table"></div>
             </div>
 

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -22,7 +22,7 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Account Dashboard</h1>
             <p class="mb-4">See an overview of account balances and recent activity. Charts and tables reveal how money flows through each account. Sort codes and account numbers are shown where applicable; credit cards list only their card number.</p>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="cards">
                 <div id="accounts-table"></div>
                 <div id="accounts-chart" class="mt-4" style="height:400px" data-chart-desc="Waterfall chart showing balance changes per account."></div>
             </div>

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -25,7 +25,7 @@
             </button>
             <div id="result" class="mt-4"></div>
             <div id="debug" class="mt-4 hidden">
-                <div class="bg-white p-4 rounded shadow border border-gray-400">
+                <div class="cards cards-tight space-y-3">
                     <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
                     <p class="text-sm font-semibold">Prompt</p>
                     <pre id="debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
@@ -50,7 +50,7 @@ function renderFeedback(data){
     const highlights = data.highlights.map(h=>`<li>${escapeHtml(h)}</li>`).join('');
     const actions = data.actions.map(a=>`<li>${escapeHtml(a)}</li>`).join('');
     return `
-        <div class="bg-white p-4 rounded shadow border border-gray-400 space-y-4">
+        <div class="cards cards-tight space-y-4">
             <p>${escapeHtml(data.summary)}</p>
             <div>
                 <h3 class="font-semibold">Highlights</h3>

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -34,7 +34,7 @@
             <button id="run" class="bg-green-600 text-white px-4 py-2 rounded"><i class="fas fa-robot inline w-4 h-4 mr-1"></i>Run AI Tagging</button>
             <div id="result" class="mt-4"></div>
             <div id="debug" class="mt-4 hidden">
-                <div class="bg-white p-4 rounded shadow border border-gray-400">
+                <div class="cards cards-tight space-y-3">
                     <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
                     <p class="text-sm font-semibold">Prompt</p>
                     <pre id="debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -20,7 +20,7 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Backup &amp; Restore</h1>
             <p class="mb-4">Create backups of your data or restore from an earlier snapshot. Use the tools below to download a copy of your information or load a previous backup.</p>
-            <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-4">
+            <section class="cards space-y-4">
                 <h2 class="text-xl font-semibold">Download Backup</h2>
 
                 <p>Select which data to include in the compressed JSON backup file. User and account
@@ -41,7 +41,7 @@
 
                 <p class="mt-4">Need your transactions in another format? Visit the <a href="export.html" class="text-indigo-600 underline">Exports</a> page.</p>
             </section>
-            <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-4">
+            <section class="cards space-y-4">
                 <h2 class="text-xl font-semibold">Restore Backup</h2>
                 <p>Select a gzipped JSON backup file to restore any included transactions, categories, tags, groups, segments, projects, budgets, or settings.</p>
                 <form id="restore-form" action="../php_backend/public/restore.php" method="POST" enctype="multipart/form-data" class="space-y-4">

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -31,17 +31,17 @@
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end">Set Budget</button>
             </form>
         </section>
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
-            <h2 class="text-xl font-semibold mb-4">AI Budgeting</h2>
+        <section class="cards space-y-4">
+            <h2 class="text-xl font-semibold">AI Budgeting</h2>
 
-            <p class="mb-4">Send your savings goal and the last 12 months of category totals to the AI to propose next month's budgets and provide a brief explanation.</p>
+            <p>Send your savings goal and the last 12 months of category totals to the AI to propose next month's budgets and provide a brief explanation.</p>
             <form id="ai-form" class="md:flex md:space-x-4 space-y-4 md:space-y-0">
                 <label class="block">Savings Goal (£)<br><input type="number" step="0.01" id="goal" class="border p-2 rounded" data-help="Monthly amount you want to save. The AI uses this plus a year of history to set budgets."></label>
                 <button id="ai-run" type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end"><i class="fas fa-robot inline w-4 h-4 mr-1"></i>Generate Budgets</button>
             </form>
             <div id="ai-result" class="mt-4"></div>
-            <div id="ai-debug" class="mt-4 hidden">
-                <div class="bg-white p-4 rounded shadow border border-gray-400">
+            <div id="ai-debug" class="hidden">
+                <div class="cards cards-tight space-y-3">
                     <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
                     <p class="text-sm font-semibold">Prompt</p>
                     <pre id="ai-debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
@@ -55,7 +55,7 @@
             <h2 class="text-xl font-semibold mb-4">Current Budgets</h2>
             <div id="budget-table"></div>
         </section>
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
+        <section class="cards">
             <h2 class="text-xl font-semibold mb-4">Budget Progress</h2>
             <div id="budget-chart" style="height:400px" data-chart-desc="Bullet chart comparing spending to budgets."></div>
         </section>

--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -1,10 +1,62 @@
-/* Shared card component styles extracted from Tailwind utilities */
+/* Shared glassmorphism card styles applied across the site */
 .cards {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.65));
-  padding: 1.5rem;
-  border-radius: 0.25rem;
-  box-shadow: 0 1px 3px 0 rgba(0,0,0,0.1), 0 1px 2px -1px rgba(0,0,0,0.1);
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+  --card-padding: 1.5rem;
+  --card-radius: 1rem;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(255, 255, 255, 0.52));
+  padding: var(--card-padding);
+  border-radius: var(--card-radius);
+  box-shadow:
+    0 25px 45px -20px rgba(15, 23, 42, 0.35),
+    0 18px 35px -28px rgba(15, 23, 42, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(20px) saturate(150%);
+  -webkit-backdrop-filter: blur(20px) saturate(150%);
+  position: relative;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.cards::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.cards:hover {
+  transform: translateY(-2px);
+  box-shadow:
+    0 32px 55px -26px rgba(15, 23, 42, 0.45),
+    0 18px 45px -30px rgba(15, 23, 42, 0.3);
+}
+
+.cards:hover::before {
+  opacity: 1;
+}
+
+.cards-tight {
+  --card-padding: 1rem;
+}
+
+.cards-snug {
+  --card-padding: 1.25rem;
+}
+
+.cards-roomy {
+  --card-padding: 2rem;
+}
+
+.cards-rounded-lg {
+  --card-radius: 0.75rem;
+}
+
+.cards-rounded-xl {
+  --card-radius: 1.5rem;
+}
+
+.cards-rounded-full {
+  --card-radius: 9999px;
 }

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -20,7 +20,7 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Duplicate Transactions</h1>
             <p class="mb-4">Remove unwanted duplicate entries to keep your records accurate.</p>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="cards">
                 <div class="mb-4 space-x-2">
                     <button id="refresh" class="bg-indigo-600 text-white px-3 py-1 rounded"><i class="fas fa-rotate inline w-4 h-4 mr-1"></i>Refresh</button>
                     <button id="dedupe-all" class="bg-red-600 text-white px-3 py-1 rounded"><i class="fas fa-clone inline w-4 h-4 mr-1"></i>Dedupe All</button>

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -41,22 +41,22 @@
                 </nav>
             </div>
 
-            <div id="income-sunburst" class="tab-content bg-white p-6 rounded shadow border border-gray-400"><div id="income-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of income by segment, category and tag."></div></div>
-            <div id="outgoing-sunburst" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="outgoing-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of outgoings by segment, category and tag."></div></div>
-            <div id="monthly-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="monthly-chart" class="h-[80vh]" data-chart-desc="Column chart of monthly spending totals."></div></div>
-            <div id="cumulative-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="cumulative-chart" class="h-[80vh]" data-chart-desc="Line chart of cumulative spending through the year."></div></div>
-            <div id="pie-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="pie-chart" class="h-[80vh]" data-chart-desc="Pie chart of spending by category."></div></div>
-            <div id="income-tag-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="income-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of income totals by tag."></div></div>
-            <div id="outgoing-tag-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="outgoing-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of outgoing totals by tag."></div></div>
-            <div id="scatter-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="scatter-chart" class="h-[80vh]" data-chart-desc="Bubble chart comparing monthly income and outgoings."></div></div>
-            <div id="stream-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="stream-chart" class="h-[80vh]" data-chart-desc="Stream graph of category spending over the year."></div></div>
+            <div id="income-sunburst" class="tab-content cards"><div id="income-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of income by segment, category and tag."></div></div>
+            <div id="outgoing-sunburst" class="tab-content cards hidden"><div id="outgoing-sunburst-chart" class="h-[80vh]" data-chart-desc="Sunburst chart of outgoings by segment, category and tag."></div></div>
+            <div id="monthly-chart-container" class="tab-content cards hidden"><div id="monthly-chart" class="h-[80vh]" data-chart-desc="Column chart of monthly spending totals."></div></div>
+            <div id="cumulative-chart-container" class="tab-content cards hidden"><div id="cumulative-chart" class="h-[80vh]" data-chart-desc="Line chart of cumulative spending through the year."></div></div>
+            <div id="pie-chart-container" class="tab-content cards hidden"><div id="pie-chart" class="h-[80vh]" data-chart-desc="Pie chart of spending by category."></div></div>
+            <div id="income-tag-container" class="tab-content cards hidden"><div id="income-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of income totals by tag."></div></div>
+            <div id="outgoing-tag-container" class="tab-content cards hidden"><div id="outgoing-tag-chart" class="h-[80vh]" data-chart-desc="Column chart of outgoing totals by tag."></div></div>
+            <div id="scatter-chart-container" class="tab-content cards hidden"><div id="scatter-chart" class="h-[80vh]" data-chart-desc="Bubble chart comparing monthly income and outgoings."></div></div>
+            <div id="stream-chart-container" class="tab-content cards hidden"><div id="stream-chart" class="h-[80vh]" data-chart-desc="Stream graph of category spending over the year."></div></div>
 
-            <div id="area-range-chart-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="area-range-chart" class="h-[80vh]" data-chart-desc="Area spline chart of min and max monthly spending."></div></div>
-            <div id="network-graph-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="network-graph" class="h-[80vh]" data-chart-desc="Network graph linking segments and categories."></div></div>
+            <div id="area-range-chart-container" class="tab-content cards hidden"><div id="area-range-chart" class="h-[80vh]" data-chart-desc="Area spline chart of min and max monthly spending."></div></div>
+            <div id="network-graph-container" class="tab-content cards hidden"><div id="network-graph" class="h-[80vh]" data-chart-desc="Network graph linking segments and categories."></div></div>
 
-            <div id="treegraph-container" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden"><div id="treegraph-chart" data-chart-desc="Tree graph of segments and categories."></div></div>
+            <div id="treegraph-container" class="tab-content cards hidden"><div id="treegraph-chart" data-chart-desc="Tree graph of segments and categories."></div></div>
 
-            <div id="segment-section" class="tab-content bg-white p-6 rounded shadow border border-gray-400 hidden space-y-4">
+            <div id="segment-section" class="tab-content cards hidden space-y-4">
                 <h2 class="text-xl font-semibold">Segment Totals</h2>
                 <div id="segment-table"></div>
                 <div id="segment-chart" class="h-[80vh]" data-chart-desc="Column chart of segment totals."></div>

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -27,13 +27,13 @@
             </label>
 
             <h2 class="text-xl font-semibold mt-6 mb-2">Monthly Totals</h2>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="cards">
                 <div id="month-table"></div>
                 <div id="month-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of monthly totals for each group."></div>
             </div>
 
             <h2 class="text-xl font-semibold mt-6 mb-2">Yearly Totals</h2>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="cards">
                 <div id="year-table"></div>
                 <div id="year-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of yearly totals for each group."></div>
             </div>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -27,7 +27,7 @@
                 <label class="block">Description<br><textarea id="group-description" class="border p-2 rounded w-full" data-help="Description for the group"></textarea></label>
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Group</button>
             </form>
-            <div class="mt-6 bg-white p-4 rounded shadow border border-gray-400">
+            <div class="mt-6 cards cards-tight">
                 <h2 class="text-xl font-semibold mb-2">Existing Groups</h2>
                 <div id="group-table"></div>
             </div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -98,7 +98,7 @@
                     </div>
                 </div>
                 <div class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-3">
-                    <a href="ai_tags.html" class="group flex items-center justify-between rounded-2xl bg-white p-5 shadow-lg transition hover:-translate-y-1 hover:shadow-xl" aria-label="Tune AI tagging rules">
+                    <a href="ai_tags.html" class="group flex items-center justify-between cards cards-snug cards-rounded-xl" aria-label="Tune AI tagging rules">
                         <div>
                             <p class="text-xs font-semibold uppercase tracking-wide text-indigo-600">Automation</p>
                             <p class="mt-1 text-sm text-gray-700">Fine-tune AI tags to keep categories consistent.</p>
@@ -107,7 +107,7 @@
                             <i class="fas fa-magic text-xl" aria-hidden="true"></i>
                         </span>
                     </a>
-                    <a href="budgets.html" class="group flex items-center justify-between rounded-2xl bg-white p-5 shadow-lg transition hover:-translate-y-1 hover:shadow-xl" aria-label="Review your budgets">
+                    <a href="budgets.html" class="group flex items-center justify-between cards cards-snug cards-rounded-xl" aria-label="Review your budgets">
                         <div>
                             <p class="text-xs font-semibold uppercase tracking-wide text-indigo-600">Budgets</p>
                             <p class="mt-1 text-sm text-gray-700">See which targets are thriving and where to adjust.</p>
@@ -116,7 +116,7 @@
                             <i class="fas fa-bullseye text-xl" aria-hidden="true"></i>
                         </span>
                     </a>
-                    <a href="search.html" class="group flex items-center justify-between rounded-2xl bg-white p-5 shadow-lg transition hover:-translate-y-1 hover:shadow-xl" aria-label="Search transactions">
+                    <a href="search.html" class="group flex items-center justify-between cards cards-snug cards-rounded-xl" aria-label="Search transactions">
                         <div>
                             <p class="text-xs font-semibold uppercase tracking-wide text-indigo-600">Investigation</p>
                             <p class="mt-1 text-sm text-gray-700">Drill into transactions with powerful filtering.</p>
@@ -130,22 +130,22 @@
             </section>
 
             <section class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8 opacity-0 transition-opacity duration-700" data-no-card="true">
-                <div class="bg-white/70 p-6 rounded shadow border border-white/40 backdrop-blur-xl ring-1 ring-white/50 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg">
+                <div class="cards cards-tight flex flex-col items-center text-center">
                     <i class="fas fa-chart-line fa-6x mb-2 text-indigo-600"></i>
                     <p class="text-gray-700">Visualise your spending trends with clear charts that highlight where your money goes.</p>
                 </div>
-                <div class="bg-white/70 p-6 rounded shadow border border-white/40 backdrop-blur-xl ring-1 ring-white/50 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg">
+                <div class="cards cards-tight flex flex-col items-center text-center">
                     <i class="fas fa-piggy-bank fa-6x mb-2 text-indigo-600"></i>
                     <p class="text-gray-700">Track savings effortlessly to see how your balance grows over time.</p>
                 </div>
-                <div class="bg-white/70 p-6 rounded shadow border border-white/40 backdrop-blur-xl ring-1 ring-white/50 flex flex-col items-center text-center transition transform hover:-translate-y-1 hover:shadow-lg">
+                <div class="cards cards-tight flex flex-col items-center text-center">
                     <i class="fas fa-wallet fa-6x mb-2 text-indigo-600"></i>
                     <p class="text-gray-700">Manage budgets with ease by setting targets and watching your progress.</p>
                 </div>
             </section>
 
 
-            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card="true">
+            <section class="mt-8 cards cards-roomy opacity-0 transition-opacity duration-700" data-no-card="true">
 
                 <h2 class="text-2xl font-semibold mb-4 text-indigo-700">What You Can Do</h2>
                 <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -221,7 +221,7 @@
             </section>
 
 
-            <section class="mt-8 bg-white p-8 rounded-lg shadow-lg opacity-0 transition-opacity duration-700" data-no-card="true">
+            <section class="mt-8 cards cards-roomy opacity-0 transition-opacity duration-700" data-no-card="true">
 
                 <h2 class="text-2xl font-semibold mb-4 text-indigo-700">How Data Is Organised</h2>
                 <svg role="img" aria-label="Segments link to categories and tags while groups stand alone" class="mx-auto mb-4" width="360" height="120">

--- a/frontend/js/category_drag.js
+++ b/frontend/js/category_drag.js
@@ -59,7 +59,7 @@
   function createCategoryCard(cat){
     const card = document.createElement('div');
 
-    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-full flex gap-4 items-start';
+    card.className = 'cards cards-tight w-full flex gap-4 items-start';
 
     card.dataset.categoryId = cat.id;
 
@@ -134,7 +134,7 @@
 
   function createUnassignedCard(tags){
     const card = document.createElement('div');
-    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-full';
+    card.className = 'cards cards-tight w-full';
     const title = document.createElement('h2');
     title.className = 'font-semibold mb-2';
     title.textContent = 'Unassigned Tags';

--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -55,7 +55,7 @@ const init = () => {
   overlay.className = 'fixed inset-0 bg-black bg-opacity-50 hidden flex items-center justify-center p-4';
 
   const box = document.createElement('div');
-  box.className = 'bg-white p-6 rounded shadow border border-gray-400 max-w-md text-center';
+  box.className = 'cards max-w-md text-center';
   const text = document.createElement('p');
   text.textContent = helpText;
   const close = document.createElement('button');

--- a/frontend/js/segment_drag.js
+++ b/frontend/js/segment_drag.js
@@ -52,7 +52,7 @@
 
   function createSegmentCard(seg){
     const card = document.createElement('div');
-    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-64 flex-shrink-0';
+    card.className = 'cards cards-tight w-64 flex-shrink-0';
     card.dataset.segmentId = seg.id;
 
     const header = document.createElement('div');
@@ -123,7 +123,7 @@
 
   function createUnassignedCard(categories){
     const card = document.createElement('div');
-    card.className = 'bg-white p-4 rounded shadow border border-gray-400 w-64 flex-shrink-0';
+    card.className = 'cards cards-tight w-64 flex-shrink-0';
     const title = document.createElement('h2');
     title.className = 'font-semibold mb-2';
     title.textContent = 'Unassigned Categories';

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -30,15 +30,15 @@
             </label>
 
             <div id="totals" class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Income</p>
                     <p id="income-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Outgoings</p>
                     <p id="outgoings-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Delta</p>
                     <p id="delta-total" class="text-3xl font-bold">£0.00</p>
                 </div>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -23,7 +23,7 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Statement</h1>
             <p class="mb-4">Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.</p>
-            <div class="bg-white p-6 rounded shadow border border-gray-400">
+            <div class="cards">
                 <form id="statement-form" class="flex flex-wrap items-end gap-4">
                     <div class="w-full sm:w-auto">
                         <label for="year" class="block text-sm font-medium text-gray-700 mb-1">Year</label>
@@ -41,44 +41,44 @@
                 </form>
             </div>
             <div id="totals" class="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                <div id="income-card" class="bg-white p-4 rounded shadow border border-gray-400 text-center cursor-pointer">
+                <div id="income-card" class="cards cards-tight text-center cursor-pointer">
                     <p class="text-gray-500">Income</p>
                     <p id="income-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div id="outgoings-card" class="bg-white p-4 rounded shadow border border-gray-400 text-center cursor-pointer">
+                <div id="outgoings-card" class="cards cards-tight text-center cursor-pointer">
                     <p class="text-gray-500">Outgoings</p>
                     <p id="outgoings-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Delta</p>
                     <p id="delta-total" class="text-3xl font-bold">£0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Savings Rate</p>
                     <p id="savings-rate" class="text-3xl font-bold">0%</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Largest Expense Category</p>
                     <p id="largest-category" class="text-3xl font-bold">N/A</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Recurring vs One-off</p>
                     <p id="recurring-ratio" class="text-lg font-bold">Recurring: £0.00 (0%)<br>One-off: £0.00 (0%)</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Average Transaction Size</p>
                     <p id="avg-transaction" class="text-lg font-bold">Income: £0.00<br>Expenses: £0.00</p>
                 </div>
-                <div class="bg-white p-4 rounded shadow border border-gray-400 text-center">
+                <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Days Until Negative Balance</p>
                     <p id="days-negative" class="text-3xl font-bold">N/A</p>
                 </div>
             </div>
-            <div class="bg-white p-6 rounded shadow border border-gray-400 mt-4">
+            <div class="cards mt-4">
                 <div id="transactions-grid"></div>
             </div>
             <div class="mt-4">
-                <div class="bg-white p-6 rounded shadow border border-gray-400">
+                <div class="cards">
 
                     <div id="category-donut" style="height:500px;" data-chart-desc="Donut chart of spending by category for the selected month."></div>
 

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -18,7 +18,7 @@
     <main class="flex-1 p-6">
       <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Palette Settings</h1>
 
-      <div class="bg-white p-6 rounded shadow border border-gray-400 space-y-4">
+      <div class="cards space-y-4">
         <ul class="list-disc pl-5 text-gray-700">
           <li>Set segment colours using the picker beside each name. Ticking <em>Lock</em> keeps your choice.</li>
           <li>To reset a segment, untick its <em>Lock</em> box and press <strong>Refresh</strong>.</li>

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -41,7 +41,7 @@
 
             </section>
 
-            <section id="detail-card" class="hidden bg-white p-6 rounded shadow border border-gray-400 space-y-4">
+            <section id="detail-card" class="hidden cards space-y-4">
 
                 <div class="flex justify-between items-center">
                     <h2 id="detail-title" class="text-xl font-semibold text-indigo-700"></h2>

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -21,7 +21,7 @@
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Add Project</h1>
         <p class="mb-4">Capture ideas for home projects and detail their costs and benefits.</p>
 
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
+        <section class="cards">
             <h2 class="text-xl font-semibold mb-4">Project Details</h2>
             <form id="project-form" class="grid md:grid-cols-2 gap-4">
                 <input type="hidden" id="project_id">

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -24,7 +24,7 @@
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Projects</h1>
         <p class="mb-4">Review your planned projects, explore costs and compare their priorities.</p>
 
-        <section class="bg-white p-6 rounded shadow border border-gray-400 space-y-6">
+        <section class="cards space-y-6">
             <div>
                 <h2 class="text-xl font-semibold mb-4">Budget Planning</h2>
                 <div class="flex items-end space-x-4">

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -21,7 +21,7 @@
     <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Archived Projects</h1>
         <p class="mb-4">Review projects that have been archived. Restore any project to make it active again.</p>
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
+        <section class="cards">
             <div id="archived-projects-table"></div>
         </section>
     </main>

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -22,7 +22,7 @@
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Project Board</h1>
         <p class="mb-4">Browse all active projects in a card layout.</p>
 
-        <section class="bg-white p-6 rounded shadow border border-gray-400">
+        <section class="cards">
             <div id="projects-board" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"></div>
         </section>
     </main>
@@ -80,7 +80,7 @@ async function loadProjects(){
     board.innerHTML = '';
     projects.forEach(p => {
         const card = document.createElement('div');
-        card.className = 'bg-white p-4 rounded shadow border border-gray-400 flex flex-col space-y-2';
+        card.className = 'cards cards-tight flex flex-col space-y-2';
 
         const header = document.createElement('div');
         header.className = 'flex justify-between items-start';

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -23,13 +23,13 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Reports</h1>
             <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>
-            <form id="report-form" class="bg-white p-4 rounded shadow border border-gray-400 grid grid-cols-1 md:grid-cols-3 gap-4">
+            <form id="report-form" class="cards cards-tight grid grid-cols-1 md:grid-cols-3 gap-4">
                 <label class="block md:col-span-3">Ask in plain English:
                     <input type="text" id="nl-query" class="border p-2 rounded w-full" placeholder="e.g., costs for cars in the last 12 months" data-help="Describe the report you want in plain English">
                 </label>
                 <div id="ai-status" class="md:col-span-3 text-sm text-gray-600 hidden" aria-live="polite"></div>
                 <div id="ai-debug" class="md:col-span-3 hidden">
-                    <div class="bg-white p-4 rounded shadow border border-gray-400">
+                    <div class="cards cards-tight space-y-3">
                         <h3 class="font-semibold text-gray-700 mb-2">AI Debug</h3>
                         <p class="text-sm font-semibold">Prompt</p>
                         <pre id="ai-debug-request" class="text-xs bg-gray-100 p-2 mb-2 overflow-x-auto"></pre>
@@ -56,8 +56,8 @@
                 <button type="button" id="delete-report" class="bg-red-600 text-white px-3 py-2 rounded" aria-label="Delete saved report"><i class="fas fa-trash inline w-4 h-4"></i></button>
             </div>
             <div id="results-grid" class="mt-4"></div>
-            <div id="chart" class="mt-6 bg-white p-6 rounded shadow border border-gray-400" style="height:400px;" data-chart-desc="Column chart of transaction amounts grouped by your criteria."></div>
-            <div id="category-chart" class="mt-6 bg-white p-6 rounded shadow border border-gray-400" style="height:400px;" data-chart-desc="Pie chart of transaction totals by category."></div>
+            <div id="chart" class="mt-6 cards" style="height:400px;" data-chart-desc="Column chart of transaction amounts grouped by your criteria."></div>
+            <div id="category-chart" class="mt-6 cards" style="height:400px;" data-chart-desc="Pie chart of transaction totals by category."></div>
         </main>
     </div>
     <script src="js/menu.js"></script>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -28,7 +28,7 @@
                 <label class="block">Description<br><textarea id="tag-description" class="border p-2 rounded w-full" data-help="Description for the tag"></textarea></label>
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Tag</button>
             </form>
-            <div class="mt-6 bg-white p-4 rounded shadow border border-gray-400">
+            <div class="mt-6 cards cards-tight">
                 <h2 class="text-xl font-semibold mb-2">Existing Tags</h2>
                 <div id="tag-table"></div>
             </div>

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -49,7 +49,7 @@
             }
 
             const card = document.createElement('div');
-            card.className = 'relative bg-white p-6 rounded shadow';
+            card.className = 'cards';
 
             function createBadge(text, colorClasses) {
                 const span = document.createElement('span');


### PR DESCRIPTION
## Summary
- restyle the shared cards component with a richer glassmorphism treatment and helper utilities for padding and radius tweaks
- swap legacy Tailwind card utility stacks for the new `cards` styles across dashboards, AI tooling, projects, reports, and supporting modals
- ensure dynamic cards created in JavaScript also adopt the shared glass look for consistent presentation

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca92ce266c832e91bb359c71572e29