### PR TITLE
Soften glassmorphism card styling

### DIFF
--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -6,12 +6,12 @@
   padding: var(--card-padding);
   border-radius: var(--card-radius);
   background-color: rgba(255, 255, 255, 0.15); /* Tailwind bg-white/15 */
-  backdrop-filter: blur(8px); /* Tailwind backdrop-blur */
-  -webkit-backdrop-filter: blur(8px);
+  backdrop-filter: blur(4px); /* Softer backdrop blur */
+  -webkit-backdrop-filter: blur(4px);
   box-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.4), /* Tailwind ring-1 ring-white/40 */
-    0 10px 15px -3px rgba(15, 23, 42, 0.1),
-    0 4px 6px -4px rgba(15, 23, 42, 0.1); /* Tailwind shadow-lg */
+    0 0 0 1px rgba(255, 255, 255, 0.3), /* Tailwind ring-1 ring-white/30 */
+    0 6px 12px -5px rgba(15, 23, 42, 0.12),
+    0 2px 4px -2px rgba(15, 23, 42, 0.08); /* Softer ambient shadow */
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 
 }
@@ -20,9 +20,9 @@
   transform: translateY(-2px);
   box-shadow:
 
-    0 0 0 1px rgba(255, 255, 255, 0.45),
-    0 20px 25px -5px rgba(15, 23, 42, 0.15),
-    0 10px 10px -5px rgba(15, 23, 42, 0.1); /* Tailwind shadow-xl */
+    0 0 0 1px rgba(255, 255, 255, 0.35),
+    0 12px 20px -6px rgba(15, 23, 42, 0.14),
+    0 6px 10px -5px rgba(15, 23, 42, 0.1); /* Subtle hover lift */
 
 }
 


### PR DESCRIPTION
## Summary
- reduce the backdrop blur on shared card styling for a clearer background
- lighten the default and hover shadows to create a subtler elevation effect

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68ca9eb96a14832e8f2e37c691772532