### PR TITLE
Standardise primary content surfaces and wrap unframed page blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@
 - Project wiki pages are stored in the `wiki/` directory and mirror the GitHub wiki.
 
 ## Decisions
+- Surface system standardised to `cards` (default glass) and `cards cards-solid` (solid) variants. Use `cards cards-tight` for comparable forms/tables/charts and reserve `cards cards-solid` for dense filter/control areas that need stronger contrast.
 - Sections use scroll-based fade-in; apply `opacity-0` initially and `frontend/js/scroll_animations.js` adds a `fade-in` class when in view.
 - Settings include an accent font weight option offering thin (100), light (300), and bold (700) styles.
 - Settings provide a table font option applied to all Tabulator tables.

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -23,27 +23,37 @@
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">All Years Dashboard</h1>
             <p class="mb-4">Compare financial totals across every recorded year to reveal long-term trends and patterns in your finances.</p>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Tag Totals</h2>
-            <div id="tags-table" class="mt-2"></div>
-            <div id="tags-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of tag totals across all years."></div>
+            <section class="cards cards-tight mt-6">
+                <h2 class="text-xl font-semibold mb-2">Tag Totals</h2>
+                <div id="tags-table"></div>
+                <div id="tags-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of tag totals across all years."></div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Category Totals</h2>
-            <div id="categories-table" class="mt-2"></div>
-            <div id="categories-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of category totals across all years."></div>
+            <section class="cards cards-tight mt-6">
+                <h2 class="text-xl font-semibold mb-2">Category Totals</h2>
+                <div id="categories-table"></div>
+                <div id="categories-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of category totals across all years."></div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Category & Tag Breakdown</h2>
-            <div id="category-tag-sunburst" class="mt-2 grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div id="category-tag-income" style="height:400px" data-chart-desc="Sunburst chart of income by category and tag over all years."></div>
-                <div id="category-tag-outgoings" style="height:400px" data-chart-desc="Sunburst chart of outgoings by category and tag over all years."></div>
-            </div>
+            <section class="cards cards-tight mt-6">
+                <h2 class="text-xl font-semibold mb-2">Category & Tag Breakdown</h2>
+                <div id="category-tag-sunburst" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div id="category-tag-income" style="height:400px" data-chart-desc="Sunburst chart of income by category and tag over all years."></div>
+                    <div id="category-tag-outgoings" style="height:400px" data-chart-desc="Sunburst chart of outgoings by category and tag over all years."></div>
+                </div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Segment Totals</h2>
-            <div id="segments-table" class="mt-2"></div>
-            <div id="segments-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of segment totals across all years."></div>
+            <section class="cards cards-tight mt-6">
+                <h2 class="text-xl font-semibold mb-2">Segment Totals</h2>
+                <div id="segments-table"></div>
+                <div id="segments-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of segment totals across all years."></div>
+            </section>
 
-            <h2 class="text-xl font-semibold mt-6 mb-2">Group Totals</h2>
-            <div id="groups-table" class="mt-2"></div>
-            <div id="groups-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of group totals across all years."></div>
+            <section class="cards cards-tight mt-6">
+                <h2 class="text-xl font-semibold mb-2">Group Totals</h2>
+                <div id="groups-table"></div>
+                <div id="groups-chart" class="mt-4" style="height:400px" data-chart-desc="Column chart of group totals across all years."></div>
+            </section>
         </main>
     </div>
     <script src="js/menu.js"></script>

--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -41,6 +41,14 @@
   --card-radius: 1.75rem;
 }
 
