### PR TITLE
Simplify menu visuals and improve active navigation clarity

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -46,8 +46,7 @@ window.fetchNoCache = fetchNoCache;
     hoverStyle.textContent = `
       a { transition: color 0.2s ease; }
       a:hover { color: ${colors[600]}; }
-      button { transition: transform 0.1s ease, box-shadow 0.1s ease; }
-      button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
+      button { transition: color 0.2s ease, background-color 0.2s ease, border-color 0.2s ease; }
     `;
   };
 
@@ -156,15 +155,20 @@ window.fetchNoCache = fetchNoCache;
       'overflow-y-auto',
       'z-40'
     );
-    menu.classList.remove('bg-white', 'border-r');
-    menu.classList.add(
+    menu.classList.remove(
       'bg-gradient-to-b',
       'from-white/80',
-      `to-${colorScheme}-100/30`,
       'backdrop-blur-xl',
       'border',
       'border-white/40',
-      'shadow-2xl'
+      'shadow-2xl',
+      `to-${colorScheme}-100/30`
+    );
+    menu.classList.add(
+      'bg-white',
+      'border-r',
+      'border-slate-200',
+      'shadow-sm'
     );
 
     fetchNoCache('menu.php')
@@ -214,6 +218,18 @@ window.fetchNoCache = fetchNoCache;
         const current = location.pathname.split('/').pop();
         const link = menu.querySelector(`a[href="${current}"]`);
         if (link) {
+          link.classList.add(
+            'border-l-2',
+            `border-${colorScheme}-600`,
+            'font-medium',
+            'text-gray-900',
+            `bg-${colorScheme}-50`
+          );
+          const activeIcon = link.querySelector('i');
+          if (activeIcon) {
+            activeIcon.classList.remove('text-slate-400');
+            activeIcon.classList.add(`text-${colorScheme}-600`);
+          }
           const section = link.closest('div')?.querySelector('h3')?.textContent?.trim();
           const page = link.textContent.trim();
           const heading = document.querySelector('main h1');

--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -7,98 +7,98 @@
 <span id="release-number" class="bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded mt-1">v0.0.0</span>
   </div>
 </div>
-<div class="space-y-2">
+<div class="space-y-4">
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Start Here</h3>
-    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-      <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="index.html"><i class="fas fa-home mr-1"></i> Home</a></li>
-      <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="upload.html"><i class="fas fa-upload mr-1"></i> Upload OFX Files</a></li>
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Start Here</h3>
+    <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
+      <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="index.html"><i class="fas fa-home w-4 text-center text-slate-400"></i> Home</a></li>
+      <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="upload.html"><i class="fas fa-upload w-4 text-center text-slate-400"></i> Upload OFX Files</a></li>
     </ul>
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Statements &amp; Transactions</h3>
-    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_statement.html"><i class="fas fa-file-invoice mr-1"></i> Monthly Statement</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="report.html"><i class="fas fa-file-lines mr-1"></i> Transaction Reports</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="search.html"><i class="fas fa-search mr-1"></i> Search Transactions</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="transfers.html"><i class="fas fa-right-left mr-1"></i> Transfers</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ignored.html"><i class="fas fa-eye-slash mr-1"></i> Ignored Transactions</a></li>
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Statements &amp; Transactions</h3>
+    <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="monthly_statement.html"><i class="fas fa-file-invoice w-4 text-center text-slate-400"></i> Monthly Statement</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="report.html"><i class="fas fa-file-lines w-4 text-center text-slate-400"></i> Transaction Reports</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="search.html"><i class="fas fa-search w-4 text-center text-slate-400"></i> Search Transactions</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="transfers.html"><i class="fas fa-right-left w-4 text-center text-slate-400"></i> Transfers</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="ignored.html"><i class="fas fa-eye-slash w-4 text-center text-slate-400"></i> Ignored Transactions</a></li>
     </ul>
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Dashboards &amp; Graphs</h3>
-    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="yearly_dashboard.html"><i class="fas fa-calendar mr-1"></i> Yearly Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="all_years_dashboard.html"><i class="fas fa-calendar-alt mr-1"></i> All Years Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="monthly_dashboard.html"><i class="fas fa-calendar-day mr-1"></i> Monthly Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="group_dashboard.html"><i class="fas fa-object-group mr-1"></i> Group Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="account_dashboard.html"><i class="fas fa-wallet mr-1"></i> Account Dashboard</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="recurring_spend.html"><i class="fas fa-rotate mr-1"></i> Recurring Spend</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="pivot.html"><i class="fas fa-table mr-1"></i> Pivot Analysis</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="graphs.html"><i class="fas fa-chart-bar mr-1"></i> Graphs</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ai_feedback.html"><i class="fas fa-comments-dollar mr-1"></i> AI Feedback</a></li>
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Dashboards &amp; Graphs</h3>
+    <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="yearly_dashboard.html"><i class="fas fa-calendar w-4 text-center text-slate-400"></i> Yearly Dashboard</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="all_years_dashboard.html"><i class="fas fa-calendar-alt w-4 text-center text-slate-400"></i> All Years Dashboard</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="monthly_dashboard.html"><i class="fas fa-calendar-day w-4 text-center text-slate-400"></i> Monthly Dashboard</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="group_dashboard.html"><i class="fas fa-object-group w-4 text-center text-slate-400"></i> Group Dashboard</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="account_dashboard.html"><i class="fas fa-wallet w-4 text-center text-slate-400"></i> Account Dashboard</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="recurring_spend.html"><i class="fas fa-rotate w-4 text-center text-slate-400"></i> Recurring Spend</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="pivot.html"><i class="fas fa-table w-4 text-center text-slate-400"></i> Pivot Analysis</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="graphs.html"><i class="fas fa-chart-bar w-4 text-center text-slate-400"></i> Graphs</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="ai_feedback.html"><i class="fas fa-comments-dollar w-4 text-center text-slate-400"></i> AI Feedback</a></li>
     </ul>
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Budgeting</h3>
-    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="budgets.html"><i class="fas fa-piggy-bank mr-1"></i> Budgets</a></li>
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Budgeting</h3>
+    <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="budgets.html"><i class="fas fa-piggy-bank w-4 text-center text-slate-400"></i> Budgets</a></li>
     </ul>
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Projects</h3>
-    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="project_add.html"><i class="fas fa-plus mr-1"></i> Add Project</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="projects.html"><i class="fas fa-screwdriver-wrench mr-1"></i> View Projects</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="projects_board.html"><i class="fas fa-table-columns mr-1"></i> Project Board</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="projects_archived.html"><i class="fas fa-box-archive mr-1"></i> Archived Projects</a></li>
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Projects</h3>
+    <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="project_add.html"><i class="fas fa-plus w-4 text-center text-slate-400"></i> Add Project</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="projects.html"><i class="fas fa-screwdriver-wrench w-4 text-center text-slate-400"></i> View Projects</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="projects_board.html"><i class="fas fa-table-columns w-4 text-center text-slate-400"></i> Project Board</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="projects_archived.html"><i class="fas fa-box-archive w-4 text-center text-slate-400"></i> Archived Projects</a></li>
     </ul>
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Organise Data</h3>
-    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="tags.html"><i class="fas fa-tags mr-1"></i> Manage Tags</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="ai_tags.html"><i class="fas fa-robot mr-1"></i> AI Tags</a></li>
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Organise Data</h3>
+    <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="tags.html"><i class="fas fa-tags w-4 text-center text-slate-400"></i> Manage Tags</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="ai_tags.html"><i class="fas fa-robot w-4 text-center text-slate-400"></i> AI Tags</a></li>
         <li>
-          <a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="missing_tags.html">
-            <span class="flex items-center"><i class="fas fa-question-circle mr-1"></i> Missing Tags</span>
+          <a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="missing_tags.html">
+            <span class="flex items-center gap-2"><i class="fas fa-question-circle w-4 text-center text-slate-400"></i> Missing Tags</span>
             <span id="missing-tags-count" class="ml-auto bg-red-600 text-white text-xs font-bold rounded-full px-2 hidden"></span>
           </a>
         </li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="categories.html"><i class="fas fa-folder-open mr-1"></i> Manage Categories</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="groups.html"><i class="fas fa-layer-group mr-1"></i> Manage Groups</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="segments.html"><i class="fas fa-chart-pie mr-1"></i> Manage Segments</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="palette.html"><i class="fas fa-palette mr-1"></i> Colour Palette</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="categories.html"><i class="fas fa-folder-open w-4 text-center text-slate-400"></i> Manage Categories</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="groups.html"><i class="fas fa-layer-group w-4 text-center text-slate-400"></i> Manage Groups</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="segments.html"><i class="fas fa-chart-pie w-4 text-center text-slate-400"></i> Manage Segments</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="palette.html"><i class="fas fa-palette w-4 text-center text-slate-400"></i> Colour Palette</a></li>
       </ul>
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Export</h3>
-    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-      <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="export.html"><i class="fas fa-file-export mr-1"></i> Export Data</a></li>
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Export</h3>
+    <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
+      <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="export.html"><i class="fas fa-file-export w-4 text-center text-slate-400"></i> Export Data</a></li>
     </ul>
   </div>
 
   <div class="group">
-    <h3 class="text-lg font-semibold text-gray-700 mb-2 cursor-pointer">Admin Tools</h3>
-    <ul class="space-y-1 overflow-hidden max-h-0 transition-all duration-300">
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="processes.html"><i class="fas fa-gears mr-1"></i> Run Processes</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="logs.html"><i class="fas fa-scroll mr-1"></i> View Logs</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="dedupe.html"><i class="fas fa-clone mr-1"></i> Remove Duplicates</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="backup.html"><i class="fas fa-database mr-1"></i> Backup &amp; Restore</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="../settings.php"><i class="fas fa-cog mr-1"></i> System Settings</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="../users.php"><i class="fas fa-users mr-1"></i> Manage Users</a></li>
-        <li><a class="flex items-center text-gray-700 hover:text-gray-900 hover:bg-indigo-50 px-2 py-1 rounded" href="../logout.php"><i class="fas fa-right-from-bracket mr-1"></i> Logout</a></li>
+    <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Admin Tools</h3>
+    <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="processes.html"><i class="fas fa-gears w-4 text-center text-slate-400"></i> Run Processes</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="logs.html"><i class="fas fa-scroll w-4 text-center text-slate-400"></i> View Logs</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="dedupe.html"><i class="fas fa-clone w-4 text-center text-slate-400"></i> Remove Duplicates</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="backup.html"><i class="fas fa-database w-4 text-center text-slate-400"></i> Backup &amp; Restore</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="../settings.php"><i class="fas fa-cog w-4 text-center text-slate-400"></i> System Settings</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="../users.php"><i class="fas fa-users w-4 text-center text-slate-400"></i> Manage Users</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="../logout.php"><i class="fas fa-right-from-bracket w-4 text-center text-slate-400"></i> Logout</a></li>
     </ul>
   </div>
 </div>
 
-<div id="user-info" class="flex items-center mt-auto pt-4 border-t">
-  <i id="user-icon" class="fas fa-user mr-2"></i>
+<div id="user-info" class="flex items-center mt-auto pt-4 border-t border-slate-200 text-sm text-slate-600">
+  <i id="user-icon" class="fas fa-user w-4 text-center text-slate-400 mr-2"></i>
   <span id="current-user">&nbsp;</span>
 </div>


### PR DESCRIPTION
### Motivation
- Reduce heavy decorative styling on the sidebar and make the menu visually clearer and more stable across pages.
- Remove aggressive hover transform behaviour and keep only subtle color/border/background transitions for controls.
- Standardise section headings and spacing to improve scanning and consistency across groups.
- Make the active page state more obvious with a left accent border and stronger weight while keeping icons muted and consistent.

### Description
- In `frontend/js/menu.js` removed gradient/blur/shadow decorations and replaced them with a stable white panel and divider by adding `bg-white`, `border-r`, `border-slate-200`, and `shadow-sm` and removing the previous gradient/blur classes.
- In `frontend/js/menu.js` removed the global button hover lift (`transform: translateY(-2px)`) from the injected `hoverStyle` and limited transitions to `color`, `background-color`, and `border-color` for a subtler effect.
- In `frontend/js/menu.js` added explicit active-link treatment when the current page link is found (adds `border-l-2`, `border-<color>-600`, `font-medium`, clearer text and a light active background) and tints the active icon to match the accent colour.
- In `frontend/menu.php` standardised section headings to `text-sm uppercase tracking-wide` with increased spacing (`space-y-4` and `space-y-1.5`), unified link classes to a consistent `px-3 py-2 rounded-md text-sm` pattern, and normalised icon classes to `w-4 text-center text-slate-400` to keep icon treatment subtle and consistent.

### Testing
- Ran `php -l frontend/menu.php` to validate PHP markup and it completed successfully.
- Ran `node --check frontend/js/menu.js` to verify JS syntax and it completed successfully.
- Started a local dev server with `php -S 0.0.0.0:8000` and confirmed the app served; this completed successfully.
- Captured an updated UI screenshot of the menu with Playwright to visually confirm the changes and the capture succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69870f94669c832ea65129d1568bc419)