### PR TITLE
Soften data visuals with translucent styling

### DIFF
--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -49,3 +49,119 @@
 .cards-rounded-full {
   --card-radius: 9999px;
 }
+
+/* Glassmorphism surfaces for data visualisations */
+.glass-surface {
+  background-color: rgba(255, 255, 255, 0.14);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 0.75rem;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.25),
+    0 18px 30px -15px rgba(15, 23, 42, 0.4);
+}
+
+.glass-input {
+  background-color: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 0.75rem;
+  color: #0f172a;
+  padding: 0.625rem 0.875rem;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.25),
+    0 12px 25px -20px rgba(15, 23, 42, 0.6);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.glass-input::placeholder {
+  color: rgba(51, 65, 85, 0.65);
+}
+
+.glass-input:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.55);
+  box-shadow:
+    0 0 0 2px rgba(99, 102, 241, 0.2),
+    0 20px 45px -18px rgba(79, 70, 229, 0.45);
+  background-color: rgba(255, 255, 255, 0.22);
+}
+
+.glass-table {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.glass-table .tabulator-header,
+.glass-table .tabulator-tableholder,
+.glass-table .tabulator-footer,
+.glass-table .tabulator-paginator {
+  background-color: transparent;
+}
+
+.glass-table .tabulator-header {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.glass-table .tabulator-footer,
+.glass-table .tabulator-paginator {
+  border-top: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.glass-table-row {
+  background-color: rgba(255, 255, 255, 0.18) !important;
+  transition: background-color 0.2s ease;
+}
+
+.glass-table-row:hover {
+  background-color: rgba(255, 255, 255, 0.26) !important;
+}
+
+.glass-table-row .tabulator-cell {
+  background-color: transparent !important;
+  color: #0f172a;
+}
+
+.glass-table-row .tabulator-cell:first-child {
+  border-left: none !important;
+}
+
+.glass-table-row .tabulator-cell:last-child {
+  border-right: none !important;
+}
+
+.glass-table-row .tabulator-cell {
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18) !important;
+}
+
+.glass-table .tabulator-tableholder .tabulator-table {
+  background-color: transparent;
+}
+
+.glass-table .tabulator-calcs-row {
+  background-color: rgba(255, 255, 255, 0.2) !important;
+}
+
+.glass-table .tabulator-calcs-row .tabulator-cell {
+  background-color: transparent !important;
+  color: #0f172a;
+}
+
+.highcharts-container.glass-chart {
+  background-color: rgba(255, 255, 255, 0.14) !important;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 0.75rem;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.25),
+    0 18px 30px -15px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  padding: 0.75rem;
+}
+
+.highcharts-container.glass-chart svg {
+  border-radius: 0.75rem;
+}

--- a/frontend/js/color_map.js
+++ b/frontend/js/color_map.js
@@ -54,17 +54,38 @@ try {
 }
 
 function getChartTheme() {
-    const text = '#000000';
+    const text = '#0f172a';
     const styles = getComputedStyle(document.documentElement);
     const chartFont = styles.getPropertyValue('--chart-font').trim() || 'Inter, sans-serif';
+    const background = 'rgba(255, 255, 255, 0.14)';
+    const plotBackground = 'rgba(255, 255, 255, 0.05)';
+    const borderColor = 'rgba(255, 255, 255, 0.35)';
     return {
         colors: chartColors,
-        chart: { style: { fontFamily: chartFont, color: text }, backgroundColor: '#ffffff' },
+        chart: {
+            style: { fontFamily: chartFont, color: text },
+            backgroundColor: background,
+            plotBackgroundColor: plotBackground,
+            borderColor,
+            borderRadius: 12,
+            borderWidth: 1,
+            className: 'glass-chart'
+        },
         credits: { enabled: false },
-        legend: { enabled: true, itemStyle: { fontSize: '10px', color: text, fontFamily: chartFont } },
+        legend: {
+            enabled: true,
+            backgroundColor: 'rgba(255, 255, 255, 0.08)',
+            borderRadius: 12,
+            itemStyle: { fontSize: '10px', color: text, fontFamily: chartFont }
+        },
         title: { style: { color: text, fontFamily: chartFont } },
         xAxis: { labels: { style: { color: text, fontFamily: chartFont } }, title: { style: { color: text, fontFamily: chartFont } } },
         yAxis: { labels: { style: { color: text, fontFamily: chartFont } }, title: { style: { color: text, fontFamily: chartFont } } },
+        tooltip: {
+            backgroundColor: 'rgba(15, 23, 42, 0.92)',
+            borderColor: 'rgba(148, 163, 184, 0.4)',
+            style: { color: '#F8FAFC', fontFamily: chartFont }
+        },
         plotOptions: {
             series: { showInLegend: true },
             pie: { showInLegend: true },
@@ -78,15 +99,30 @@ function applyChartTheme() {
     Highcharts.setOptions(opts);
     const update = {
         colors: opts.colors,
-        chart: { backgroundColor: opts.chart.backgroundColor },
-        legend: { itemStyle: opts.legend.itemStyle },
+        chart: {
+            backgroundColor: opts.chart.backgroundColor,
+            plotBackgroundColor: opts.chart.plotBackgroundColor,
+            className: opts.chart.className,
+            borderColor: opts.chart.borderColor,
+            borderRadius: opts.chart.borderRadius,
+            borderWidth: opts.chart.borderWidth
+        },
+        legend: {
+            itemStyle: opts.legend.itemStyle,
+            backgroundColor: opts.legend.backgroundColor,
+            borderRadius: opts.legend.borderRadius
+        },
         title: opts.title,
         xAxis: { labels: opts.xAxis.labels, title: opts.xAxis.title },
-        yAxis: { labels: opts.yAxis.labels, title: opts.yAxis.title }
+        yAxis: { labels: opts.yAxis.labels, title: opts.yAxis.title },
+        tooltip: opts.tooltip
     };
     Highcharts.charts.forEach(c => {
         if (c) {
             c.update(update, false);
+            if (opts.chart.className && c.container) {
+                c.container.classList.add(opts.chart.className);
+            }
             c.redraw();
         }
     });

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -38,10 +38,11 @@ function badgeFormatter(colorClasses) {
 function styleCalcRows(table) {
     const rows = table.element.querySelectorAll('.tabulator-calcs-row');
     rows.forEach(row => {
-        row.classList.add('bg-white');
+        row.classList.remove('bg-white');
+        row.classList.add('glass-table-row');
         row.style.backgroundColor = '';
         row.querySelectorAll('.tabulator-cell').forEach(cell => {
-            cell.classList.add('bg-white');
+            cell.classList.remove('bg-white');
             cell.style.backgroundColor = '';
         });
     });
@@ -70,7 +71,8 @@ function tailwindTabulator(element, options) {
     options.rowFormatter = function(row) {
         if (userRowFormatter) userRowFormatter(row);
         const rowEl = row.getElement();
-        rowEl.classList.add('bg-white', 'hover:bg-white', 'border-b', 'border-gray-200', 'border-b-[0.5px]');
+        rowEl.classList.remove('bg-white', 'hover:bg-white');
+        rowEl.classList.add('glass-table-row');
         rowEl.classList.remove('tabulator-row-even', 'tabulator-row-odd');
         rowEl.style.borderTop = '0';
         rowEl.querySelectorAll('.tabulator-cell').forEach(cell => {
@@ -117,7 +119,7 @@ function tailwindTabulator(element, options) {
         const searchInput = document.createElement('input');
         searchInput.type = 'text';
         searchInput.placeholder = 'Search';
-        searchInput.className = 'tabulator-search mb-2 p-2 border-0 rounded w-full accent';
+        searchInput.className = 'tabulator-search glass-input mb-2 w-full';
         searchInput.style.colorScheme = 'light';
         tableEl.parentNode.insertBefore(searchInput, tableEl);
         searchInput.addEventListener('input', function() {
@@ -140,10 +142,11 @@ function tailwindTabulator(element, options) {
     table.on('dataProcessed', function() {
         styleCalcRows(table);
     });
-    el.classList.add('border-0', 'rounded-lg', 'overflow-hidden', 'bg-white', 'shadow-sm');
+    el.classList.add('border-0', 'rounded-xl', 'overflow-hidden', 'glass-table', 'glass-surface');
     const header = el.querySelector('.tabulator-header');
     if (header) {
-        header.classList.add('bg-white', 'border-b', 'border-gray-200', 'border-b-[0.5px]', 'rounded-t-lg');
+        header.classList.remove('bg-white');
+        header.classList.add('rounded-t-lg');
         header.style.backgroundColor = '';
         header.querySelectorAll('.tabulator-col').forEach(col => {
             col.style.borderRight = '0';
@@ -154,7 +157,8 @@ function tailwindTabulator(element, options) {
     if (tableHolder) tableHolder.classList.add('rounded-b-lg');
     const paginator = el.querySelector('.tabulator-paginator');
     if (paginator) {
-        paginator.classList.add('bg-white', 'border-t', 'border-gray-200', 'border-t-[0.5px]', 'p-2', 'rounded-b-lg');
+        paginator.classList.remove('bg-white');
+        paginator.classList.add('p-2', 'rounded-b-lg');
         paginator.style.backgroundColor = '';
     }
     return table;


### PR DESCRIPTION
## Summary
- introduce reusable glass-surface styles for data-heavy widgets, including tables, search inputs and chart containers
- update the Tabulator helper to apply the new translucent styling and remove hard-coded white backgrounds
- refresh the Highcharts theme so charts pick up the same frosted-glass appearance and tooltip palette

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca9c2b9d7c832ebfeeb474d95e4d95