### PR TITLE
Remove forced white background from styled inputs

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -70,7 +70,7 @@ window.fetchNoCache = fetchNoCache;
   const styleInputs = (root = document) => {
     root.querySelectorAll('input:not([type="checkbox"]):not([type="radio"]):not(.unstyled), select:not(.unstyled), textarea:not(.unstyled)').forEach(el => {
       if (!el.classList.contains('styled-input')) {
-        el.classList.add('styled-input', 'p-2', 'border', 'rounded', 'bg-white', 'border-gray-400');
+        el.classList.add('styled-input', 'p-2', 'border', 'rounded', 'border-gray-400');
       }
     });
   };


### PR DESCRIPTION
## Summary
- stop adding the `bg-white` class when styling shared inputs so embedded widgets keep their own backgrounds

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68cabb7fbf64832ea134db8d7471ce8d