### PR TITLE
Make ops titlebar background transparent

### DIFF
--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -140,7 +140,7 @@
 .ops-titlebar {
     padding: 0.75rem 1rem;
     border-bottom: 1px solid #e2e8f0;
-    background: #e2e8f0;
+    background: transparent;
 }
 
 .ops-titlebar h2,


### PR DESCRIPTION
### Motivation
- Remove the hard-coded grey fill on `.ops-titlebar` so title bars inherit their parent/card background and allow the professional (white) and standard (gradient/card) themes to show through.

### Description
- Changed `.ops-titlebar { background: #e2e8f0; }` to `background: transparent;` in `frontend/operational_ui.css` and left `.ops-titlebar h2, .ops-titlebar h3` typography rules unchanged; confirmed the selector is used in `frontend/monthly_dashboard.html`, `frontend/yearly_dashboard.html`, and `frontend/budgets.html`.

### Testing
- Ran a targeted search with `rg` to verify the CSS change and heading rules, executed `curl -I http://127.0.0.1:8000/frontend/monthly_dashboard.html` to confirm the page is served, and attempted Playwright-based screenshot/theme checks which were executed but returned null/404 computed-style results in the execution environment so visual verification may need a local browser check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698721d4c998832e90fae9a7c9b5be03)