### PR TITLE
Unify admin pages with shared frontend sidebar shell

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -7,11 +7,15 @@ function fetchNoCache(input, init = {}) {
 }
 window.fetchNoCache = fetchNoCache;
 
+const apiBase = document.body?.dataset?.apiBase || '../php_backend/public';
+const frontendBase = document.body?.dataset?.menuBase || (window.location.pathname.includes('/frontend/') ? '' : 'frontend/');
+const resolveFrontendAsset = path => `${frontendBase}${path}`;
+
   if (!document.getElementById('cards-css')) {
     const cardLink = document.createElement('link');
     cardLink.id = 'cards-css';
     cardLink.rel = 'stylesheet';
-    cardLink.href = 'cards.css';
+    cardLink.href = resolveFrontendAsset('cards.css');
     document.head.appendChild(cardLink);
   }
 
@@ -20,7 +24,7 @@ window.fetchNoCache = fetchNoCache;
     const themeLink = document.createElement('link');
     themeLink.id = 'theme-professional-css';
     themeLink.rel = 'stylesheet';
-    themeLink.href = 'css/theme-professional.css';
+    themeLink.href = resolveFrontendAsset('css/theme-professional.css');
     document.head.appendChild(themeLink);
   }
 
@@ -117,12 +121,12 @@ window.fetchNoCache = fetchNoCache;
   function loadFontsModule(cb) {
     if (window.applyFonts) { cb(); return; }
     const s = document.createElement('script');
-    s.src = 'js/fonts.js';
+    s.src = resolveFrontendAsset('js/fonts.js');
     s.onload = cb;
     document.head.appendChild(s);
   }
 
