### PR TITLE
Add reusable page header helper for operational pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,4 @@
 - Settings allow selecting fonts for headings, body text, tables and charts with options ranging from modern to funky.
 
 - Page headings use a shared pattern: `<header class="page-header">` with an `h1.page-title` and optional `.page-subtitle` / `.page-header-actions`; keep this header directly on the page canvas above the first content card.
+- Page headers should be rendered via `frontend/js/page_header.js` using `renderPageHeader(main, { title, breadcrumb, subtitle, actions })`; `title` is required, other fields are optional, and output must keep `page-header`, `page-title`, `page-breadcrumb`, and `page-subtitle` classes.

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -295,12 +295,18 @@ const attachSidebarSearchHandler = (root = document) => {
           }
           const section = link.closest('div')?.querySelector('h3')?.textContent?.trim();
           const page = link.textContent.trim();
-          const heading = document.querySelector('main h1');
-          if (section && page && heading) {
-            const crumb = document.createElement('div');
-            crumb.textContent = `${section} / ${page}`;
-            crumb.className = `page-breadcrumb text-${colorScheme}-900`;
-            heading.insertAdjacentElement('afterend', crumb);
+          const main = document.querySelector('main.ops-main');
+          const breadcrumb = section && page ? `${section} / ${page}` : '';
+          if (breadcrumb && main && typeof window.updatePageHeader === 'function') {
+            window.updatePageHeader(main, { breadcrumb: breadcrumb });
+          } else {
+            const heading = document.querySelector('main h1');
+            if (breadcrumb && heading) {
+              const crumb = document.createElement('div');
+              crumb.textContent = breadcrumb;
+              crumb.className = `page-breadcrumb text-${colorScheme}-900`;
+              heading.insertAdjacentElement('afterend', crumb);
+            }
           }
         }
         // Display counter for untagged transactions in menu

--- a/frontend/js/page_header.js
+++ b/frontend/js/page_header.js
@@ -1,0 +1,104 @@
+(function () {
+  const HEADER_SELECTOR = 'header.page-header';
+
+  function createTextElement(tagName, className, text) {
+    if (!text) {
+      return null;
+    }
+    const element = document.createElement(tagName);
+    element.className = className;
+    element.textContent = text;
+    return element;
+  }
+
+  function toActionsNode(actions) {
+    if (!actions) {
+      return null;
+    }
+
+    const actionsWrap = document.createElement('div');
+    actionsWrap.className = 'page-header-actions';
+
+    if (typeof actions === 'string') {
+      actionsWrap.innerHTML = actions;
+      return actionsWrap;
+    }
+
+    if (actions instanceof HTMLElement) {
+      actionsWrap.appendChild(actions);
+      return actionsWrap;
+    }
+
+    return null;
+  }
+
+  function getExistingOptions(main) {
+    const existingHeader = main.querySelector(':scope > ' + HEADER_SELECTOR);
+    const existingTitle = existingHeader ? existingHeader.querySelector('.page-title') : null;
+    const existingBreadcrumb = existingHeader ? existingHeader.querySelector('.page-breadcrumb') : null;
+    const existingSubtitle = existingHeader ? existingHeader.querySelector('.page-subtitle') : null;
+
+    return {
+      title: main.dataset.pageHeaderTitle || (existingTitle ? existingTitle.textContent.trim() : ''),
+      breadcrumb: main.dataset.pageHeaderBreadcrumb || (existingBreadcrumb ? existingBreadcrumb.textContent.trim() : ''),
+      subtitle: main.dataset.pageHeaderSubtitle || (existingSubtitle ? existingSubtitle.textContent.trim() : ''),
+      actions: null
+    };
+  }
+
+  function renderPageHeader(main, options) {
+    if (!main) {
+      return null;
+    }
+
+    const merged = Object.assign({}, getExistingOptions(main), options || {});
+    if (!merged.title) {
+      throw new Error('page_header: "title" is required');
+    }
+
+    const header = document.createElement('header');
+    header.className = 'page-header';
+
+    const content = document.createElement('div');
+    content.className = 'w-full text-left';
+
+    const titleEl = createTextElement('h1', 'page-title', merged.title);
+    const breadcrumbEl = createTextElement('div', 'page-breadcrumb', merged.breadcrumb);
+    const subtitleEl = createTextElement('p', 'page-subtitle', merged.subtitle);
+
+    if (titleEl) {
+      content.appendChild(titleEl);
+    }
+    if (breadcrumbEl) {
+      content.appendChild(breadcrumbEl);
+    }
+    if (subtitleEl) {
+      content.appendChild(subtitleEl);
+    }
+
+    header.appendChild(content);
+
+    const actionsNode = toActionsNode(merged.actions);
+    if (actionsNode) {
+      header.appendChild(actionsNode);
+    }
+
+    const existingHeader = main.querySelector(':scope > ' + HEADER_SELECTOR);
+    if (existingHeader) {
+      existingHeader.replaceWith(header);
+    } else {
+      main.insertBefore(header, main.firstChild);
+    }
+
+    main.__pageHeaderState = merged;
+    return header;
+  }
+
+  function updatePageHeader(main, partialOptions) {
+    const previous = main && main.__pageHeaderState ? main.__pageHeaderState : {};
+    return renderPageHeader(main, Object.assign({}, previous, partialOptions || {}));
+  }
+
+  window.renderPageHeader = renderPageHeader;
+  window.updatePageHeader = updatePageHeader;
+})();

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -23,12 +23,6 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <header class="page-header">
-                <div>
-                    <h1 id="page-title" class="page-title">Monthly Statement</h1>
-                    <p class="page-subtitle">Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.</p>
-                </div>
-            </header>
             <div class="cards">
                 <form id="statement-form" class="flex flex-wrap items-end gap-4">
                     <div class="w-full sm:w-auto">
