### PR TITLE
Prevent Tabulator search recursion

### DIFF
--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -122,9 +122,16 @@ function tailwindTabulator(element, options) {
         searchInput.className = 'tabulator-search glass-input mb-2 w-full';
         searchInput.style.colorScheme = 'light';
         tableEl.parentNode.insertBefore(searchInput, tableEl);
+        let searchInProgress = false;
         searchInput.addEventListener('input', function() {
             if (typeof table.search === 'function') {
-                table.search(this.value, searchFields);
+                if (searchInProgress) return;
+                searchInProgress = true;
+                try {
+                    table.search(this.value, searchFields);
+                } finally {
+                    searchInProgress = false;
+                }
             } else {
                 const query = this.value.toLowerCase();
                 table.setFilter(function(data) {


### PR DESCRIPTION
## Summary
- guard the custom search input handler against re-entrant calls when Tabulator's built-in search API fires input events
- maintain existing fallback filter logic for environments without the Tabulator search module to keep search behaviour consistent

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68cac16490ec832ea0cc14cbaa31037e