### PR TITLE
Introduce reusable page header pattern and migrate pages to consistent h1 placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,3 +72,5 @@
 - Table font CSS variables (`--tabulator-*`) are set in the shared menu so Tabulator tables use the correct fonts during initial render.
 - Settings page offers additional funky font options: Bangers, Caveat, Dancing Script, Fredoka, Pacifico.
 - Settings allow selecting fonts for headings, body text, tables and charts with options ranging from modern to funky.
+
+- Page headings use a shared pattern: `<header class="page-header">` with an `h1.page-title` and optional `.page-subtitle` / `.page-header-actions`; keep this header directly on the page canvas above the first content card.

--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -23,7 +23,9 @@
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
             <div class="flex items-center mb-4">
-                <h1 class="text-2xl font-semibold flex-1 text-indigo-700"><i class="fas fa-shield-halved inline w-6 h-6 mr-2"></i>Two-Factor Authentication</h1>
+                            <header class="page-header">
+                <h1 class="text-2xl font-semibold flex-1 text-indigo-700 page-title"><i class="fas fa-shield-halved inline w-6 h-6 mr-2"></i>Two-Factor Authentication</h1>
+            </header>
                 <button id="help-btn" class="text-indigo-600 font-light"><i class="fas fa-question-circle inline w-5 h-5"></i></button>
             </div>
             <p class="mb-4">Set up TOTP-based authentication and verify your one-time codes.</p>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -22,7 +22,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 id="account-name" class="text-2xl font-semibold mb-4 text-indigo-700">Account Balance</h1>
+                        <header class="page-header">
+                <h1 id="account-name" class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Account Balance</h1>
+            </header>
             <p id="account-details" class="mb-4 text-gray-600"></p>
             <p class="mb-4">View the balance over time based on the latest bank statement.</p>
             <div class="cards">

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -22,7 +22,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Account Dashboard</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Account Dashboard</h1>
+            </header>
             <p class="mb-4">See an overview of account balances and recent activity. Charts and tables reveal how money flows through each account. Sort codes and account numbers are shown where applicable; credit cards list only their card number.</p>
             <div class="cards">
                 <div id="accounts-table"></div>

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -19,7 +19,9 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">AI Feedback</h1>
+                    <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">AI Feedback</h1>
+            </header>
         <p class="mb-4">Request an AI-generated overview of your finances for the last 12 months.</p>
         <section>
             <button id="run" class="bg-indigo-600 text-white px-4 py-2 rounded">

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -19,7 +19,9 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">AI Tags</h1>
+                    <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">AI Tags</h1>
+            </header>
         <p class="mb-4">Configure OpenAI and automatically tag transactions.</p>
 
         <section>

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -23,7 +23,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">All Years Dashboard</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">All Years Dashboard</h1>
+            </header>
             <p class="mb-4">Compare financial totals across every recorded year to reveal long-term trends and patterns in your finances.</p>
 
             <section class="cards cards-tight mt-6">

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -20,7 +20,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Backup &amp; Restore</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Backup &amp; Restore</h1>
+            </header>
             <p class="mb-4">Create backups of your data or restore from an earlier snapshot. Use the tools below to download a copy of your information or load a previous backup.</p>
             <section class="cards space-y-4">
                 <h2 class="text-xl font-semibold">Download Backup</h2>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -22,7 +22,9 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Budgets</h1>
+                    <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Budgets</h1>
+            </header>
         <p class="mb-4">Set monthly spending limits for categories and monitor progress. Use this page to plan ahead and see where you may need to adjust your spending.</p>
         <section class="ops-section">
             <form id="budget-form" class="ops-form-grid cols-4">

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -20,7 +20,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Categories</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Manage Categories</h1>
+            </header>
             <p class="mb-4">Create categories and assign tags to organise your transactions. A well-maintained list keeps reports clear and makes searching easier.</p>
             <section class="cards cards-tight">
             <form id="category-form" class="space-y-4">

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -20,7 +20,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Duplicate Transactions</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Duplicate Transactions</h1>
+            </header>
             <p class="mb-4">Remove unwanted duplicate entries to keep your records accurate.</p>
             <div class="cards">
                 <div class="mb-4 space-x-2">

