### PR TITLE
Standardize operational UI patterns on budget and dashboard pages

### DIFF
--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -14,30 +14,47 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+    <link rel="stylesheet" href="operational_ui.css">
     <!-- Font Awesome icons loaded via menu.js -->
 
 </head>
 <body class="bg-gradient-to-b from-indigo-200 via-slate-100 to-white">
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
-    <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
+    <main class="ops-main flex-1 min-w-0 overflow-x-auto">
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Budgets</h1>
         <p class="mb-4">Set monthly spending limits for categories and monitor progress. Use this page to plan ahead and see where you may need to adjust your spending.</p>
-        <section>
-            <form id="budget-form" class="md:flex md:space-x-4 space-y-4 md:space-y-0">
-                <label class="block">Month<br><input type="month" id="month" class="border p-2 rounded" data-help="Month for the budget"></label>
-                <label class="block">Category<br><select id="category" class="border p-2 rounded" data-help="Category to assign the budget"></select></label>
-                <label class="block">Amount (£)<br><input type="number" step="0.01" id="amount" class="border p-2 rounded" data-help="Budget amount in pounds"></label>
-                <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end">Set Budget</button>
+        <section class="ops-section">
+            <form id="budget-form" class="ops-form-grid cols-4">
+                <label class="ops-field" for="month">
+                    <span class="ops-label">Month</span>
+                    <input type="month" id="month" class="ops-input" data-help="Month for the budget">
+                    <span class="ops-help">The budget period that new values apply to.</span>
+                </label>
+                <label class="ops-field" for="category">
+                    <span class="ops-label">Category</span>
+                    <select id="category" class="ops-select" data-help="Category to assign the budget"></select>
+                    <span class="ops-help">Choose the spending category to constrain.</span>
+                </label>
+                <label class="ops-field" for="amount">
+                    <span class="ops-label">Amount (£)</span>
+                    <input type="number" step="0.01" id="amount" class="ops-input" data-help="Budget amount in pounds">
+                    <span class="ops-help">Set the monthly budget amount in pounds.</span>
+                </label>
+                <button type="submit" class="ops-btn-primary" aria-label="Set budget">Set Budget</button>
             </form>
         </section>
-        <section class="cards space-y-4">
-            <h2 class="text-xl font-semibold">AI Budgeting</h2>
+        <section class="ops-section cards space-y-4">
+            <h2 class="ops-heading">AI Budgeting</h2>
 
             <p>Send your savings goal and the last 12 months of category totals to the AI to propose next month's budgets and provide a brief explanation.</p>
-            <form id="ai-form" class="md:flex md:space-x-4 space-y-4 md:space-y-0">
-                <label class="block">Savings Goal (£)<br><input type="number" step="0.01" id="goal" class="border p-2 rounded" data-help="Monthly amount you want to save. The AI uses this plus a year of history to set budgets."></label>
-                <button id="ai-run" type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded self-end"><i class="fas fa-robot inline w-4 h-4 mr-1"></i>Generate Budgets</button>
+            <form id="ai-form" class="ops-form-grid cols-3">
+                <label class="ops-field" for="goal">
+                    <span class="ops-label">Savings Goal (£)</span>
+                    <input type="number" step="0.01" id="goal" class="ops-input" data-help="Monthly amount you want to save. The AI uses this plus a year of history to set budgets.">
+                    <span class="ops-help">Target amount you want left over after monthly spending.</span>
+                </label>
+                <button id="ai-run" type="submit" class="ops-btn-primary" aria-label="Generate budgets with AI"><i class="fas fa-robot inline w-4 h-4"></i>Generate Budgets</button>
             </form>
             <div id="ai-result" class="mt-4"></div>
             <div id="ai-debug" class="hidden">
@@ -51,13 +68,17 @@
             </div>
 
         </section>
-        <section>
-            <h2 class="text-xl font-semibold mb-4">Current Budgets</h2>
-            <div id="budget-table"></div>
+        <section class="ops-table-block">
+            <div class="ops-titlebar"><h2>Current Budgets</h2></div>
+            <div class="ops-table-content">
+                <div id="budget-table"></div>
+            </div>
         </section>
