### PR TITLE
Remove redundant shadow utility from menu nav

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,7 +25,7 @@
 </head>
 <body class="bg-gradient-to-b from-indigo-200 via-slate-100 to-white">
     <div class="flex flex-col md:flex-row min-h-screen">
-        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto shadow"></nav>
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <section class="mb-8" data-no-card="true">
                 <div class="relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-950 via-indigo-700 to-sky-600 text-white shadow-2xl">


### PR DESCRIPTION
## Summary
- remove the redundant `shadow` utility from the sidebar navigation so it uses the `shadow-2xl` applied by JavaScript

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cac6a31e58832e8657746324ec7210