--- a/frontend/export.html
+++ b/frontend/export.html
@@ -19,7 +19,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Exports</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Exports</h1>
+            </header>
             <p class="mb-4">Download transactions for a chosen period in your preferred format.</p>
             <section class="space-y-4">
                 <h2 class="text-xl font-semibold">Create Export</h2>

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -19,7 +19,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-4">
-            <h1 class="text-2xl font-semibold text-indigo-700">Graphs</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold text-indigo-700 page-title">Graphs</h1>
+            </header>
             <p class="mb-4">Explore a collection of charts that illustrate your income and spending patterns. Choose a year to see how your finances evolve and compare categories or tags visually.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full"></select>

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -22,7 +22,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Group Dashboard</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Group Dashboard</h1>
+            </header>
             <p class="mb-4">Review group spending by month and year to see how different areas of your budget change over time.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full" data-help="Select year"></select>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -22,7 +22,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Groups</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Manage Groups</h1>
+            </header>
             <p class="mb-4">Create groups to collect related categories for reporting and analysis. Grouping similar categories helps you see broader spending patterns.</p>
             <section class="cards cards-tight">
             <form id="group-form" class="space-y-4">

--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -19,7 +19,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Ignored Transactions</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Ignored Transactions</h1>
+            </header>
             <p class="mb-4">Transactions tagged with <strong>IGNORE</strong> are hidden from dashboards and reports. Use this page to review and restore them.</p>
             <section class="cards cards-tight">
                 <div id="ignored-table"></div>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -37,7 +37,9 @@
                                 <i class="fas fa-shield-alt text-slate-600" aria-hidden="true"></i>
                                 Financial operations overview
                             </span>
-                            <h1 class="text-4xl font-semibold leading-tight md:text-5xl">Operational visibility for <span id="landing-site-name">Finance Manager</span></h1>
+                                        <header class="page-header">
+                <h1 class="text-4xl font-semibold leading-tight md:text-5xl page-title">Operational visibility for <span id="landing-site-name">Finance Manager</span></h1>
+            </header>
                             <p class="text-base text-slate-600">Track account activity, reconcile imports, and review reporting in one place. The platform is designed for consistent financial controls and clear audit trails.</p>
                             <div class="flex flex-wrap gap-3">
                                 <a href="upload.html" class="inline-flex items-center justify-center rounded-full bg-indigo-600 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-indigo-700" aria-label="Upload transactions">

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -22,7 +22,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Application Logs</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Application Logs</h1>
+            </header>
             <p class="mb-4">Review recent log entries to monitor system activity. Filtering by time or keyword helps you trace what happened during a specific event.</p>
             <div class="mb-4 flex items-center space-x-2">
                 <label class="text-sm">Days to keep/show:

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -21,7 +21,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Missing Tags</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Missing Tags</h1>
+            </header>
             <p class="mb-4">Identify transactions that have not yet been tagged so you can assign categories before they slip through your reports.</p>
             <section class="cards cards-tight">
                 <div id="untagged-table"></div>

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -21,7 +21,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Dashboard</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Monthly Dashboard</h1>
+            </header>
             <p class="mb-4">View income and outgoings for a chosen month. Compare different months to spot trends and track progress toward your goals.</p>
             <section class="ops-section">
                 <form class="ops-form-grid cols-3" aria-label="Monthly dashboard filters">

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -23,7 +23,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 id="page-title" class="text-2xl font-semibold mb-4 text-indigo-700">Monthly Statement</h1>
+                        <header class="page-header">
+                <h1 id="page-title" class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Monthly Statement</h1>
+            </header>
             <p class="mb-4">Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.</p>
             <div class="cards">
                 <form id="statement-form" class="flex flex-wrap items-end gap-4">

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -13,6 +13,30 @@
     margin-top: 1.5rem;
 }
 
