### PR TITLE
Prevent desktop utility bar overlap with page headings

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -368,6 +368,17 @@ const resolveFrontendAsset = path => `${frontendBase}${path}`;
     </a>
   `;
   document.body.appendChild(utility);
+
+  if (content) {
+    const main = content.querySelector('main');
+    if (main) {
+      // Preserve existing mobile spacing while reserving desktop room for the
+      // injected utility bar so page titles do not sit underneath it.
+      main.classList.add('md:pt-20');
+      main.classList.remove('md:pt-0');
+    }
+  }
+
   const latestLink = document.getElementById('latest-statement-link');
   if (latestLink) {
     fetchNoCache(`${apiBase}/transaction_months.php`)


### PR DESCRIPTION
### Motivation
- Avoid the injected utility bar overlapping page headings on desktop (md+) while keeping the current mobile layout intact.

### Description
- After the utility bar is appended, reserve desktop-only top space by adding `md:pt-20` and removing `md:pt-0` on the page `main` element so authenticated pages globally have room for the utility bar, and preserve existing mobile spacing and accessibility (`aria-label`) on search controls.

### Testing
- Started a local PHP dev server and fetched `frontend/monthly_statement.html` with `curl -I` which returned `HTTP/1.1 200 OK`, and ran headless Playwright scripts to capture screenshots at `1280x900` and `1920x1080`; an initial Chromium crash occurred but subsequent runs produced screenshots, however a DOM-based overlap check in this environment did not detect the utility bar so a visual overlap assertion could not be conclusively made by the automated run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698723a74a08832e83d1697485f38886)