+/* Solid card variant for dense controls and data-heavy screens */
+.cards-solid {
+  background-color: #ffffff;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
 /* Glassmorphism surfaces for data visualisations */
 .glass-surface {
   background-color: rgba(255, 255, 255, 0.14);

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -20,16 +20,20 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Categories</h1>
             <p class="mb-4">Create categories and assign tags to organise your transactions. A well-maintained list keeps reports clear and makes searching easier.</p>
+            <section class="cards cards-tight">
             <form id="category-form" class="space-y-4">
                 <label class="block">Category Name<br><input type="text" id="category-name" class="border p-2 rounded w-full" data-help="Name for the category"></label>
                 <label class="block">Description<br><textarea id="category-description" class="border p-2 rounded w-full" data-help="Description for the category"></textarea></label>
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Category</button>
             </form>
+            </section>
 
-            <div id="category-layout" class="mt-6 flex flex-col gap-4">
+            <section class="cards mt-6">
+                <div id="category-layout" class="flex flex-col gap-4">
                 <div id="unassigned"></div>
                 <div id="category-container" class="flex flex-col gap-4"></div>
-            </div>
+                </div>
+            </section>
         </main>
     </div>
     <script src="js/menu.js"></script>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -22,11 +22,13 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Groups</h1>
             <p class="mb-4">Create groups to collect related categories for reporting and analysis. Grouping similar categories helps you see broader spending patterns.</p>
+            <section class="cards cards-tight">
             <form id="group-form" class="space-y-4">
                 <label class="block">Group Name<br><input type="text" id="group-name" class="border p-2 rounded w-full" data-help="Name for the group"></label>
                 <label class="block">Description<br><textarea id="group-description" class="border p-2 rounded w-full" data-help="Description for the group"></textarea></label>
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Group</button>
             </form>
+            </section>
             <div class="mt-6 cards cards-tight">
                 <h2 class="text-xl font-semibold mb-2">Existing Groups</h2>
                 <div id="group-table"></div>

--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -19,7 +19,9 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Ignored Transactions</h1>
             <p class="mb-4">Transactions tagged with <strong>IGNORE</strong> are hidden from dashboards and reports. Use this page to review and restore them.</p>
-            <div id="ignored-table"></div>
+            <section class="cards cards-tight">
+                <div id="ignored-table"></div>
+            </section>
         </main>
     </div>
     <script src="js/menu.js"></script>

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -21,7 +21,9 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Missing Tags</h1>
             <p class="mb-4">Identify transactions that have not yet been tagged so you can assign categories before they slip through your reports.</p>
-            <div id="untagged-table"></div>
+            <section class="cards cards-tight">
+                <div id="untagged-table"></div>
+            </section>
         </main>
     </div>
     <script src="js/menu.js"></script>

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -22,7 +22,7 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Pivot Analysis</h1>
             <p class="mb-4">Explore transactions using a flexible pivot table. Choose a year or analyse all recorded data.</p>
-            <section class="space-y-4">
+            <section class="cards cards-tight space-y-4">
                 <div class="flex flex-col md:flex-row md:items-end md:space-x-4 space-y-4 md:space-y-0">
                     <div class="flex flex-col">
                         <label for="year-select" class="font-semibold">Year</label>

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -22,7 +22,7 @@
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Project Board</h1>
         <p class="mb-4">Browse all active projects in a card layout.</p>
 
-        <section class="bg-white p-6 rounded shadow space-y-4">
+        <section class="cards cards-solid cards-tight space-y-4">
             <div class="flex flex-col lg:flex-row lg:items-end gap-3">
                 <label class="flex-1">
                     <span class="block text-sm font-semibold mb-1">Search Projects</span>
@@ -276,7 +276,7 @@ async function loadProjects(){
     });
 
         if(!filteredProjects.length){
-            board.innerHTML = '<div class="bg-white p-6 rounded shadow text-sm text-gray-600">No projects match the selected filters.</div>';
+            board.innerHTML = '<div class="cards cards-solid cards-tight text-sm text-gray-600">No projects match the selected filters.</div>';
         }
     }
 

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -22,15 +22,21 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Search Transactions</h1>
             <p class="mb-4">Find specific transactions using keywords and view the results below. Quick searches help you jump straight to the entries you need.</p>
