### PR TITLE
Make project bubble chart background transparent

### DIFF
--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -126,7 +126,14 @@ function drawBubble(){
     }));
 
     Highcharts.chart('project-bubble-chart', {
-        chart: { type: 'bubble', plotBorderWidth: 1, zoomType: 'xy', height: 600 },
+        chart: {
+            type: 'bubble',
+            plotBorderWidth: 1,
+            zoomType: 'xy',
+            height: 600,
+            backgroundColor: 'rgba(255,255,255,0)',
+            plotBackgroundColor: 'rgba(255,255,255,0)'
+        },
         title: { text: `${xOpt.label} vs ${yOpt.label}` },
         xAxis: {
             title: { text: xOpt.label },


### PR DESCRIPTION
## Summary
- set the projects bubble chart background and plot area to transparent so the gradient page background shows through

## Testing
- php tests/run_tests.php

------
https://chatgpt.com/codex/tasks/task_e_68d2991cecd0832ebff9b1ffabf08b94