### PR TITLE
Standardize page header hero styling across frontend pages

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -11,6 +11,18 @@ const apiBase = document.body?.dataset?.apiBase || '../php_backend/public';
 const frontendBase = document.body?.dataset?.menuBase || (window.location.pathname.includes('/frontend/') ? '' : 'frontend/');
 const resolveFrontendAsset = path => `${frontendBase}${path}`;
 
+const applySharedPageHeaderLayout = () => {
+  document.querySelectorAll('main .page-header').forEach(header => {
+    header.classList.add('page-header-hero');
+    const next = header.nextElementSibling;
+    if (next && next.matches('p') && !next.classList.contains('page-subtitle')) {
+      next.classList.add('page-subtitle');
+    }
+  });
+};
+
+applySharedPageHeaderLayout();
+
   if (!document.getElementById('cards-css')) {
     const cardLink = document.createElement('link');
     cardLink.id = 'cards-css';

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -24,8 +24,25 @@
 }
 
 .page-title {
-    margin: 0;
+    margin: 0 !important;
     text-align: left;
+}
+
+.page-header-hero {
+    max-width: 72rem;
+    margin: 0 auto 1rem;
+    padding: 1.5rem;
+    border-radius: 1.5rem;
+    border: 1px solid rgba(191, 219, 254, 0.8);
+    background: linear-gradient(145deg, rgba(224, 231, 255, 0.88), rgba(219, 234, 254, 0.65));
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
+}
+
+.page-header-hero + .page-subtitle,
+.page-header-hero + p {
+    max-width: 72rem;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .page-breadcrumb {
@@ -54,6 +71,10 @@
 
     .ops-main > * + * {
         margin-top: 2rem;
+    }
+
+    .page-header-hero {
+        padding: 2rem 2.5rem;
     }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a single, site-wide header treatment that matches the settings page look so all page headings are left-aligned and visually consistent without editing each page individually.
- Avoid per-page rewrites by applying a shared CSS pattern and a small script to opt pages in automatically.

### Description
- Added a reusable `.page-header-hero` style in `frontend/operational_ui.css` that constrains width, applies rounded corners, a subtle gradient background, border and padding to match the settings-page top container and enforces consistent spacing via `max-width` and responsive padding.
- Enforced title spacing by setting `.page-title { margin: 0 !important; }` to remove inconsistencies caused by mixed heading classes across pages.
- Updated `frontend/js/menu.js` to include `applySharedPageHeaderLayout()` which automatically adds the `.page-header-hero` class to every `main .page-header` and converts an immediate following `p` into `.page-subtitle` when appropriate so pages inherit the styling without file-by-file changes.

### Testing
- Launched a local PHP server with `php -S 0.0.0.0:8000` and confirmed the server started successfully.
- Loaded `http://127.0.0.1:8000/frontend/projects.html` in an automated Playwright script and captured a screenshot to validate the new header treatment, which completed successfully.
- Changes were committed to the repository and the two modified files are `frontend/operational_ui.css` and `frontend/js/menu.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872cbd9bc0832ea2e3b1db521d3e1a)