### PR TITLE
Add more heading font choices

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -61,6 +61,14 @@ $fontOptions = ['' => 'Default',
     'Dancing Script' => 'Dancing Script',
     'Fredoka' => 'Fredoka',
     'Pacifico' => 'Pacifico',
+    'Playfair Display' => 'Playfair Display',
+    'Merriweather' => 'Merriweather',
+    'Oswald' => 'Oswald',
+    'Raleway' => 'Raleway',
+    'Nunito' => 'Nunito',
+    'Quicksand' => 'Quicksand',
+    'Fjalla One' => 'Fjalla One',
+    'Source Serif Pro' => 'Source Serif Pro',
 ];
 $weightOptions = ['' => 'Default', '100' => 'Thin', '300' => 'Light', '700' => 'Bold'];
 $colorOptions = ['indigo', 'blue', 'green', 'red', 'purple', 'teal', 'orange'];


### PR DESCRIPTION
## Summary
- expand the settings font list with additional heading-friendly Google Fonts

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca9ddbca48832eaac38d62286d7996