+            <section class="cards cards-tight">
             <form id="search-form" class="space-y-4">
                 <input type="text" id="term" placeholder="Search value" class="border p-2 rounded w-full" data-help="Value to search across transactions">
                 <input type="number" step="0.01" id="min-amount" placeholder="Min Amount (£)" class="border p-2 rounded w-full" data-help="Minimum amount to match">
                 <input type="number" step="0.01" id="max-amount" placeholder="Max Amount (£)" class="border p-2 rounded w-full" data-help="Maximum amount to match">
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Search</button>
             </form>
-            <div id="results-grid" class="mt-4"></div>
-            <p id="total" class="mt-4"></p>
-            <div id="results-chart" class="mt-6" style="height:400px" data-chart-desc="Column chart showing spending totals from search results."></div>
+            </section>
+            <section class="cards cards-tight mt-4">
+                <div id="results-grid"></div>
+                <p id="total" class="mt-4"></p>
+            </section>
+            <section class="cards cards-tight mt-6">
+                <div id="results-chart" style="height:400px" data-chart-desc="Column chart showing spending totals from search results."></div>
+            </section>
         </main>
     </div>
     <script src="js/menu.js"></script>

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -20,15 +20,19 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Segments</h1>
             <p class="mb-4">Create segments to group categories for broader analysis. Drag categories between segments to adjust their grouping.</p>
+            <section class="cards cards-tight">
             <form id="segment-form" class="space-y-4">
                 <label class="block">Segment Name<br><input type="text" id="segment-name" class="border p-2 rounded w-full" data-help="Name for the segment"></label>
                 <label class="block">Description<br><textarea id="segment-description" class="border p-2 rounded w-full" data-help="Description for the segment"></textarea></label>
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Segment</button>
             </form>
-            <div id="segment-layout" class="mt-6 flex items-start gap-4">
+            </section>
+            <section class="cards mt-6">
+                <div id="segment-layout" class="flex items-start gap-4">
                 <div id="unassigned" class="flex-shrink-0"></div>
                 <div id="segment-container" class="flex-1 flex gap-4 overflow-x-auto items-start"></div>
-            </div>
+                </div>
+            </section>
         </main>
     </div>
     <script src="js/menu.js"></script>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -22,12 +22,14 @@
         <main class="flex-1 min-w-0 overflow-x-auto p-6">
             <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Tags</h1>
             <p class="mb-4">Create new tags and manage existing ones for categorising transactions. Tags act like labels that make reports and searches more meaningful.</p>
+            <section class="cards cards-tight">
             <form id="tag-form" class="space-y-4">
                 <label class="block">Tag Name<br><input type="text" id="tag-name" class="border p-2 rounded w-full" data-help="Name for the tag"></label>
                 <label class="block">Keyword (for auto tagging)<br><input type="text" id="tag-keyword" class="border p-2 rounded w-full" data-help="Keyword used to auto-tag transactions"></label>
                 <label class="block">Description<br><textarea id="tag-description" class="border p-2 rounded w-full" data-help="Description for the tag"></textarea></label>
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Create Tag</button>
             </form>
+            </section>
             <div class="mt-6 cards cards-tight">
                 <h2 class="text-xl font-semibold mb-2">Existing Tags</h2>
                 <div id="tag-table"></div>

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -19,7 +19,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
-            <section>
+            <section class="cards cards-tight">
                 <h1 class="text-2xl font-semibold mb-4 flex items-center justify-between text-indigo-700">
                     Detected Transfers
 
@@ -32,14 +32,14 @@
                 <p class="mb-4">Manage possible transfers between accounts and mark them so they don't count toward income or outgoings.</p>
                 <div id="transfers-table"></div>
             </section>
-            <section>
+            <section class="cards cards-tight">
                 <h2 class="text-xl font-semibold mb-4 flex items-center justify-between">
                     Marked Transfers
                     <button id="undo-all" class="bg-red-600 text-white px-3 py-1 rounded text-sm"><i class="fas fa-rotate-left inline w-4 h-4 mr-1"></i>Undo All</button>
                 </h2>
                 <div id="linked-table"></div>
             </section>
-            <section>
+            <section class="cards cards-tight">
                 <h2 class="text-xl font-semibold mb-4">Link Transactions as Transfer</h2>
                 <form id="link-form" class="space-y-4">
                     <input type="number" id="id1" placeholder="First transaction ID" class="border p-2 rounded w-full" data-help="ID of the first transaction">