+/* Reusable page header pattern: title plus optional subtitle/actions */
+.page-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.page-title {
+    margin: 0;
+}
+
+.page-subtitle {
+    margin: 0.35rem 0 0;
+    color: #4b5563;
+}
+
+.page-header-actions {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
 @media (min-width: 768px) {
     .ops-main {
         padding: 2rem;

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -18,7 +18,9 @@
   <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-      <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Palette Settings</h1>
+                  <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Palette Settings</h1>
+            </header>
 
       <div class="cards space-y-4">
         <ul class="list-disc pl-5 text-gray-700">

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -22,7 +22,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Pivot Analysis</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Pivot Analysis</h1>
+            </header>
             <p class="mb-4">Explore transactions using a flexible pivot table. Choose a year or analyse all recorded data.</p>
             <section class="cards cards-tight space-y-4">
                 <div class="flex flex-col md:flex-row md:items-end md:space-x-4 space-y-4 md:space-y-0">

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -20,7 +20,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Run Processes</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Run Processes</h1>
+            </header>
             <p class="mb-4">Run background tasks like auto-tagging, category or segment assignment. These automated processes tidy your data so reports stay accurate without manual effort.</p>
             <div class="space-x-4">
                 <button id="tagging-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-tags inline w-4 h-4 mr-1"></i>Run Tagging</button>

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -20,7 +20,9 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Add Project</h1>
+                    <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Add Project</h1>
+            </header>
         <p class="mb-4">Capture ideas for home projects and detail their costs and benefits.</p>
 
         <section class="cards">

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -23,7 +23,9 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Projects</h1>
+                    <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Projects</h1>
+            </header>
         <p class="mb-4">Review your planned projects, explore costs and compare their priorities.</p>
 
         <section class="grid gap-6 xl:grid-cols-3 auto-rows-min">

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -21,7 +21,9 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Archived Projects</h1>
+                    <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Archived Projects</h1>
+            </header>
         <p class="mb-4">Review projects that have been archived. Restore any project to make it active again.</p>
         <section class="cards">
             <div id="archived-projects-table"></div>

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -21,7 +21,9 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Project Board</h1>
+                    <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Project Board</h1>
+            </header>
         <p class="mb-4">Browse all active projects in a card layout.</p>
 
         <section class="cards cards-solid cards-tight space-y-4">

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -22,7 +22,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Recurring Spend Detection</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Recurring Spend Detection</h1>
+            </header>
             <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses. The results highlight ongoing commitments so you know where money leaves your account regularly.</p>
             <button id="run-analysis" class="bg-indigo-600 text-white px-4 py-2 rounded mb-4"><i class="fas fa-chart-line inline w-4 h-4 mr-2"></i>Run Analysis</button>
             <h2 class="text-xl font-semibold mt-6 mb-2">Recurring Outgoings</h2>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -23,7 +23,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Reports</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Transaction Reports</h1>
+            </header>
             <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>
             <form id="report-form" class="cards cards-tight grid grid-cols-1 md:grid-cols-3 gap-4">
                 <label class="block md:col-span-3">Ask in plain English:

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -22,7 +22,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Search Transactions</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Search Transactions</h1>
+            </header>
             <p class="mb-4">Find specific transactions using keywords and view the results below. Quick searches help you jump straight to the entries you need.</p>
             <section class="cards cards-tight">
             <form id="search-form" class="space-y-4">

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -20,7 +20,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Segments</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Manage Segments</h1>
+            </header>
             <p class="mb-4">Create segments to group categories for broader analysis. Drag categories between segments to adjust their grouping.</p>
             <section class="cards cards-tight">
             <form id="segment-form" class="space-y-4">

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -22,7 +22,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Manage Tags</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Manage Tags</h1>
+            </header>
             <p class="mb-4">Create new tags and manage existing ones for categorising transactions. Tags act like labels that make reports and searches more meaningful.</p>
             <section class="cards cards-tight">
             <form id="tag-form" class="space-y-4">

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -26,7 +26,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Transaction Details</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Transaction Details</h1>
+            </header>
             <p class="mb-4">Review or edit the information for a single transaction. Changes here immediately update dashboards, reports and budgets.</p>
             <div id="transaction-details" class="mt-4"></div>
         </main>

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -22,15 +22,17 @@
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <section class="cards cards-tight">
-                <h1 class="text-2xl font-semibold mb-4 flex items-center justify-between text-indigo-700">
-                    Detected Transfers
-
-                    <span class="space-x-2">
-                        <button id="assist-btn" class="bg-indigo-600 text-white px-3 py-1 rounded text-sm"><i class="fas fa-magic inline w-4 h-4 mr-1"></i>Assist</button>
-                        <button id="mark-all" class="bg-green-600 text-white px-3 py-1 rounded text-sm"><i class="fas fa-check-double inline w-4 h-4 mr-1"></i>Mark All</button>
-                    </span>
-
-                </h1>
+                            <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 flex items-center justify-between text-indigo-700 page-title">
+                                    Detected Transfers
+                
+                                    <span class="space-x-2">
+                                        <button id="assist-btn" class="bg-indigo-600 text-white px-3 py-1 rounded text-sm"><i class="fas fa-magic inline w-4 h-4 mr-1"></i>Assist</button>
+                                        <button id="mark-all" class="bg-green-600 text-white px-3 py-1 rounded text-sm"><i class="fas fa-check-double inline w-4 h-4 mr-1"></i>Mark All</button>
+                                    </span>
+                
+                                </h1>
+            </header>
                 <p class="mb-4">Manage possible transfers between accounts and mark them so they don't count toward income or outgoings.</p>
                 <div id="transfers-table"></div>
             </section>

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -19,7 +19,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Upload OFX Files</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Upload OFX Files</h1>
+            </header>
         <p class="mb-4">Upload one or more OFX statements from your bank to import transactions into the system. The file contents will be processed and your data added to the database for review.</p>
             <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                 <input type="file" name="ofx_files[]" accept=".ofx" multiple required class="block w-full" data-help="Select one or more OFX files to upload">

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -21,7 +21,9 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <h1 class="text-2xl font-semibold mb-4 text-indigo-700">Yearly Dashboard</h1>
+                        <header class="page-header">
+                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Yearly Dashboard</h1>
+            </header>
             <p class="mb-4">Analyse totals for a single year through charts and tables to understand how income and spending evolved month by month.</p>
             <section class="ops-section">
                 <form class="ops-form-grid cols-2" aria-label="Yearly dashboard filters">

--- a/settings.php
+++ b/settings.php
@@ -168,6 +168,7 @@ $bg600 = "bg-{$colorScheme}-600";
 
       <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="frontend/cards.css">
+    <link rel="stylesheet" href="frontend/operational_ui.css">
       <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
       <style>
           a { transition: color 0.2s ease; }
@@ -176,15 +177,18 @@ $bg600 = "bg-{$colorScheme}-600";
           button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
       </style>
 </head>
-<body class="bg-gray-50" data-api-base="php_backend/public">
+<body class="ops-body" data-api-base="php_backend/public">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
-        <main class="flex-1 min-w-0 overflow-x-auto p-6">
-            <section class="max-w-4xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
-                <i class="fas fa-cogs <?= $text600 ?> text-6xl mb-4 block mx-auto"></i>
-                <div class="uppercase <?= $text900 ?> text-[0.6rem] mb-1">ADMIN TOOLS / SYSTEM SETTINGS</div>
-                <h1 class="text-2xl font-semibold mb-4 <?= $text700 ?>">System Settings</h1>
-                <p class="mb-4">Adjust application configuration values.</p>
+        <main class="ops-main flex-1 min-w-0 overflow-x-auto">
+            <section class="max-w-4xl mx-auto">
+                <header class="page-header">
+                    <div>
+                        <h1 class="text-2xl font-semibold <?= $text700 ?> page-title">System Settings</h1>
+                        <p class="page-subtitle">Adjust application configuration values.</p>
+                    </div>
+                </header>
+                <div class="cards cards-solid border border-gray-400">
                 <?php if ($message): ?>
                     <p class="mb-4 text-green-600"><?= htmlspecialchars($message) ?></p>
                 <?php endif; ?>
@@ -257,9 +261,8 @@ $bg600 = "bg-{$colorScheme}-600";
             </label>
                     <button type="submit" class="<?= $bg600 ?> text-white px-4 py-2 rounded md:col-span-2" aria-label="Save Settings"><i class="fas fa-save inline w-4 h-4 mr-2"></i>Save Settings</button>
                 </form>
+                </div>
             </section>
-        </main>
-    </div>
         </main>
     </div>
     <script src="frontend/js/menu.js"></script>
@@ -283,6 +286,5 @@ $bg600 = "bg-{$colorScheme}-600";
         if (opt.value) opt.style.fontFamily = opt.value;
       });
     </script>
-    <script src="frontend/js/menu.js"></script>
   </body>
 </html>

--- a/users.php
+++ b/users.php
@@ -80,6 +80,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="frontend/cards.css">
+    <link rel="stylesheet" href="frontend/operational_ui.css">
     <link rel="icon" type="image/png" sizes="any" href="/favicon.png">
 
       <!-- Font Awesome icons loaded via frontend/js/menu.js -->
@@ -90,15 +91,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           button:hover { transform: translateY(-2px); box-shadow: 0 4px 6px rgba(0,0,0,0.3); }
       </style>
 </head>
-<body class="bg-gray-50" data-api-base="php_backend/public">
+<body class="ops-body" data-api-base="php_backend/public">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
-        <main class="flex-1 min-w-0 overflow-x-auto p-6">
-            <section class="max-w-2xl mx-auto bg-white p-6 rounded shadow border border-gray-400">
-        <i class="fas fa-piggy-bank text-indigo-600 text-6xl mb-4 block mx-auto"></i>
-        <div class="uppercase text-indigo-900 text-[0.6rem] mb-1">ADMIN TOOLS / MANAGE USERS</div>
-        <h1 class="text-2xl font-semibold mb-4 text-indigo-700">User Management</h1>
-        <p class="mb-4">Add new users, update your password, or manage two-factor authentication from this page.</p>
+        <main class="ops-main flex-1 min-w-0 overflow-x-auto">
+            <section class="max-w-2xl mx-auto">
+        <header class="page-header">
+            <div>
+                <h1 class="text-2xl font-semibold text-indigo-700 page-title">User Management</h1>
+                <p class="page-subtitle">Add new users, update your password, or manage two-factor authentication from this page.</p>
+            </div>
+        </header>
+        <div class="cards cards-solid border border-gray-400">
         <?php if ($message): ?>
             <p class="mb-4 text-green-600"><?= htmlspecialchars($message) ?></p>
         <?php endif; ?>
@@ -137,9 +141,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </div>
             </form>
         </div>
+        </div>
             </section>
-        </main>
-    </div>
         </main>
     </div>
     <script src="frontend/js/menu.js"></script>
@@ -162,6 +165,5 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
 
     <script src="frontend/js/2fa.js"></script>
-    <script src="frontend/js/menu.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Unify page heading presentation so every page uses a single header structure (title + optional subtitle/actions) and consistent spacing across the app.
- Move admin pages (`settings.php`, `users.php`) to the same canvas-level heading placement used by main frontend screens so the UI feels consistent.

### Description
- Added a reusable header pattern in `frontend/operational_ui.css` introducing `.page-header`, `.page-title`, `.page-subtitle`, and `.page-header-actions` to standardise layout and spacing.
- Updated all frontend pages to wrap the primary `h1` in `<header class="page-header">` and to apply the `page-title` class so title placement and spacing are consistent site-wide.
- Refactored `settings.php` and `users.php` to use the same `ops-body`/`ops-main` layout and the new header pattern, moving content into the first content `cards` block beneath the page header.
- Recorded the new convention in `AGENTS.md` under Decisions to document the pattern for future changes.

### Testing
- Ran `php -l settings.php` and `php -l users.php` to ensure no PHP syntax errors, both checks passed.
- Executed a script-based consistency check that validated each frontend page contains a matching `h1` wrapped in a `page-header` and that each `h1` includes the `page-title` class, which passed for all pages.
- Attempted a Playwright screenshot to visually validate the header, but the browser process crashed in this environment (SIGSEGV) so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69871df24810832eb10f620ce78829b0)