-        <section class="cards">
-            <h2 class="text-xl font-semibold mb-4">Budget Progress</h2>
-            <div id="budget-chart" style="height:400px" data-chart-desc="Bullet chart comparing spending to budgets."></div>
+        <section class="ops-chart-block">
+            <div class="ops-titlebar"><h2>Budget Progress</h2></div>
+            <div class="ops-chart-content">
+                <div id="budget-chart" class="ops-chart-canvas" data-chart-desc="Bullet chart comparing spending to budgets."></div>
+            </div>
         </section>
     </main>
 </div>

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -14,22 +14,29 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+    <link rel="stylesheet" href="operational_ui.css">
 
 </head>
 <body class="bg-gradient-to-b from-indigo-200 via-slate-100 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
-        <main class="flex-1 min-w-0 overflow-x-auto p-6">
+        <main class="ops-main flex-1 min-w-0 overflow-x-auto">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Dashboard</h1>
             <p class="mb-4">View income and outgoings for a chosen month. Compare different months to spot trends and track progress toward your goals.</p>
-            <label for="year-select" class="block">Year:
-                <select id="year-select" class="border p-2 rounded w-full" data-help="Select year"></select>
-            </label>
-            <label for="month-select" class="block mt-2">Month:
-                <select id="month-select" class="border p-2 rounded w-full" data-help="Select month"></select>
-            </label>
+            <section class="ops-section">
+                <form class="ops-form-grid cols-3" aria-label="Monthly dashboard filters">
+                    <label for="year-select" class="ops-field"><span class="ops-label">Year</span>
+                        <select id="year-select" class="ops-select" data-help="Select year"></select>
+                        <span class="ops-help">Choose which year of monthly data to inspect.</span>
+                    </label>
+                    <label for="month-select" class="ops-field"><span class="ops-label">Month</span>
+                        <select id="month-select" class="ops-select" data-help="Select month"></select>
+                        <span class="ops-help">Filter the dashboard to one month.</span>
+                    </label>
+                </form>
+            </section>
 
-            <div id="totals" class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div id="totals" class="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div class="cards cards-tight text-center">
                     <p class="text-gray-500">Income</p>
                     <p id="income-total" class="text-3xl font-bold">£0.00</p>
@@ -44,27 +51,49 @@
                 </div>
             </div>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Tag Totals</h2>
-            <div id="tags-table" class="mt-2"></div>
-            <div id="tags-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of tag totals for selected month."></div>
+            <section class="ops-table-block">
+                <div class="ops-titlebar"><h2>Tag Totals</h2></div>
+                <div class="ops-table-content"><div id="tags-table"></div></div>
+            </section>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Tag Totals Chart</h2></div>
+                <div class="ops-chart-content"><div id="tags-chart" class="ops-chart-canvas" data-chart-desc="Column chart of tag totals for selected month."></div></div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Category Totals</h2>
-            <div id="categories-table" class="mt-2"></div>
-            <div id="categories-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of category totals for selected month."></div>
+            <section class="ops-table-block">
+                <div class="ops-titlebar"><h2>Category Totals</h2></div>
+                <div class="ops-table-content"><div id="categories-table"></div></div>
+            </section>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Category Totals Chart</h2></div>
+                <div class="ops-chart-content"><div id="categories-chart" class="ops-chart-canvas" data-chart-desc="Column chart of category totals for selected month."></div></div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Category & Tag Breakdown</h2>
-            <div id="category-tag-sunburst" class="mt-2 grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div id="category-tag-income" style="height:400px" data-chart-desc="Sunburst chart of income by category and tag for selected month."></div>
-                <div id="category-tag-outgoings" style="height:400px" data-chart-desc="Sunburst chart of outgoings by category and tag for selected month."></div>
-            </div>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Category & Tag Breakdown</h2></div>
+                <div id="category-tag-sunburst" class="ops-chart-content grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div id="category-tag-income" class="ops-chart-canvas" data-chart-desc="Sunburst chart of income by category and tag for selected month."></div>
+                    <div id="category-tag-outgoings" class="ops-chart-canvas" data-chart-desc="Sunburst chart of outgoings by category and tag for selected month."></div>
+                </div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Segment Totals</h2>
-            <div id="segments-table" class="mt-2"></div>
-            <div id="segments-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of segment totals for selected month."></div>
+            <section class="ops-table-block">
+                <div class="ops-titlebar"><h2>Segment Totals</h2></div>
+                <div class="ops-table-content"><div id="segments-table"></div></div>
+            </section>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Segment Totals Chart</h2></div>
+                <div class="ops-chart-content"><div id="segments-chart" class="ops-chart-canvas" data-chart-desc="Column chart of segment totals for selected month."></div></div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Group Totals</h2>
-            <div id="groups-table" class="mt-2"></div>
-            <div id="groups-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of group totals for selected month."></div>
+            <section class="ops-table-block">
+                <div class="ops-titlebar"><h2>Group Totals</h2></div>
+                <div class="ops-table-content"><div id="groups-table"></div></div>
+            </section>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Group Totals Chart</h2></div>
+                <div class="ops-chart-content"><div id="groups-chart" class="ops-chart-canvas" data-chart-desc="Column chart of group totals for selected month."></div></div>
+            </section>
         </main>
     </div>
     <script src="js/menu.js"></script>
