### PR TITLE
Align page titles left and render breadcrumbs beneath headings

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -262,7 +262,7 @@ const resolveFrontendAsset = path => `${frontendBase}${path}`;
           a.addEventListener('click', () => menu.classList.add('hidden'))
         );
 
-        // Build breadcrumb text above the page title
+        // Build breadcrumb text underneath the page title
         const current = location.pathname.split('/').pop();
         const link = menu.querySelector(`a[href="${current}"]`);
         if (link) {
@@ -283,9 +283,9 @@ const resolveFrontendAsset = path => `${frontendBase}${path}`;
           const heading = document.querySelector('main h1');
           if (section && page && heading) {
             const crumb = document.createElement('div');
-            crumb.textContent = `${section} / ${page}`.toUpperCase();
-            crumb.className = `uppercase text-${colorScheme}-900 text-[0.6rem] mb-1`;
-            heading.before(crumb);
+            crumb.textContent = `${section} / ${page}`;
+            crumb.className = `page-breadcrumb text-${colorScheme}-900`;
+            heading.insertAdjacentElement('afterend', crumb);
           }
         }
         // Display counter for untagged transactions in menu

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -18,12 +18,22 @@
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
+    text-align: left;
     gap: 0.75rem;
     margin-bottom: 1rem;
 }
 
 .page-title {
     margin: 0;
+    text-align: left;
+}
+
+.page-breadcrumb {
+    margin-top: 0.35rem;
+    font-size: 0.6rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .page-subtitle {


### PR DESCRIPTION
### Motivation
- Make page headings visually consistent by aligning main titles to the top-left and presenting breadcrumbs directly underneath the title for clearer information hierarchy.

### Description
- Updated shared header styles in `frontend/operational_ui.css` to enforce left alignment for `.page-header` and `.page-title` and added a new `.page-breadcrumb` rule for compact, uppercase breadcrumb text beneath headings.
- Modified the menu script in `frontend/js/menu.js` so the breadcrumb is created with the `page-breadcrumb` class and injected after the main `h1` (`heading.insertAdjacentElement('afterend', crumb)`) instead of being placed before it.
- Removed the inline uppercasing in the script and rely on the new CSS `text-transform: uppercase` so styling is controlled in CSS rather than JS.

### Testing
- Ran `git diff --check` to validate the patch format and found no issues (passed). 
- Started a local PHP dev server and executed a Playwright-based smoke test that navigated to `frontend/account.html` and captured a full-page screenshot to verify breadcrumb injection and title alignment (succeeded and produced an artifact).
- Performed a quick code search to confirm page title elements remain present across frontend templates after the change (sanity check succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698726d06d20832ea3c3dbfa6a9688b2)