### PR TITLE
Fix sidebar search redirect binding

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -11,6 +11,20 @@ const apiBase = document.body?.dataset?.apiBase || '../php_backend/public';
 const frontendBase = document.body?.dataset?.menuBase || (window.location.pathname.includes('/frontend/') ? '' : 'frontend/');
 const resolveFrontendAsset = path => `${frontendBase}${path}`;
 
+const attachSidebarSearchHandler = (root = document) => {
+  const sidebarSearchForm = root.getElementById('sidebar-search-form');
+  if (!sidebarSearchForm || sidebarSearchForm.dataset.bound === 'true') return;
+
+  sidebarSearchForm.dataset.bound = 'true';
+  sidebarSearchForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const term = root.getElementById('sidebar-search')?.value.trim();
+    if (term) {
+      window.location.href = `${resolveFrontendAsset('search.html')}?value=${encodeURIComponent(term)}`;
+    }
+  });
+};
+
   if (!document.getElementById('cards-css')) {
     const cardLink = document.createElement('link');
     cardLink.id = 'cards-css';
@@ -192,6 +206,7 @@ const resolveFrontendAsset = path => `${frontendBase}${path}`;
       .then(resp => resp.text())
       .then(html => {
         menu.innerHTML = html;
+        attachSidebarSearchHandler(document);
         if (frontendBase === 'frontend/') {
           menu.querySelectorAll('a[href]').forEach(linkEl => {
             const href = linkEl.getAttribute('href') || '';
@@ -349,16 +364,7 @@ const resolveFrontendAsset = path => `${frontendBase}${path}`;
   });
   document.body.appendChild(toggle);
 
-  const sidebarSearchForm = document.getElementById('sidebar-search-form');
-  if (sidebarSearchForm) {
-    sidebarSearchForm.addEventListener('submit', e => {
-      e.preventDefault();
-      const term = document.getElementById('sidebar-search').value.trim();
-      if (term) {
-        window.location.href = `${resolveFrontendAsset('search.html')}?value=${encodeURIComponent(term)}`;
-      }
-    });
-  }
+  attachSidebarSearchHandler(document);
 
   // Apply Tailwind card styling to all sections or wrap main content in a card
   document.querySelectorAll('main').forEach(main => {


### PR DESCRIPTION
### Motivation
- Sidebar search in the shared menu was submitting to the current page instead of navigating to the centralized search page when the menu is injected dynamically.
- The change ensures the dynamically-loaded menu form consistently intercepts submit events and redirects users to the search UI.

### Description
- Added a reusable helper `attachSidebarSearchHandler(root)` that wires the `#sidebar-search-form` submit to redirect to `search.html?value=...`.
- Prevent duplicate handlers by marking bound forms with a `data-bound` flag.
- Call the helper immediately after `menu.php` is injected and again as a safe fallback during initial page setup so both dynamic and static menu roots are covered.
- Removed the previous ad-hoc direct binding in favor of the centralized helper.

### Testing
- Ran a code search (`rg -n "search\.html|sidebar|Search"`) to verify relevant call sites and references, which succeeded.
- Started a local PHP dev server and attempted end-to-end verification with a Playwright script to exercise the sidebar search flow, but the environment returned `Not Found` for the expected frontend routes so the E2E check could not complete.
- Per project guidance, no database-dependent tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69872e4ac40c832ea47711cff90f0ab0)