### PR TITLE
Set professional theme background to white

### DIFF
--- a/frontend/css/theme-professional.css
+++ b/frontend/css/theme-professional.css
@@ -1,6 +1,6 @@
 /* Optional professional theme layer with restrained surfaces and spacing */
 body.theme-professional {
-  background-color: #f8fafc;
+  background-color: #ffffff;
 }
 
 .theme-professional .rounded-3xl {
@@ -21,7 +21,7 @@ body.theme-professional {
 .theme-professional .bg-gradient-to-l,
 .theme-professional .bg-gradient-to-t {
   background-image: none !important;
-  background-color: #f8fafc !important;
+  background-color: #ffffff !important;
 }
 
 .theme-professional .ops-btn-primary,


### PR DESCRIPTION
### Motivation
- Make the professional theme use a pure white page background and ensure gradient utility classes render white when disabled to provide a restrained, professional appearance.

### Description
- Updated `frontend/css/theme-professional.css` to set `body.theme-professional { background-color: #ffffff; }` and to override `.theme-professional .bg-gradient-*` entries to `background-color: #ffffff !important;` instead of the prior slate tone.

### Testing
- No full test suite was run because this is a style-only change; a local PHP server was started with `php -S 0.0.0.0:8000` and an automated Playwright script was executed to enable the professional theme and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873766ee08832e88248da690a34a79)