### PR TITLE
Make operational UI surfaces transparent to respect parent theme cards

### DIFF
--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -134,7 +134,7 @@
     border: 1px solid #dbe3ef;
     border-radius: 0.75rem;
     overflow: hidden;
-    background: #ffffff;
+    background: transparent;
 }
 
 .ops-titlebar {
@@ -154,7 +154,7 @@
 .ops-table-content,
 .ops-chart-content {
     padding: 0.9rem;
-    background: #ffffff;
+    background: transparent;
 }
 
 .ops-chart-canvas {
@@ -162,11 +162,11 @@
 }
 
 
-/* Standard table presentation: opaque surfaces with high-contrast headers */
+/* Standard table presentation: parent surface controls background while headers stay high-contrast */
 .ops-standard-table {
     border: 1px solid #dbe3ef;
     border-radius: 0.75rem;
-    background: #ffffff;
+    background: transparent;
     box-shadow: 0 8px 20px -18px rgba(15, 23, 42, 0.55);
 }
 


### PR DESCRIPTION
### Motivation
- Remove hard-coded white fills so shared operational surfaces defer to parent card/theme backgrounds and support transparent/professional themes.
- Preserve borders, radii and spacing so layout and contrast (headers/controls) remain consistent while allowing parent surfaces (e.g. `cards` / `cards-solid`) to define the perceived white surface.

### Description
- Changed `.ops-table-block` and `.ops-chart-block` to `background: transparent` in `frontend/operational_ui.css` while keeping border, radius and overflow rules intact.
- Changed `.ops-table-content` and `.ops-chart-content` to `background: transparent` while retaining padding so content spacing is unchanged.
- Changed `.ops-standard-table` base background to `transparent` and updated the comment to clarify that headers remain high-contrast and parent surfaces control the main background.

### Testing
- Launched the local PHP server with `php -S 0.0.0.0:8000` and the server started successfully.
- Ran a Playwright script to open `frontend/monthly_dashboard.html`, `frontend/yearly_dashboard.html`, and `frontend/budgets.html` and captured screenshots, which completed successfully.
- Verified the CSS changes via search and inspected `frontend/operational_ui.css` and committed the update to the repository successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698723962eb0832ea02946569ad9dfb3)