### PR TITLE
Remove table drop shadow when nested in cards

### DIFF
--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -164,3 +164,17 @@
 .highcharts-container.glass-chart svg {
   border-radius: 0.75rem;
 }
+
+/*
+  Tables rendered inside cards already inherit the card's elevation. Remove
+  the additional drop shadow and soften the border highlight so stacked
+  surfaces don't show a bright white line at the top of the table.
+*/
+.cards .tabulator.glass-surface {
+  box-shadow: none;
+  border-color: rgba(148, 163, 184, 0.35);
+}
+
+.cards .tabulator.glass-surface:hover {
+  box-shadow: none;
+}


### PR DESCRIPTION
## Summary
- remove the additional drop shadow from Tabulator tables when they are already displayed inside a card
- soften the table border colour so the top edge no longer appears white

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68cab60a4684832eb98c73a7bc4895c7