### PR TITLE
Make chart backgrounds fully transparent

### DIFF
--- a/frontend/js/color_map.js
+++ b/frontend/js/color_map.js
@@ -57,8 +57,8 @@ function getChartTheme() {
     const text = '#0f172a';
     const styles = getComputedStyle(document.documentElement);
     const chartFont = styles.getPropertyValue('--chart-font').trim() || 'Inter, sans-serif';
-    const background = 'rgba(255, 255, 255, 0.14)';
-    const plotBackground = 'rgba(255, 255, 255, 0.05)';
+    const background = 'rgba(255, 255, 255, 0)';
+    const plotBackground = 'rgba(255, 255, 255, 0)';
     const borderColor = 'rgba(255, 255, 255, 0.35)';
     return {
         colors: chartColors,


### PR DESCRIPTION
## Summary
- set the shared Highcharts theme to use fully transparent chart and plot backgrounds

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68d287da4d6c832eae0f2576bb7a0ac2