--- a/settings.php
+++ b/settings.php
@@ -164,6 +164,7 @@ $bg600 = "bg-{$colorScheme}-600";
     </script>
 
       <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="frontend/cards.css">
       <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
       <style>
           a { transition: color 0.2s ease; }
@@ -173,7 +174,7 @@ $bg600 = "bg-{$colorScheme}-600";
       </style>
 </head>
 <body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
-    <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
+    <div class="max-w-4xl mx-auto cards cards-solid border border-gray-400">
         <i class="fas fa-cogs <?= $text600 ?> text-6xl mb-4 block mx-auto"></i>
         <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1">ADMIN TOOLS / SYSTEM SETTINGS</div>
         <h1 class="text-2xl font-semibold mb-4 <?= $text700 ?>">System Settings</h1>

--- a/users.php
+++ b/users.php
@@ -79,6 +79,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     </script>
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="frontend/cards.css">
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
 
       <!-- Font Awesome icons loaded via frontend/js/menu.js -->
@@ -90,7 +91,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       </style>
 </head>
 <body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
-    <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
+    <div class="max-w-2xl mx-auto cards cards-solid border border-gray-400">
         <i class="fas fa-piggy-bank text-indigo-600 text-6xl mb-4 block mx-auto"></i>
         <div class="uppercase text-indigo-900 text-[0.6rem] mb-1">ADMIN TOOLS / MANAGE USERS</div>
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">User Management</h1>
@@ -117,7 +118,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         <h2 class="text-xl font-semibold mt-6 mb-2">Two-Factor Authentication</h2>
         <p class="mb-4"><?= $has2fa ? '2FA is enabled for your account.' : '2FA is not enabled. Generate a secret to enable it.' ?></p>
-        <div class="bg-white p-4 rounded shadow border border-gray-400 space-y-4 mb-6">
+        <div class="cards cards-solid cards-tight border border-gray-400 space-y-4 mb-6">
             <form id="generate-form" class="space-y-4">
                 <input type="hidden" id="gen-username" value="<?= htmlspecialchars($username) ?>">
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-qrcode inline w-4 h-4 mr-2"></i>Generate QR</button>


### PR DESCRIPTION
### Motivation
- Establish a single, approved surface system so forms, tables and charts share consistent spacing, border-radius and elevation across the app. 
- Replace ad hoc `bg-white p-6 rounded shadow` usages and many unframed sections which caused inconsistent visual weight and spacing. 
- Provide an accessible solid variant for dense control areas and document when to use glass vs solid surfaces. 

### Description
- Added a `cards-solid` variant to `frontend/cards.css` to provide a neutral solid surface alongside the existing glass `cards` style. 
- Recorded the surface system decision in `AGENTS.md` and documented recommended usage (default `cards`, `cards cards-tight` for comparable blocks, `cards cards-solid` for dense controls). 
- Replaced ad hoc `bg-white p-6 rounded shadow` panels and wrapped previously unframed forms/tables/charts with approved containers (`<section class="cards cards-tight">` or `cards cards-solid`) in multiple pages including `frontend/projects_board.html`, `frontend/all_years_dashboard.html`, `frontend/search.html`, `frontend/ignored.html`, `frontend/missing_tags.html`, `frontend/categories.html`, `frontend/groups.html`, `frontend/segments.html`, `frontend/tags.html`, `frontend/transfers.html`, and `frontend/pivot.html`. 
- Updated admin pages `users.php` and `settings.php` to load `frontend/cards.css` and converted their white panels to use `cards cards-solid` for consistency. 

### Testing
- Ran `php -l users.php` which reported no syntax errors. 
- Ran `php -l settings.php` which reported no syntax errors. 
- Ran `git diff --check` to validate whitespace and diff issues and it returned no problems. 
- No database-dependent tests were run per the instruction not to run DB-requiring tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698718bed710832e9db1e7ce512af819)