@@ -215,14 +244,14 @@
 
                 const days = new Date(year, month, 0).getDate();
 
-                buildTable('tags-table', data.tags, days, 'bg-indigo-200 text-indigo-800');
+                buildTable('tags-table', data.tags, days, 'bg-slate-200 text-slate-800');
                 buildChart('tags-chart', 'Tag Totals', data.tags);
-                buildTable('categories-table', data.categories, days, 'bg-green-200 text-green-800');
+                buildTable('categories-table', data.categories, days, 'bg-slate-200 text-slate-800');
                 buildChart('categories-chart', 'Category Totals', data.categories, d => getCategoryColor(d.name, d.segment_name));
                 buildSunburstCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
-                buildTable('segments-table', data.segments, days, 'bg-yellow-200 text-yellow-800');
+                buildTable('segments-table', data.segments, days, 'bg-slate-200 text-slate-800');
                 buildChart('segments-chart', 'Segment Totals', data.segments, d => getSegmentColor(d.name));
-                buildTable('groups-table', data.groups, days, 'bg-purple-200 text-purple-800');
+                buildTable('groups-table', data.groups, days, 'bg-slate-200 text-slate-800');
                 buildChart('groups-chart', 'Group Totals', data.groups);
             });
     }

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -1,0 +1,132 @@
+/* Shared operational UI patterns for dashboard and planning screens */
+.ops-main {
+    padding: 1.5rem;
+}
+
+.ops-main > * + * {
+    margin-top: 1.5rem;
+}
+
+@media (min-width: 768px) {
+    .ops-main {
+        padding: 2rem;
+    }
+
+    .ops-main > * + * {
+        margin-top: 2rem;
+    }
+}
+
+.ops-section {
+    background-color: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+    padding: 1rem;
+}
+
+@media (min-width: 768px) {
+    .ops-section {
+        padding: 1.5rem;
+    }
+}
+
+.ops-heading {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 0.75rem;
+}
+
+.ops-form-grid {
+    display: grid;
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    gap: 1rem;
+    align-items: end;
+}
+
+@media (min-width: 768px) {
+    .ops-form-grid.cols-4 {
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .ops-form-grid.cols-3 {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .ops-form-grid.cols-2 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+.ops-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.ops-label {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #334155;
+}
+
+.ops-help {
+    font-size: 0.75rem;
+    color: #64748b;
+}
+
+.ops-input,
+.ops-select {
+    width: 100%;
+    border: 1px solid #cbd5e1;
+    border-radius: 0.5rem;
+    padding: 0.55rem 0.75rem;
+    color: #1f2937;
+    background: #ffffff;
+}
+
+.ops-btn-primary {
+    height: 2.6rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    font-weight: 600;
+    padding: 0 1rem;
+    background: #4f46e5;
+    color: #ffffff;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+}
+
+.ops-table-block,
+.ops-chart-block {
+    border: 1px solid #dbe3ef;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    background: #f8fafc;
+}
+
+.ops-titlebar {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid #e2e8f0;
+    background: #eef2ff;
+}
+
+.ops-titlebar h2,
+.ops-titlebar h3 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.ops-table-content,
+.ops-chart-content {
+    padding: 0.9rem;
+    background: #f8fafc;
+}
+
+.ops-chart-canvas {
+    min-height: 400px;
+}

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -14,39 +14,67 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+    <link rel="stylesheet" href="operational_ui.css">
 
 </head>
 <body class="bg-gradient-to-b from-indigo-200 via-slate-100 to-white">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
-        <main class="flex-1 min-w-0 overflow-x-auto p-6">
+        <main class="ops-main flex-1 min-w-0 overflow-x-auto">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Yearly Dashboard</h1>
             <p class="mb-4">Analyse totals for a single year through charts and tables to understand how income and spending evolved month by month.</p>
-            <label for="year-select" class="block">Year:
-                <select id="year-select" class="border p-2 rounded w-full" data-help="Select year to display"></select>
-            </label>
+            <section class="ops-section">
+                <form class="ops-form-grid cols-2" aria-label="Yearly dashboard filters">
+                    <label for="year-select" class="ops-field"><span class="ops-label">Year</span>
+                        <select id="year-select" class="ops-select" data-help="Select year to display"></select>
+                        <span class="ops-help">Choose which year to visualize across all tables and charts.</span>
+                    </label>
+                </form>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Tag Totals</h2>
-            <div id="tags-table" class="mt-2"></div>
-            <div id="tags-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of tag totals for selected year."></div>
+            <section class="ops-table-block">
+                <div class="ops-titlebar"><h2>Tag Totals</h2></div>
+                <div class="ops-table-content"><div id="tags-table"></div></div>
+            </section>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Tag Totals Chart</h2></div>
+                <div class="ops-chart-content"><div id="tags-chart" class="ops-chart-canvas" data-chart-desc="Column chart of tag totals for selected year."></div></div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Category Totals</h2>
-            <div id="categories-table" class="mt-2"></div>
-            <div id="categories-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of category totals for selected year."></div>
+            <section class="ops-table-block">
+                <div class="ops-titlebar"><h2>Category Totals</h2></div>
+                <div class="ops-table-content"><div id="categories-table"></div></div>
+            </section>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Category Totals Chart</h2></div>
+                <div class="ops-chart-content"><div id="categories-chart" class="ops-chart-canvas" data-chart-desc="Column chart of category totals for selected year."></div></div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Category & Tag Breakdown</h2>
-            <div id="category-tag-sunburst" class="mt-2 grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div id="category-tag-income" style="height:400px" data-chart-desc="Sunburst chart of income by category and tag for selected year."></div>
-                <div id="category-tag-outgoings" style="height:400px" data-chart-desc="Sunburst chart of outgoings by category and tag for selected year."></div>
-            </div>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Category & Tag Breakdown</h2></div>
+                <div id="category-tag-sunburst" class="ops-chart-content grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div id="category-tag-income" class="ops-chart-canvas" data-chart-desc="Sunburst chart of income by category and tag for selected year."></div>
+                    <div id="category-tag-outgoings" class="ops-chart-canvas" data-chart-desc="Sunburst chart of outgoings by category and tag for selected year."></div>
+                </div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Segment Totals</h2>
-            <div id="segments-table" class="mt-2"></div>
-            <div id="segments-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of segment totals for selected year."></div>
+            <section class="ops-table-block">
+                <div class="ops-titlebar"><h2>Segment Totals</h2></div>
+                <div class="ops-table-content"><div id="segments-table"></div></div>
+            </section>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Segment Totals Chart</h2></div>
+                <div class="ops-chart-content"><div id="segments-chart" class="ops-chart-canvas" data-chart-desc="Column chart of segment totals for selected year."></div></div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Group Totals</h2>
-            <div id="groups-table" class="mt-2"></div>
-            <div id="groups-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of group totals for selected year."></div>
+            <section class="ops-table-block">
+                <div class="ops-titlebar"><h2>Group Totals</h2></div>
+                <div class="ops-table-content"><div id="groups-table"></div></div>
+            </section>
+            <section class="ops-chart-block">
+                <div class="ops-titlebar"><h2>Group Totals Chart</h2></div>
+                <div class="ops-chart-content"><div id="groups-chart" class="ops-chart-canvas" data-chart-desc="Column chart of group totals for selected year."></div></div>
+            </section>
         </main>
     </div>
     <script src="js/menu.js"></script>
@@ -188,14 +216,14 @@
         fetch('../php_backend/public/yearly_dashboard.php?year=' + year)
             .then(resp => resp.json())
             .then(data => {
-                buildTable('tags-table', data.tags, 'bg-indigo-200 text-indigo-800');
+                buildTable('tags-table', data.tags, 'bg-slate-200 text-slate-800');
                 buildChart('tags-chart', 'Tag Totals ' + year, data.tags);
-                buildTable('categories-table', data.categories, 'bg-green-200 text-green-800');
+                buildTable('categories-table', data.categories, 'bg-slate-200 text-slate-800');
                 buildChart('categories-chart', 'Category Totals ' + year, data.categories, d => getCategoryColor(d.name, d.segment_name));
                 buildSunburstCharts('category-tag-income', 'category-tag-outgoings', data.categories, data.tags);
-                buildTable('segments-table', data.segments, 'bg-yellow-200 text-yellow-800');
+                buildTable('segments-table', data.segments, 'bg-slate-200 text-slate-800');
                 buildChart('segments-chart', 'Segment Totals ' + year, data.segments, d => getSegmentColor(d.name));
-                buildTable('groups-table', data.groups, 'bg-purple-200 text-purple-800');
+                buildTable('groups-table', data.groups, 'bg-slate-200 text-slate-800');
                 buildChart('groups-chart', 'Group Totals ' + year, data.groups);
             });
     }


### PR DESCRIPTION
### Motivation
- Create a single set of reusable UI rules for operational screens to ensure consistent vertical rhythm, card padding and visual treatment across dashboards and planning pages.
- Standardize form labels, helper text placement, and primary button sizing to avoid ad-hoc class use and improve accessibility.
- Provide consistent table and chart containers with neutral backgrounds and title bars to improve scanability and reduce visual noise.
- Apply the new pattern first to budget and dashboard pages to establish a baseline for other operational screens.

### Description
- Added a shared stylesheet `frontend/operational_ui.css` defining the operational primitives such as `ops-main`, `ops-section`, `ops-form-grid`, `ops-field`, `ops-label`, `ops-help`, `ops-input`, `ops-select`, `ops-btn-primary`, `ops-table-block`, `ops-chart-block`, `ops-titlebar` and `ops-chart-canvas`.
- Updated `frontend/budgets.html` to use the new patterns by linking the stylesheet, replacing ad-hoc form markup with `ops-form-grid` and `ops-field` patterns, adding helper text and consistent primary button styles, and converting the budgets table and chart areas into `ops-table-block` / `ops-chart-block` wrappers.
- Updated `frontend/monthly_dashboard.html` to use `ops-main` spacing, a standardized filter form using `ops-form-grid`, converted each table/chart region to the table/chart wrapper pattern and normalized per-section badge colour usages to a neutral style (`bg-slate-200 text-slate-800`).
- Updated `frontend/yearly_dashboard.html` with the same filter form, table/chart wrapper conversions and neutral table styling to match monthly and budgets pages.
- Small accessibility touches: added `aria-label` to key buttons and `aria-label` on dashboard filter forms where appropriate.

### Testing
- Ran `git diff --check` to validate whitespace and patch sanity, which succeeded.
- Served the frontend with `php -S 0.0.0.0:8000` and used a Playwright script to capture a visual screenshot of `frontend/budgets.html` for visual verification, which succeeded.
- No database-dependent automated tests were run in accordance with instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870f7bbb70832eb504cb82cb0e1527)