### PR TITLE
Remove outlines from Highcharts visuals

### DIFF
--- a/frontend/js/color_map.js
+++ b/frontend/js/color_map.js
@@ -59,16 +59,15 @@ function getChartTheme() {
     const chartFont = styles.getPropertyValue('--chart-font').trim() || 'Inter, sans-serif';
     const background = 'rgba(255, 255, 255, 0)';
     const plotBackground = 'rgba(255, 255, 255, 0)';
-    const borderColor = 'rgba(255, 255, 255, 0.35)';
     return {
         colors: chartColors,
         chart: {
             style: { fontFamily: chartFont, color: text },
             backgroundColor: background,
             plotBackgroundColor: plotBackground,
-            borderColor,
+            borderColor: 'transparent',
             borderRadius: 12,
-            borderWidth: 1,
+            borderWidth: 0,
             className: 'glass-chart',
             shadow: false
         },
@@ -88,8 +87,8 @@ function getChartTheme() {
             style: { color: '#F8FAFC', fontFamily: chartFont }
         },
         plotOptions: {
-            series: { showInLegend: true, shadow: false },
-            pie: { showInLegend: true, shadow: false },
+            series: { showInLegend: true, shadow: false, borderWidth: 0 },
+            pie: { showInLegend: true, shadow: false, borderWidth: 0 },
             sunburst: { showInLegend: true, shadow: false }
         }
     };
@@ -119,8 +118,8 @@ function applyChartTheme() {
         yAxis: { labels: opts.yAxis.labels, title: opts.yAxis.title },
         tooltip: opts.tooltip,
         plotOptions: {
-            series: { shadow: opts.plotOptions.series.shadow },
-            pie: { shadow: opts.plotOptions.pie.shadow },
+            series: { shadow: opts.plotOptions.series.shadow, borderWidth: opts.plotOptions.series.borderWidth },
+            pie: { shadow: opts.plotOptions.pie.shadow, borderWidth: opts.plotOptions.pie.borderWidth },
             sunburst: { shadow: opts.plotOptions.sunburst.shadow }
         }
     };


### PR DESCRIPTION
### Motivation
- Remove visible outlines and borders from Highcharts graphics so charts render without container or series outlines to match the UI design requirement.

### Description
- Update `getChartTheme()` in `frontend/js/color_map.js` to set `chart.borderColor` to `transparent` and `chart.borderWidth` to `0` so the chart container has no outline.
- Add `borderWidth: 0` to `plotOptions.series` and `plotOptions.pie` so series and pie slices render without outlines by default.
- Include the `borderWidth` values in the runtime update payload passed to `c.update(...)` so existing charts are refreshed with the no-outline settings.

### Testing
- Started a local PHP server with `php -S 0.0.0.0:8000` and loaded `frontend/graphs.html` to visually validate the change, which succeeded.
- Ran a headless browser script (Playwright) to capture a screenshot of `http://127.0.0.1:8000/frontend/graphs.html`, which completed and produced `artifacts/highcharts-no-outline.png`.
- No database-dependent automated tests were run in accordance with project constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987359c0748832ea998826a35e4a20e)