-  fetchNoCache('../php_backend/public/brand_settings.php')
+  fetchNoCache(`${apiBase}/brand_settings.php`)
     .then(r => r.json())
     .then(f => {
       siteName = f.site_name || siteName;
@@ -184,10 +188,21 @@ window.fetchNoCache = fetchNoCache;
       'shadow-sm'
     );
 
-    fetchNoCache('menu.php')
+    fetchNoCache(resolveFrontendAsset('menu.php'))
       .then(resp => resp.text())
       .then(html => {
         menu.innerHTML = html;
+        if (frontendBase === 'frontend/') {
+          menu.querySelectorAll('a[href]').forEach(linkEl => {
+            const href = linkEl.getAttribute('href') || '';
+            if (!href || href.startsWith('http://') || href.startsWith('https://') || href.startsWith('#') || href.startsWith('/')) return;
+            if (href.startsWith('../')) {
+              linkEl.setAttribute('href', href.replace(/^\.\.\//, ''));
+            } else {
+              linkEl.setAttribute('href', resolveFrontendAsset(href));
+            }
+          });
+        }
         const titleEl = menu.querySelector('#site-title');
         if (titleEl) titleEl.textContent = siteName;
         menu.querySelectorAll('img[alt="Finance Manager logo"]').forEach(img => {
@@ -198,7 +213,7 @@ window.fetchNoCache = fetchNoCache;
         const userEl = menu.querySelector('#current-user');
         const iconEl = menu.querySelector('#user-icon');
         if (userEl) {
-          fetchNoCache('../php_backend/public/current_user.php')
+          fetchNoCache(`${apiBase}/current_user.php`)
             .then(r => (r.ok ? r.json() : Promise.reject()))
             .then(u => {
               userEl.textContent = u.username || 'Guest';
@@ -274,7 +289,7 @@ window.fetchNoCache = fetchNoCache;
           }
         }
         // Display counter for untagged transactions in menu
-        fetchNoCache('../php_backend/public/untagged_count.php')
+        fetchNoCache(`${apiBase}/untagged_count.php`)
           .then(r => r.json())
           .then(data => {
             const total = Number(data.count || 0);
@@ -290,7 +305,7 @@ window.fetchNoCache = fetchNoCache;
 
         const releaseEls = document.querySelectorAll('#release-number');
         if (releaseEls.length > 0) {
-          fetchNoCache('../php_backend/public/version.php')
+          fetchNoCache(`${apiBase}/version.php`)
             .then(r => r.json())
             .then(v => {
               const version = v.version || 'unknown';
@@ -355,7 +370,7 @@ window.fetchNoCache = fetchNoCache;
   document.body.appendChild(utility);
   const latestLink = document.getElementById('latest-statement-link');
   if (latestLink) {
-    fetchNoCache('../php_backend/public/transaction_months.php')
+    fetchNoCache(`${apiBase}/transaction_months.php`)
       .then(r => r.json())
       .then(months => {
         if (months.length > 0) {
@@ -419,17 +434,17 @@ window.fetchNoCache = fetchNoCache;
 
   // Load page help overlay on every page
   const helpScript = document.createElement('script');
-  helpScript.src = 'js/page_help.js';
+  helpScript.src = resolveFrontendAsset('js/page_help.js');
   document.body.appendChild(helpScript);
 
   const logoutScript = document.createElement('script');
-  logoutScript.src = 'js/auto_logout.js';
+  logoutScript.src = resolveFrontendAsset('js/auto_logout.js');
   document.body.appendChild(logoutScript);
 
   const tooltipScript = document.createElement('script');
-  tooltipScript.src = 'js/tooltips.js';
+  tooltipScript.src = resolveFrontendAsset('js/tooltips.js');
   document.body.appendChild(tooltipScript);
 
   const fullscreenScript = document.createElement('script');
-  fullscreenScript.src = 'js/chart_fullscreen.js';
+  fullscreenScript.src = resolveFrontendAsset('js/chart_fullscreen.js');
   document.body.appendChild(fullscreenScript);

--- a/settings.php
+++ b/settings.php
@@ -172,17 +172,19 @@ $bg600 = "bg-{$colorScheme}-600";
           button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
       </style>
 </head>
-<body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
-    <div class="max-w-4xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
-        <i class="fas fa-cogs <?= $text600 ?> text-6xl mb-4 block mx-auto"></i>
-        <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1">ADMIN TOOLS / SYSTEM SETTINGS</div>
-        <h1 class="text-2xl font-semibold mb-4 <?= $text700 ?>">System Settings</h1>
-        <p class="mb-4">Adjust application configuration values.</p>
-        <p class="mb-4"><a href="logout.php" class="<?= $text600 ?> hover:underline">Logout</a> | <a href="frontend/index.html" class="<?= $text600 ?> hover:underline">Home</a></p>
-        <?php if ($message): ?>
-            <p class="mb-4 text-green-600"><?= htmlspecialchars($message) ?></p>
-        <?php endif; ?>
-        <form method="post" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+<body class="bg-gray-50" data-api-base="php_backend/public">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
+            <section class="max-w-4xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
+                <i class="fas fa-cogs <?= $text600 ?> text-6xl mb-4 block mx-auto"></i>
+                <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1">ADMIN TOOLS / SYSTEM SETTINGS</div>
+                <h1 class="text-2xl font-semibold mb-4 <?= $text700 ?>">System Settings</h1>
+                <p class="mb-4">Adjust application configuration values.</p>
+                <?php if ($message): ?>
+                    <p class="mb-4 text-green-600"><?= htmlspecialchars($message) ?></p>
+                <?php endif; ?>
+                <form method="post" class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <label class="block">OpenAI API Token:
                 <input type="text" name="openai_api_token" value="<?= htmlspecialchars($openai) ?>" class="border p-2 rounded w-full" data-help="Token used for AI tagging">
             </label>
@@ -249,8 +251,10 @@ $bg600 = "bg-{$colorScheme}-600";
                     <?php endforeach; ?>
                 </select>
             </label>
-            <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded md:col-span-2" aria-label="Save Settings"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
-        </form>
+                    <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded md:col-span-2" aria-label="Save Settings"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
+                </form>
+            </section>
+        </main>
     </div>
     <script src="frontend/js/input_help.js"></script>
     <script src="frontend/js/page_help.js"></script>
@@ -272,5 +276,6 @@ $bg600 = "bg-{$colorScheme}-600";
         if (opt.value) opt.style.fontFamily = opt.value;
       });
     </script>
+    <script src="frontend/js/menu.js"></script>
   </body>
 </html>

--- a/users.php
+++ b/users.php
@@ -89,13 +89,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
       </style>
 </head>
-<body class="min-h-screen bg-gray-50 p-6" data-api-base="php_backend/public">
-    <div class="max-w-2xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
+<body class="bg-gray-50" data-api-base="php_backend/public">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
+        <main class="flex-1 min-w-0 overflow-x-auto p-6">
+            <section class="max-w-2xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
         <i class="fas fa-piggy-bank text-indigo-600 text-6xl mb-4 block mx-auto"></i>
         <div class="uppercase text-indigo-900 text-[0.6rem] mb-1">ADMIN TOOLS / MANAGE USERS</div>
         <h1 class="text-2xl font-semibold mb-4 text-indigo-700">User Management</h1>
         <p class="mb-4">Add new users, update your password, or manage two-factor authentication from this page.</p>
-        <p class="mb-4"><a href="logout.php" class="text-indigo-600 hover:underline">Logout</a> | <a href="frontend/index.html" class="text-indigo-600 hover:underline">Home</a></p>
         <?php if ($message): ?>
             <p class="mb-4 text-green-600"><?= htmlspecialchars($message) ?></p>
         <?php endif; ?>
@@ -134,6 +136,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </div>
             </form>
         </div>
+            </section>
+        </main>
     </div>
     <script src="frontend/js/input_help.js"></script>
     <script src="frontend/js/page_help.js"></script>
@@ -154,5 +158,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 
     <script src="frontend/js/2fa.js"></script>
+    <script src="frontend/js/menu.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Bring admin screens into parity with frontend pages by using the same app shell and shared navigation so icon, tooltip and responsive behaviour is consistent.
- Remove duplicated inline navigation pieces on admin pages once the shared sidebar is available.

### Description
- Updated `settings.php` to wrap content in the standard app shell (`flex min-h-screen`), add a `<nav id="menu">` sidebar and a `main` content region, and removed the inline `Logout | Home` link row while preserving all settings controls.
- Updated `users.php` to use the same shell and sidebar pattern and removed duplicated inline nav links while keeping user management and 2FA flows intact.
- Loaded the shared `frontend/js/menu.js` on both admin pages so menu, icon colouring and tooltip behaviour match frontend screens.
- Enhanced `frontend/js/menu.js` to work from both `/frontend/*` pages and root-level admin PHP pages by resolving frontend asset paths dynamically, using `data-api-base` for backend endpoints, loading `menu.php` via a resolved path and rewriting menu `href`s when necessary.

### Testing
- Linted PHP files with `php -l settings.php` and `php -l users.php`, both reported no syntax errors.
- Verified search targets and presence of menu/sidebar with `rg` checks for `id="menu"`, `Logout |`, `frontend/js/menu.js` and `flex min-h-screen` against modified files.
- Started a local PHP server `php -S 0.0.0.0:8000` and captured a mobile viewport screenshot of `settings.php` using Playwright to validate responsive behaviour; screenshot generation succeeded.
- All automated checks listed above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698718ca4eac832e8aa219ce37a8e44f)