### PR TITLE
Fix sidebar search redirect to consistently open transaction search page

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -355,7 +355,7 @@ const resolveFrontendAsset = path => `${frontendBase}${path}`;
       e.preventDefault();
       const term = document.getElementById('sidebar-search').value.trim();
       if (term) {
-        window.location.href = `search.html?value=${encodeURIComponent(term)}`;
+        window.location.href = `${resolveFrontendAsset('search.html')}?value=${encodeURIComponent(term)}`;
       }
     });
   }


### PR DESCRIPTION
### Motivation
- The sidebar search used a plain relative path (`search.html?value=...`) which could resolve incorrectly from some pages due to differing `frontendBase` resolution.
- Ensure the sidebar always navigates to the correct frontend asset location so searches reliably open the transaction search page.

### Description
- Updated the sidebar search submit handler in `frontend/js/menu.js` to build the destination via `resolveFrontendAsset('search.html')` instead of a plain relative path.
- The search term is still URL-encoded and passed as the `value` query parameter, leaving the `frontend/search.html` fetch behavior unchanged.

### Testing
- No automated tests were executed for this change (database-backed tests were skipped per project/instruction).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872b4643a8832e84b9ca92051610c2)