### PR TITLE
Harden manual transfer linking validation and error reporting

### DIFF
--- a/php_backend/public/link_transfer.php
+++ b/php_backend/public/link_transfer.php
@@ -27,7 +27,7 @@ try {
         echo json_encode(['status' => 'ok']);
     } else {
         http_response_code(400);
-        echo json_encode(['error' => 'Unable to link transactions']);
+        echo json_encode(['error' => 'Unable to link transactions. Ensure they are in different accounts, have opposite amounts, and are not linked to another transfer.']);
     }
 } catch (Exception $e) {
     http_response_code(500);


### PR DESCRIPTION
### Motivation

- Prevent invalid or unsafe transfer links by ensuring manual linking only succeeds for true inter-account opposite amounts and does not accidentally relink existing transfers.
- Make failure modes explicit at API entry points so callers receive actionable feedback when linking is rejected.

### Description

- Updated `Transaction::linkTransfer(int $id1, int $id2)` to select `account_id`, `amount`, and `transfer_id` for both rows and validate that exactly two rows are present, the `account_id`s differ, and the amounts are exact opposites, returning `false` on any failure.
- Added checks to reject linking when either transaction is already linked to a different transfer while keeping deterministic `transfer_id` assignment using `min($id1, $id2)`.
- Improved API responses by updating `php_backend/public/link_transfer.php` to return a clearer 400 error message when linking is rejected and changing `php_backend/public/mark_transfer.php` to count and report `rejected` pairs and return 400 if any pair fails to link.
- Added/adjusted tests in `tests/run_tests.php` to assert that same-account pairs cannot be linked, valid inter-account pairs can, and attempts to relink an already-linked transaction to a different transfer are rejected while preserving the original deterministic link.

### Testing

- Ran syntax checks with `php -l` on `php_backend/models/Transaction.php`, `php_backend/public/link_transfer.php`, `php_backend/public/mark_transfer.php`, and `tests/run_tests.php` with no syntax errors detected.
- Executed the full test suite with `php tests/run_tests.php`, and all tests (including the new manual-link edge cases) passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870f288110832e840ae30c824199f1)