### PR TITLE
Remove unused rounded card variants

### DIFF
--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -37,16 +37,8 @@
   --card-padding: 2rem;
 }
 
-.cards-rounded-lg {
-  --card-radius: 0.75rem;
-}
-
 .cards-rounded-xl {
   --card-radius: 1.75rem;
-}
-
-.cards-rounded-full {
-  --card-radius: 9999px;
 }
 
 /* Glassmorphism surfaces for data visualisations */


### PR DESCRIPTION
## Summary
- delete the unused medium and full rounded card utility classes from cards.css
- confirm only the extra-large rounded card variant is referenced in templates

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68cac6a5f6e4832ea17a43f79bfcbaf4