### PR TITLE
Remove latest monthly statement utility shortcut from header

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -349,42 +349,6 @@ const resolveFrontendAsset = path => `${frontendBase}${path}`;
   });
   document.body.appendChild(toggle);
 
-  const utility = document.createElement('div');
-  utility.id = 'utility-bar';
-
-
-  utility.className = `fixed top-2 right-2 md:top-8 md:right-12 bg-gradient-to-r from-white/80 to-${colorScheme}-100/40 backdrop-blur border border-white/40 text-${colorScheme}-700 p-1 flex items-center space-x-2 z-50 rounded-xl shadow-lg transition-all hover:from-white/90 hover:to-${colorScheme}-100/60 hover:shadow-2xl`;
-
-  utility.innerHTML = `
-    <a id="latest-statement-link" href="monthly_statement.html" class="flex items-center" aria-label="Latest monthly statement">
-      <i class="fas fa-file-invoice h-4 w-4"></i>
-    </a>
-  `;
-  document.body.appendChild(utility);
-
-  if (content) {
-    const main = content.querySelector('main');
-    if (main) {
-      // Preserve existing mobile spacing while reserving desktop room for the
-      // injected utility bar so page titles do not sit underneath it.
-      main.classList.add('md:pt-20');
-      main.classList.remove('md:pt-0');
-    }
-  }
-
-  const latestLink = document.getElementById('latest-statement-link');
-  if (latestLink) {
-    fetchNoCache(`${apiBase}/transaction_months.php`)
-      .then(r => r.json())
-      .then(months => {
-        if (months.length > 0) {
-          const { year, month } = months[0];
-          latestLink.href = `monthly_statement.html?year=${year}&month=${month}`;
-        }
-      })
-      .catch(err => console.error('Latest statement load failed', err));
-  }
-
   const sidebarSearchForm = document.getElementById('sidebar-search-form');
   if (sidebarSearchForm) {
     sidebarSearchForm.addEventListener('submit', e => {


### PR DESCRIPTION
### Motivation
- Remove the injected top-right utility that rendered the "Latest monthly statement" shortcut from the shared menu so the page chrome is less cluttered and the link is no longer shown.

### Description
- Deleted the injected utility bar markup and styling from `frontend/js/menu.js` that created the `#latest-statement-link` icon.
- Removed the client-side fetch to `transaction_months.php` that dynamically updated the latest statement `href` target.
- Removed the additional desktop top padding (`md:pt-20`) adjustment that was only needed to avoid overlap with the removed utility bar.
- Preserved the rest of the shared menu logic including the mobile toggle and layout adjustments.

### Testing
- Started the local PHP dev server with `php -S 0.0.0.0:8000` and it launched successfully. 
- Ran an automated Playwright script to load `http://127.0.0.1:8000/frontend/index.html` and captured a screenshot to validate the shortcut is no longer present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698729440854832e964487b06860638c)