@@ -92,6 +86,7 @@
             </div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
@@ -105,7 +100,11 @@ const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
 const form = document.getElementById('statement-form');
 const untaggedOnly = document.getElementById('untagged-only');
-const pageTitle = document.getElementById('page-title');
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Monthly Statement',
+    subtitle: 'Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.'
+});
 let table;
 
 // fetch available transaction groups once
@@ -213,7 +212,7 @@ function loadTransactions(retry = false) {
     if (!Number.isNaN(month) && !Number.isNaN(year)) {
         const monthName = new Date(year, month - 1).toLocaleString('default', { month: 'long' });
         const titleText = `Monthly Statement - ${monthName} ${year}`;
-        pageTitle.textContent = titleText;
+        window.updatePageHeader(pageMain, { title: titleText });
         document.title = titleText;
     }
 

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -16,11 +16,12 @@
 /* Reusable page header pattern: title plus optional subtitle/actions */
 .page-header {
     display: flex;
+    flex-direction: column;
     align-items: flex-start;
-    justify-content: space-between;
+    justify-content: flex-start;
     text-align: left;
-    gap: 0.75rem;
-    margin-bottom: 1rem;
+    gap: 0.35rem;
+    margin: 0;
 }
 
 .page-title {
@@ -62,6 +63,7 @@
     display: inline-flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    align-self: flex-start;
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
### Motivation
- Provide a single, reusable header component so pages render a consistent left-aligned title, breadcrumb and subtitle inside `main.ops-main`.
- Normalize spacing and alignment for headers so pages do not introduce a second container pattern and follow the shared canonical classes.

### Description
- Added a JS helper `frontend/js/page_header.js` exposing `renderPageHeader(main, { title, breadcrumb, subtitle, actions })` and `updatePageHeader(main, partialOptions)` where `title` is required and other fields are optional, and output uses the canonical classes `page-header`, `page-title`, `page-breadcrumb`, and `page-subtitle`.
- Migrated `frontend/monthly_statement.html` to initialize the shared header via `renderPageHeader` and to update the title dynamically with `updatePageHeader` as the month/year changes.
- Updated `frontend/js/menu.js` breadcrumb handling to prefer the shared header API (`updatePageHeader`) and fall back to the previous insertion logic when the helper is not present.
- Adjusted `frontend/operational_ui.css` to set `.page-header` to a column layout, tighten gaps, remove bottom margin, and ensure `.page-header-actions` aligns to the left; documented the header contract in `AGENTS.md`.

### Testing
- Ran `node --check frontend/js/page_header.js` and `node --check frontend/js/menu.js`, both succeeded.
- Ran `git diff --check` to validate whitespace/formatting checks, which reported no issues.
- Attempted an automated browser screenshot via Playwright to validate visual layout, but Chromium crashed in this environment (SIGSEGV) so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698735e67744832e888100b38c5122d9)