### PR TITLE
Align glass cards with Tailwind spec

### DIFF
--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -2,27 +2,26 @@
 /* Shared glassmorphism card styles matched to Tailwind utilities */
 .cards {
   --card-padding: 1.5rem;
-  --card-radius: 1rem;
+  --card-radius: 1.5rem;
   padding: var(--card-padding);
   border-radius: var(--card-radius);
   background-color: rgba(255, 255, 255, 0.15); /* Tailwind bg-white/15 */
-  backdrop-filter: blur(4px); /* Softer backdrop blur */
-  -webkit-backdrop-filter: blur(4px);
+  backdrop-filter: blur(8px); /* Tailwind backdrop-blur */
+  -webkit-backdrop-filter: blur(8px);
   box-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.3), /* Tailwind ring-1 ring-white/30 */
-    0 6px 12px -5px rgba(15, 23, 42, 0.12),
-    0 2px 4px -2px rgba(15, 23, 42, 0.08); /* Softer ambient shadow */
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+    0 0 0 1px rgba(255, 255, 255, 0.4), /* Tailwind ring-1 ring-white/40 */
+    0 10px 15px -3px rgba(15, 23, 42, 0.1),
+    0 4px 6px -4px rgba(15, 23, 42, 0.1); /* Tailwind shadow-lg */
+  transition: box-shadow 0.2s ease;
 
 }
 
 .cards:hover {
-  transform: translateY(-2px);
   box-shadow:
 
-    0 0 0 1px rgba(255, 255, 255, 0.35),
-    0 12px 20px -6px rgba(15, 23, 42, 0.14),
-    0 6px 10px -5px rgba(15, 23, 42, 0.1); /* Subtle hover lift */
+    0 0 0 1px rgba(255, 255, 255, 0.45),
+    0 12px 24px -6px rgba(15, 23, 42, 0.14),
+    0 6px 10px -4px rgba(15, 23, 42, 0.12); /* Slightly deeper hover shadow */
 
 }
 
@@ -43,7 +42,7 @@
 }
 
 .cards-rounded-xl {
-  --card-radius: 1.5rem;
+  --card-radius: 1.75rem;
 }
 
 .cards-rounded-full {


### PR DESCRIPTION
## Summary
- sync the shared glass card styling with the Tailwind-derived spec for radius, blur, and ring opacity
- adjust resting and hover drop shadows to match the spec's shadow-lg recipe

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68caabc76240832ea690ef77bec2f543