### PR TITLE
Display real landing metrics

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,19 +52,19 @@
                             </div>
                             <dl class="grid grid-cols-1 gap-4 pt-6 text-left sm:grid-cols-3">
                                 <div class="rounded-2xl bg-white/10 p-4 shadow-lg">
-                                    <dt class="text-xs font-semibold uppercase tracking-wide text-indigo-100">Managed balance</dt>
-                                    <dd class="mt-1 text-3xl font-semibold">£1.8m</dd>
-                                    <dd class="mt-1 text-sm text-indigo-100 opacity-80">Across linked accounts</dd>
+                                    <dt class="text-xs font-semibold uppercase tracking-wide text-indigo-100">Accounts tracked</dt>
+                                    <dd id="landing-stat-accounts" class="mt-1 text-3xl font-semibold" aria-live="polite">0</dd>
+                                    <dd class="mt-1 text-sm text-indigo-100 opacity-80">Connected to your workspace</dd>
                                 </div>
                                 <div class="rounded-2xl bg-white/10 p-4 shadow-lg">
-                                    <dt class="text-xs font-semibold uppercase tracking-wide text-indigo-100">Transactions tracked</dt>
-                                    <dd class="mt-1 text-3xl font-semibold">120k+</dd>
-                                    <dd class="mt-1 text-sm text-indigo-100 opacity-80">Auto-tagged with AI</dd>
+                                    <dt class="text-xs font-semibold uppercase tracking-wide text-indigo-100">Transactions recorded</dt>
+                                    <dd id="landing-stat-transactions" class="mt-1 text-3xl font-semibold" aria-live="polite">0</dd>
+                                    <dd class="mt-1 text-sm text-indigo-100 opacity-80">Updated as you import</dd>
                                 </div>
                                 <div class="rounded-2xl bg-white/10 p-4 shadow-lg">
-                                    <dt class="text-xs font-semibold uppercase tracking-wide text-indigo-100">Budgets on target</dt>
-                                    <dd class="mt-1 text-3xl font-semibold">92%</dd>
-                                    <dd class="mt-1 text-sm text-indigo-100 opacity-80">Refreshed every week</dd>
+                                    <dt class="text-xs font-semibold uppercase tracking-wide text-indigo-100">Tags available</dt>
+                                    <dd id="landing-stat-tags" class="mt-1 text-3xl font-semibold" aria-live="polite">0</dd>
+                                    <dd class="mt-1 text-sm text-indigo-100 opacity-80">Helping categorise spend</dd>
                                 </div>
                             </dl>
                         </div>
@@ -256,6 +256,7 @@
     <script src="js/scroll_animations.js"></script>
 
     <script src="js/carousel.js"></script>
+    <script src="js/landing_stats.js"></script>
 
   </body>
 </html>

--- a/frontend/js/landing_stats.js
+++ b/frontend/js/landing_stats.js
@@ -1,0 +1,53 @@
+// Loads live system counts for the landing page hero cards.
+document.addEventListener('DOMContentLoaded', () => {
+  const elements = {
+    accounts: document.getElementById('landing-stat-accounts'),
+    transactions: document.getElementById('landing-stat-transactions'),
+    tags: document.getElementById('landing-stat-tags'),
+  };
+
+  if (!elements.accounts && !elements.transactions && !elements.tags) {
+    return;
+  }
+
+  const formatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
+  const setFallback = () => {
+    Object.values(elements).forEach((el) => {
+      if (el) {
+        el.textContent = '—';
+      }
+    });
+  };
+
+  const fetchMetrics = typeof fetchNoCache === 'function' ? fetchNoCache : window.fetch.bind(window);
+
+  fetchMetrics('../php_backend/public/landing_metrics.php')
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response.json();
+    })
+    .then((data) => {
+      if (elements.accounts) {
+        elements.accounts.textContent = typeof data.accounts === 'number'
+          ? formatter.format(data.accounts)
+          : '—';
+      }
+      if (elements.transactions) {
+        elements.transactions.textContent = typeof data.transactions === 'number'
+          ? formatter.format(data.transactions)
+          : '—';
+      }
+      if (elements.tags) {
+        elements.tags.textContent = typeof data.tags === 'number'
+          ? formatter.format(data.tags)
+          : '—';
+      }
+    })
+    .catch((error) => {
+      console.error('Failed to load landing metrics', error);
+      setFallback();
+    });
+});

--- a/php_backend/models/Stats.php
+++ b/php_backend/models/Stats.php
@@ -1,0 +1,32 @@
+<?php
+// Aggregates simple system-wide metrics for dashboards and landing pages.
+require_once __DIR__ . '/../Database.php';
+
+class Stats {
+    /**
+     * Fetch overall counts used by the landing page hero metrics.
+     */
+    public static function getLandingMetrics(): array {
+        $db = Database::getConnection();
+
+        $counts = [
+            'accounts' => 0,
+            'transactions' => 0,
+            'tags' => 0,
+        ];
+
+        $queries = [
+            'accounts' => 'SELECT COUNT(*) FROM `accounts`',
+            'transactions' => 'SELECT COUNT(*) FROM `transactions`',
+            'tags' => 'SELECT COUNT(*) FROM `tags`',
+        ];
+
+        foreach ($queries as $key => $sql) {
+            $stmt = $db->query($sql);
+            $value = $stmt->fetchColumn();
+            $counts[$key] = $value === false ? 0 : (int)$value;
+        }
+
+        return $counts;
+    }
+}

--- a/php_backend/public/landing_metrics.php
+++ b/php_backend/public/landing_metrics.php
@@ -1,0 +1,14 @@
+<?php
+// Provides summary counts for the landing page hero stats.
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
+require_once __DIR__ . '/../models/Stats.php';
+
+header('Content-Type: application/json');
+
+try {
+    echo json_encode(Stats::getLandingMetrics());
+} catch (Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['error' => $e->getMessage()]);
+}


### PR DESCRIPTION
## Summary
- replace the landing page hero metrics with live account, transaction, and tag counts
- add a frontend helper that fetches landing metrics and formats them for display
- expose a backend endpoint and Stats model to aggregate the counts for the hero card

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca9794d388832e80fe04c0fa907e2e