### PR TITLE
Standardize table presentation across dashboards and project board

### DIFF
--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -14,6 +14,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+    <link rel="stylesheet" href="operational_ui.css">
 
 </head>
 <body class="bg-gradient-to-b from-indigo-200 via-slate-100 to-white">

--- a/frontend/js/tabulator-tailwind.js
+++ b/frontend/js/tabulator-tailwind.js
@@ -39,7 +39,7 @@ function styleCalcRows(table) {
     const rows = table.element.querySelectorAll('.tabulator-calcs-row');
     rows.forEach(row => {
         row.classList.remove('bg-white');
-        row.classList.add('glass-table-row');
+        row.classList.add('ops-table-row');
         row.style.backgroundColor = '';
         row.querySelectorAll('.tabulator-cell').forEach(cell => {
             cell.classList.remove('bg-white');
@@ -74,7 +74,7 @@ function tailwindTabulator(element, options) {
         if (userRowFormatter) userRowFormatter(row);
         const rowEl = row.getElement();
         rowEl.classList.remove('bg-white', 'hover:bg-white');
-        rowEl.classList.add('glass-table-row');
+        rowEl.classList.add('ops-table-row');
         rowEl.classList.remove('tabulator-row-even', 'tabulator-row-odd');
     };
     if (options.pagination === undefined) {
@@ -114,7 +114,7 @@ function tailwindTabulator(element, options) {
         const searchInput = document.createElement('input');
         searchInput.type = 'text';
         searchInput.placeholder = 'Search';
-        searchInput.className = 'tabulator-search glass-input mb-2 w-full';
+        searchInput.className = 'tabulator-search ops-input mb-2 w-full';
         searchInput.style.colorScheme = 'light';
         tableEl.parentNode.insertBefore(searchInput, tableEl);
         let searchInProgress = false;
@@ -144,7 +144,7 @@ function tailwindTabulator(element, options) {
     table.on('dataProcessed', function() {
         styleCalcRows(table);
     });
-    el.classList.add('border-0', 'rounded-xl', 'overflow-hidden', 'glass-table', 'glass-surface');
+    el.classList.add('border-0', 'rounded-xl', 'overflow-hidden', 'ops-standard-table');
     const header = el.querySelector('.tabulator-header');
     if (header) {
         header.classList.remove('bg-white');
@@ -160,7 +160,7 @@ function tailwindTabulator(element, options) {
     const paginator = el.querySelector('.tabulator-paginator');
     if (paginator) {
         paginator.classList.remove('bg-white');
-        paginator.classList.add('p-2', 'rounded-b-lg');
+        paginator.classList.add('p-2', 'rounded-b-lg', 'ops-table-paginator');
         paginator.style.backgroundColor = '';
     }
     return table;

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -104,13 +104,13 @@
     border: 1px solid #dbe3ef;
     border-radius: 0.75rem;
     overflow: hidden;
-    background: #f8fafc;
+    background: #ffffff;
 }
 
 .ops-titlebar {
     padding: 0.75rem 1rem;
     border-bottom: 1px solid #e2e8f0;
-    background: #eef2ff;
+    background: #e2e8f0;
 }
 
 .ops-titlebar h2,
@@ -124,9 +124,103 @@
 .ops-table-content,
 .ops-chart-content {
     padding: 0.9rem;
-    background: #f8fafc;
+    background: #ffffff;
 }
 
 .ops-chart-canvas {
     min-height: 400px;
+}
+
+
+/* Standard table presentation: opaque surfaces with high-contrast headers */
+.ops-standard-table {
+    border: 1px solid #dbe3ef;
+    border-radius: 0.75rem;
+    background: #ffffff;
+    box-shadow: 0 8px 20px -18px rgba(15, 23, 42, 0.55);
+}
+
+.ops-standard-table .tabulator-header {
+    background: #e2e8f0;
+    color: #0f172a;
+    border-bottom: 1px solid #cbd5e1;
+}
+
+.ops-standard-table .tabulator-header .tabulator-col {
+    background: transparent;
+    color: inherit;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+}
+
+.ops-standard-table .tabulator-tableholder,
+.ops-standard-table .tabulator-tableholder .tabulator-table,
+.ops-standard-table .tabulator-footer,
+.ops-standard-table .tabulator-paginator {
+    background: #ffffff;
+}
+
+.ops-standard-table .tabulator-cell {
+    font-size: 0.8125rem;
+    color: #1e293b;
+    border-color: #e2e8f0;
+}
+
+.ops-table-row {
+    background: #ffffff !important;
+}
+
+.ops-table-row:nth-child(even) {
+    background: #f8fafc !important;
+}
+
+.ops-table-row:hover {
+    background: #eef2ff !important;
+}
+
+.ops-standard-table .tabulator-calcs-row,
+.ops-standard-table .tabulator-calcs-row .tabulator-cell {
+    background: #e2e8f0 !important;
+    color: #0f172a;
+    font-weight: 600;
+}
+
+.ops-table-paginator {
+    border-top: 1px solid #e2e8f0;
+}
+
+.ops-native-table {
+    width: 100%;
+    border-collapse: collapse;
+    border: 1px solid #dbe3ef;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    font-size: 0.8125rem;
+    color: #1e293b;
+    background: #ffffff;
+}
+
+.ops-native-table th,
+.ops-native-table td {
+    padding: 0.45rem 0.6rem;
+    border-bottom: 1px solid #e2e8f0;
+    vertical-align: top;
+}
+
+.ops-native-table th {
+    width: 20%;
+    background: #e2e8f0;
+    color: #0f172a;
+    font-weight: 700;
+    text-align: left;
+}
+
+.ops-native-table tbody tr:nth-child(even) td {
+    background: #f8fafc;
+}
+
+.ops-native-table tbody tr:hover td {
+    background: #e2e8f0;
 }

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -13,6 +13,8 @@
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
 
+    <link rel="stylesheet" href="operational_ui.css">
+
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
 <body class="bg-gradient-to-b from-indigo-200 via-slate-100 to-white">
@@ -207,38 +209,38 @@ async function loadProjects(){
         details.appendChild(rationale);
 
         const table = document.createElement('table');
-        table.className = 'text-xs w-full';
+        table.className = 'ops-native-table';
         table.innerHTML = `
-            <tr>
-                <td class="pr-2 font-semibold">Cost Low:</td><td>${fmtMoney(p.cost_low)}</td>
-                <td class="pr-2 font-semibold">Cost Medium:</td><td>${fmtMoney(p.cost_medium)}</td>
-            </tr>
-            <tr>
-                <td class="pr-2 font-semibold">Cost High:</td><td>${fmtMoney(p.cost_high)}</td>
-                <td class="pr-2 font-semibold">Funding:</td><td>${p.funding_source || ''}</td>
-            </tr>
-            <tr>
-                <td class="pr-2 font-semibold">Recurring Cost:</td><td>${fmtMoney(p.recurring_cost)}</td>
-                <td class="pr-2 font-semibold">Estimated Time:</td><td>${p.estimated_time || ''}</td>
-            </tr>
-            <tr>
-                <td class="pr-2 font-semibold">Expected Lifespan:</td><td>${p.expected_lifespan || ''}</td>
-                <td class="pr-2 font-semibold">Financial Benefit:</td><td>${scoreBadge(p.benefit_financial)}</td>
-            </tr>
-            <tr>
-                <td class="pr-2 font-semibold">Quality Benefit:</td><td>${scoreBadge(p.benefit_quality)}</td>
-                <td class="pr-2 font-semibold">Risk Benefit:</td><td>${scoreBadge(p.benefit_risk)}</td>
-            </tr>
-            <tr>
-
-                <td class="pr-2 font-semibold">Sustainability Benefit:</td><td>${scoreBadge(p.benefit_sustainability)}</td>
-                <td class="pr-2 font-semibold">Score:</td><td>${renderStars(p.score, minScore, maxScore)}</td>
-
-            </tr>
-            <tr>
-                <td class="pr-2 font-semibold">Dependencies:</td><td>${p.dependencies || ''}</td>
-                <td class="pr-2 font-semibold">Risks:</td><td>${p.risks || ''}</td>
-            </tr>
+            <tbody>
+                <tr>
+                    <th scope="row">Cost Low</th><td>${fmtMoney(p.cost_low)}</td>
+                    <th scope="row">Cost Medium</th><td>${fmtMoney(p.cost_medium)}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Cost High</th><td>${fmtMoney(p.cost_high)}</td>
+                    <th scope="row">Funding</th><td>${p.funding_source || ''}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Recurring Cost</th><td>${fmtMoney(p.recurring_cost)}</td>
+                    <th scope="row">Estimated Time</th><td>${p.estimated_time || ''}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Expected Lifespan</th><td>${p.expected_lifespan || ''}</td>
+                    <th scope="row">Financial Benefit</th><td>${scoreBadge(p.benefit_financial)}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Quality Benefit</th><td>${scoreBadge(p.benefit_quality)}</td>
+                    <th scope="row">Risk Benefit</th><td>${scoreBadge(p.benefit_risk)}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Sustainability Benefit</th><td>${scoreBadge(p.benefit_sustainability)}</td>
+                    <th scope="row">Score</th><td>${renderStars(p.score, minScore, maxScore)}</td>
+                </tr>
+                <tr>
+                    <th scope="row">Dependencies</th><td>${p.dependencies || ''}</td>
+                    <th scope="row">Risks</th><td>${p.risks || ''}</td>
+                </tr>
+            </tbody>
         `;
         details.appendChild(table);
         card.appendChild(details);


### PR DESCRIPTION
### Motivation
- Provide a single, consistent table presentation across dashboards and the projects board to improve legibility and visual consistency.
- Prefer opaque surfaces with higher-contrast headers for better accessibility and predictable layering inside card stacks.
- Replace ad-hoc native table markup on the Project Board with a small standard pattern so table typography/row backgrounds match Tabulator tables.
- Ensure Tabulator instances, native tables and ops blocks share the same tokens for typography, row striping and header contrast.

### Description
- Switched default operational containers from a glass look to an opaque style by updating `ops-table-block`/`ops-table-content` backgrounds and titlebar contrast in `frontend/operational_ui.css` and added the `ops-standard-table`, `ops-table-row`, `ops-table-paginator`, and `ops-native-table` tokens for consistent table visuals.
- Updated Tabulator bootstrap/wrapper `tailwindTabulator` in `frontend/js/tabulator-tailwind.js` to apply `ops-standard-table` on the table element, use `ops-table-row` for rows, use `ops-input` for the search input, and add `ops-table-paginator` to the paginator.
- Replaced the custom inline details table markup in `frontend/projects_board.html` with the `ops-native-table` semantic pattern (uses `th scope="row"` and a tbody) and included `operational_ui.css` on the page so native details match global table tokens.
- Included `operational_ui.css` on the All Years dashboard so Tabulator tables there use the same tokens and visuals as the other dashboards.

### Testing
- Ran `git diff --check` to verify no whitespace or trivial diff issues and it succeeded.
- Launched a local PHP server with `php -S 0.0.0.0:8000 -t /workspace/Accounts` and used a Playwright script to open `frontend/projects_board.html` while mocking `php_backend/public/projects.php`, and captured a visual screenshot showing the standardized table styling; the script completed successfully and produced `artifacts/projects-board-table-standard.png`.
- No automated tests requiring the database were executed as requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698718c38bac832ebd1df4ac9395701f)