### PR TITLE
Improve Tabulator row styling performance

### DIFF
--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -105,6 +105,7 @@
 .glass-table-row {
   background-color: rgba(255, 255, 255, 0.18) !important;
   transition: background-color 0.2s ease;
+  border-top: none !important;
 }
 
 .glass-table-row:hover {
@@ -114,18 +115,10 @@
 .glass-table-row .tabulator-cell {
   background-color: transparent !important;
   color: #0f172a;
-}
-
-.glass-table-row .tabulator-cell:first-child {
-  border-left: none !important;
-}
-
-.glass-table-row .tabulator-cell:last-child {
-  border-right: none !important;
-}
-
-.glass-table-row .tabulator-cell {
+  border-top: none !important;
   border-bottom: 0.5px solid rgba(148, 163, 184, 0.18) !important;
+  border-left: none !important;
+  border-right: none !important;
 }
 
 .tabulator.glass-surface {

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -68,19 +68,14 @@ function tailwindTabulator(element, options) {
     }
 
     const userRowFormatter = options.rowFormatter;
+    // Styling is handled with CSS classes to avoid expensive per-cell DOM
+    // updates when large data sets are rendered.
     options.rowFormatter = function(row) {
         if (userRowFormatter) userRowFormatter(row);
         const rowEl = row.getElement();
         rowEl.classList.remove('bg-white', 'hover:bg-white');
         rowEl.classList.add('glass-table-row');
         rowEl.classList.remove('tabulator-row-even', 'tabulator-row-odd');
-        rowEl.style.borderTop = '0';
-        rowEl.querySelectorAll('.tabulator-cell').forEach(cell => {
-            cell.style.borderRight = '0';
-            cell.style.borderLeft = '0';
-            cell.style.borderTop = '0';
-            cell.style.borderBottom = '0';
-        });
     };
     if (options.pagination === undefined) {
         options.pagination = 'local';


### PR DESCRIPTION
## Summary
- remove per-cell DOM mutations from the Tabulator row formatter so large tables render faster
- move the remaining border styling into CSS to keep the visual treatment while avoiding inline updates

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68cad0441fac832e8826c71f5efd1744