### PR TITLE
Fix: Apply accent font weight to form controls

### DIFF
--- a/frontend/js/fonts.js
+++ b/frontend/js/fonts.js
@@ -26,6 +26,12 @@
       h1, h2, h3, h4, h5, h6 { font-family: var(--heading-font, inherit); }
       table, .tabulator, .tabulator * { font-family: var(--table-font, inherit); }
       .accent { font-family: var(--accent-font, inherit); font-weight: var(--accent-font-weight, 300); }
+      input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+      select,
+      textarea,
+      .tabulator .tabulator-header-filter input {
+        font-weight: var(--accent-font-weight, inherit);
+      }
     `;
     document.head.appendChild(style);
   }


### PR DESCRIPTION
### Motivation
- The `accent_font_weight` setting updated a CSS variable but only `.accent` elements used it, so common controls (form fields and filters) did not reflect the configured weight.

### Description
- Updated `frontend/js/fonts.js` to inject additional CSS rules that apply `var(--accent-font-weight)` to text-like `input` elements (excluding `checkbox`, `radio`, and `range`), `select`, `textarea`, and Tabulator header filter inputs so the saved setting visibly affects UI controls.
- The change uses the existing `--accent-font-weight` variable and preserves the previous behavior when the setting is not set.
- Only `frontend/js/fonts.js` was modified. The rest of the font flow and settings storage remain unchanged.

### Testing
- Validated the updated JS by parsing it with Node using `node -e "new Function(fs.readFileSync('frontend/js/fonts.js','utf8'))"`, which succeeded.
- Started a local PHP server and captured a UI screenshot via an automated Playwright script to confirm the UI renders with the new rules, which completed successfully.
- No database-dependent tests were run in accordance with the project instruction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987172c02e8832eb49c090a5cdc3342)