### PR TITLE
Move transaction search to top of sidebar menu

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -356,14 +356,7 @@ const resolveFrontendAsset = path => `${frontendBase}${path}`;
   utility.className = `fixed top-2 right-2 md:top-8 md:right-12 bg-gradient-to-r from-white/80 to-${colorScheme}-100/40 backdrop-blur border border-white/40 text-${colorScheme}-700 p-1 flex items-center space-x-2 z-50 rounded-xl shadow-lg transition-all hover:from-white/90 hover:to-${colorScheme}-100/60 hover:shadow-2xl`;
 
   utility.innerHTML = `
-    <button id="quick-search-toggle" class="md:hidden p-1" aria-label="Search transactions">
-      <i class="fas fa-search h-4 w-4"></i>
-    </button>
-    <form id="quick-search-form" class="hidden md:flex items-center">
-      <input id="quick-search" type="search" placeholder="Search" aria-label="Search transactions" class="unstyled w-24 md:w-32 text-sm p-1 border-0 focus:ring-0 focus:outline-none" />
-    </form>
     <a id="latest-statement-link" href="monthly_statement.html" class="flex items-center" aria-label="Latest monthly statement">
-
       <i class="fas fa-file-invoice h-4 w-4"></i>
     </a>
   `;
@@ -392,34 +385,14 @@ const resolveFrontendAsset = path => `${frontendBase}${path}`;
       .catch(err => console.error('Latest statement load failed', err));
   }
 
-  const quickSearchForm = document.getElementById('quick-search-form');
-
-  const quickSearchToggle = document.getElementById('quick-search-toggle');
-  if (quickSearchToggle && quickSearchForm) {
-    quickSearchToggle.addEventListener('click', () => {
-      const hidden = quickSearchForm.classList.toggle('hidden');
-      if (!hidden) {
-        document.getElementById('quick-search').focus();
-        if (latestLink) latestLink.classList.add('hidden');
-      } else if (latestLink) {
-        latestLink.classList.remove('hidden');
-      }
-    });
-  }
-
-  if (quickSearchForm) {
-    quickSearchForm.addEventListener('submit', e => {
+  const sidebarSearchForm = document.getElementById('sidebar-search-form');
+  if (sidebarSearchForm) {
+    sidebarSearchForm.addEventListener('submit', e => {
       e.preventDefault();
-      const term = document.getElementById('quick-search').value.trim();
+      const term = document.getElementById('sidebar-search').value.trim();
       if (term) {
         window.location.href = `search.html?value=${encodeURIComponent(term)}`;
       }
-
-      if (quickSearchToggle && getComputedStyle(quickSearchToggle).display !== 'none') {
-        quickSearchForm.classList.add('hidden');
-        if (latestLink) latestLink.classList.remove('hidden');
-      }
-
     });
   }
 

--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -7,6 +7,13 @@
 <span id="release-number" class="bg-gray-200 text-gray-700 text-xs px-2 py-0.5 rounded mt-1">v0.0.0</span>
   </div>
 </div>
+<form id="sidebar-search-form" class="mb-4" aria-label="Search transactions">
+  <label for="sidebar-search" class="sr-only">Search transactions</label>
+  <div class="relative">
+    <i class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"></i>
+    <input id="sidebar-search" type="search" placeholder="Search" aria-label="Search transactions" class="unstyled w-full rounded-md border border-slate-300 py-2 pl-9 pr-3 text-sm focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-200" />
+  </div>
+</form>
 <div class="space-y-4">
   <div class="group">
     <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Start Here</h3>


### PR DESCRIPTION
### Motivation
- Make the transactions search more discoverable by placing it immediately under the brand header in the left sidebar rather than hidden in the utility bar. 
- Provide a consistent, accessible search experience that is usable on both mobile and desktop viewports.

### Description
- Added a new sidebar search form in `frontend/menu.php` with `id="sidebar-search-form"` and an accessible input `#sidebar-search` positioned beneath the logo/header. 
- Removed the previous quick-search UI from the utility bar in `frontend/js/menu.js` and wired the new `#sidebar-search-form` submit handler to redirect to `search.html?value=...`. 
- Kept the latest monthly statement shortcut in the utility bar unchanged and preserved aria labels and a visually hidden label for screen readers. 
- Styled the input with Tailwind utility classes and an embedded search icon so it visually matches the menu header area.

### Testing
- Ran `php -l frontend/menu.php` and it reported no syntax errors (success). 
- Ran `node --check frontend/js/menu.js` and it reported no syntax errors (success). 
- Launched a dev server and captured a page screenshot via an automated Playwright script to validate the search appears at the top of the sidebar (screenshot captured successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698727f550e0832e8ab89e269f25a648)