### PR TITLE
Migrate operational pages to shared page header renderer

### DIFF
--- a/frontend/2fa.html
+++ b/frontend/2fa.html
@@ -22,15 +22,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-            <div class="flex items-center mb-4">
-                            <header class="page-header">
-                <h1 class="text-2xl font-semibold flex-1 text-indigo-700 page-title"><i class="fas fa-shield-halved inline w-6 h-6 mr-2"></i>Two-Factor Authentication</h1>
-            </header>
-                <button id="help-btn" class="text-indigo-600 font-light"><i class="fas fa-question-circle inline w-5 h-5"></i></button>
-            </div>
-            <p class="mb-4">Set up TOTP-based authentication and verify your one-time codes.</p>
-
-            <div class="cards mb-6">
+<div class="cards mb-6">
                   <h2 class="text-xl mb-4">Setup</h2>
                 <form id="generate-form" class="space-y-4">
                     <input id="gen-username" type="text" placeholder="Username" class="border p-2 rounded w-full" data-help="Enter your account username">
@@ -51,6 +43,16 @@
             </div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Two-Factor Authentication',
+    breadcrumb: 'Security',
+    subtitle: 'Set up TOTP-based authentication and verify your one-time codes.',
+    actions: '<button id="help-btn" class="text-indigo-600 font-light" aria-label="Open help"><i class="fas fa-question-circle inline w-5 h-5"></i></button>'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="js/overlay.js"></script>

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -22,12 +22,8 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 id="account-name" class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Account Balance</h1>
-            </header>
-            <p id="account-details" class="mb-4 text-gray-600"></p>
-            <p class="mb-4">View the balance over time based on the latest bank statement.</p>
-            <div class="cards">
+<p id="account-details" class="mb-4 text-gray-600"></p>
+<div class="cards">
                 <div id="balance-chart" style="height:400px" data-chart-desc="Line chart of account balance over time."></div>
             </div>
 
@@ -37,6 +33,15 @@
 
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Account Balance',
+    breadcrumb: 'Accounts',
+    subtitle: 'View the balance over time based on the latest bank statement.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
 
@@ -74,7 +79,7 @@
                     document.getElementById('balance-chart').textContent = 'Account not found.';
                     return;
                 }
-                document.getElementById('account-name').textContent = data.name;
+                window.updatePageHeader(pageMain, { title: data.name });
                 const details = data.sort_code ? `Sort Code: ${data.sort_code}  Account Number: ${data.account_number}` : `Card Number: ${data.account_number}`;
                 document.getElementById('account-details').textContent = details;
                 const dates = data.history.map(h => h.date);

--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -22,16 +22,21 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Account Dashboard</h1>
-            </header>
-            <p class="mb-4">See an overview of account balances and recent activity. Charts and tables reveal how money flows through each account. Sort codes and account numbers are shown where applicable; credit cards list only their card number.</p>
-            <div class="cards">
+<div class="cards">
                 <div id="accounts-table"></div>
                 <div id="accounts-chart" class="mt-4" style="height:400px" data-chart-desc="Waterfall chart showing balance changes per account."></div>
             </div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Account Dashboard',
+    breadcrumb: 'Dashboards / Accounts',
+    subtitle: 'See an overview of account balances and recent activity. Charts and tables reveal how money flows through each account. Sort codes and account numbers are shown where applicable; credit cards list only their card number.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>

--- a/frontend/ai_feedback.html
+++ b/frontend/ai_feedback.html
@@ -19,11 +19,7 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-                    <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">AI Feedback</h1>
-            </header>
-        <p class="mb-4">Request an AI-generated overview of your finances for the last 12 months.</p>
-        <section>
+<section>
             <button id="run" class="bg-indigo-600 text-white px-4 py-2 rounded">
                 <i class="fas fa-comments-dollar inline w-4 h-4 mr-1"></i>Generate Feedback
             </button>
@@ -40,7 +36,16 @@
         </section>
     </main>
 </div>
-<script src="js/menu.js"></script>
+<script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'AI Feedback',
+    breadcrumb: 'AI',
+    subtitle: 'Request an AI-generated overview of your finances for the last 12 months.'
+});
+</script>
+    <script src="js/menu.js"></script>
 <script src="js/input_help.js"></script>
 <script src="js/overlay.js"></script>
 <script>

--- a/frontend/ai_tags.html
+++ b/frontend/ai_tags.html
@@ -19,10 +19,7 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-                    <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">AI Tags</h1>
-            </header>
-        <p class="mb-4">Configure OpenAI and automatically tag transactions.</p>
+<p class="mb-4">Configure OpenAI and automatically tag transactions.</p>
 
         <section>
             <h2 class="text-xl font-semibold mb-2">OpenAI Token</h2>
@@ -49,7 +46,16 @@
         </section>
     </main>
 </div>
-<script src="js/menu.js"></script>
+<script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'AI Tags',
+    breadcrumb: 'AI',
+    subtitle: 'Use AI to suggest tags for uncategorised transactions and apply them in bulk.'
+});
+</script>
+    <script src="js/menu.js"></script>
 <script src="js/input_help.js"></script>
 <script src="js/overlay.js"></script>
 <script>

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -23,10 +23,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">All Years Dashboard</h1>
-            </header>
-            <p class="mb-4">Compare financial totals across every recorded year to reveal long-term trends and patterns in your finances.</p>
+<p class="mb-4">Compare financial totals across every recorded year to reveal long-term trends and patterns in your finances.</p>
 
             <section class="cards cards-tight mt-6">
                 <h2 class="text-xl font-semibold mb-2">Tag Totals</h2>
@@ -61,6 +58,15 @@
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'All Years Dashboard',
+    breadcrumb: 'Dashboards / Multi-year',
+    subtitle: 'Compare trends across every available year to spot long-term spending and income patterns.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>

--- a/frontend/backup.html
+++ b/frontend/backup.html
@@ -20,10 +20,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Backup &amp; Restore</h1>
-            </header>
-            <p class="mb-4">Create backups of your data or restore from an earlier snapshot. Use the tools below to download a copy of your information or load a previous backup.</p>
+<p class="mb-4">Create backups of your data or restore from an earlier snapshot. Use the tools below to download a copy of your information or load a previous backup.</p>
             <section class="cards space-y-4">
                 <h2 class="text-xl font-semibold">Download Backup</h2>
 
@@ -56,6 +53,15 @@
         </main>
     </div>
 
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Backup & Restore',
+    breadcrumb: 'Data Management',
+    subtitle: 'Create backups of your data, restore previous snapshots, and keep your records safe.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="js/overlay.js"></script>

--- a/frontend/budgets.html
+++ b/frontend/budgets.html
@@ -22,10 +22,7 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                    <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Budgets</h1>
-            </header>
-        <p class="mb-4">Set monthly spending limits for categories and monitor progress. Use this page to plan ahead and see where you may need to adjust your spending.</p>
+<p class="mb-4">Set monthly spending limits for categories and monitor progress. Use this page to plan ahead and see where you may need to adjust your spending.</p>
         <section class="ops-section">
             <form id="budget-form" class="ops-form-grid cols-4">
                 <label class="ops-field" for="month">
@@ -84,7 +81,16 @@
         </section>
     </main>
 </div>
-<script src="js/menu.js"></script>
+<script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Budgets',
+    breadcrumb: 'Planning',
+    subtitle: 'Set monthly budget targets and compare them against actual spending by category.'
+});
+</script>
+    <script src="js/menu.js"></script>
 <script src="js/input_help.js"></script>
 <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
 <script src="js/tabulator-tailwind.js"></script>

--- a/frontend/categories.html
+++ b/frontend/categories.html
@@ -20,10 +20,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Manage Categories</h1>
-            </header>
-            <p class="mb-4">Create categories and assign tags to organise your transactions. A well-maintained list keeps reports clear and makes searching easier.</p>
+<p class="mb-4">Create categories and assign tags to organise your transactions. A well-maintained list keeps reports clear and makes searching easier.</p>
             <section class="cards cards-tight">
             <form id="category-form" class="space-y-4">
                 <label class="block">Category Name<br><input type="text" id="category-name" class="border p-2 rounded w-full" data-help="Name for the category"></label>
@@ -40,6 +37,15 @@
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Manage Categories',
+    breadcrumb: 'Transactions / Configuration',
+    subtitle: 'Create and maintain categories used to organise transactions and reporting.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="js/category_drag.js"></script>

--- a/frontend/dedupe.html
+++ b/frontend/dedupe.html
@@ -20,10 +20,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Duplicate Transactions</h1>
-            </header>
-            <p class="mb-4">Remove unwanted duplicate entries to keep your records accurate.</p>
+<p class="mb-4">Remove unwanted duplicate entries to keep your records accurate.</p>
             <div class="cards">
                 <div class="mb-4 space-x-2">
                     <button id="refresh" class="bg-indigo-600 text-white px-3 py-1 rounded"><i class="fas fa-rotate inline w-4 h-4 mr-1"></i>Refresh</button>
@@ -36,6 +33,15 @@
             </div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Duplicate Transactions',
+    breadcrumb: 'Transactions / Data Quality',
+    subtitle: 'Review potential duplicate transactions and remove any accidental repeats.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>

--- a/frontend/export.html
+++ b/frontend/export.html
@@ -19,10 +19,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Exports</h1>
-            </header>
-            <p class="mb-4">Download transactions for a chosen period in your preferred format.</p>
+<p class="mb-4">Download transactions for a chosen period in your preferred format.</p>
             <section class="space-y-4">
                 <h2 class="text-xl font-semibold">Create Export</h2>
                 <div class="flex flex-col md:flex-row md:space-x-4 space-y-4 md:space-y-0">
@@ -49,6 +46,15 @@
         </main>
     </div>
 
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Exports',
+    breadcrumb: 'Data Management',
+    subtitle: 'Export transactions and related data in CSV, OFX, or XLSX formats.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="js/overlay.js"></script>

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -19,10 +19,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-4">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold text-indigo-700 page-title">Graphs</h1>
-            </header>
-            <p class="mb-4">Explore a collection of charts that illustrate your income and spending patterns. Choose a year to see how your finances evolve and compare categories or tags visually.</p>
+<p class="mb-4">Explore a collection of charts that illustrate your income and spending patterns. Choose a year to see how your finances evolve and compare categories or tags visually.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full"></select>
             </label>
@@ -68,6 +65,15 @@
         </main>
     </div>
 
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Graphs',
+    breadcrumb: 'Reports & Analysis',
+    subtitle: 'Visualise transaction data through interactive charts.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>
     <script src="https://code.highcharts.com/highcharts-more.js"></script>

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -22,10 +22,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Group Dashboard</h1>
-            </header>
-            <p class="mb-4">Review group spending by month and year to see how different areas of your budget change over time.</p>
+<p class="mb-4">Review group spending by month and year to see how different areas of your budget change over time.</p>
             <label for="year-select" class="block">Year:
                 <select id="year-select" class="border p-2 rounded w-full" data-help="Select year"></select>
             </label>
@@ -43,6 +40,15 @@
             </div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Group Dashboard',
+    breadcrumb: 'Dashboards / Groups',
+    subtitle: 'Track performance and balances by transaction group.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>

--- a/frontend/groups.html
+++ b/frontend/groups.html
@@ -22,10 +22,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Manage Groups</h1>
-            </header>
-            <p class="mb-4">Create groups to collect related categories for reporting and analysis. Grouping similar categories helps you see broader spending patterns.</p>
+<p class="mb-4">Create groups to collect related categories for reporting and analysis. Grouping similar categories helps you see broader spending patterns.</p>
             <section class="cards cards-tight">
             <form id="group-form" class="space-y-4">
                 <label class="block">Group Name<br><input type="text" id="group-name" class="border p-2 rounded w-full" data-help="Name for the group"></label>
@@ -39,6 +36,15 @@
             </div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Manage Groups',
+    breadcrumb: 'Transactions / Configuration',
+    subtitle: 'Create and edit transaction groups used for organisation and reporting.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>

--- a/frontend/ignored.html
+++ b/frontend/ignored.html
@@ -19,15 +19,21 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Ignored Transactions</h1>
-            </header>
-            <p class="mb-4">Transactions tagged with <strong>IGNORE</strong> are hidden from dashboards and reports. Use this page to review and restore them.</p>
+<p class="mb-4">Transactions tagged with <strong>IGNORE</strong> are hidden from dashboards and reports. Use this page to review and restore them.</p>
             <section class="cards cards-tight">
                 <div id="ignored-table"></div>
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Ignored Transactions',
+    breadcrumb: 'Transactions / Data Quality',
+    subtitle: 'Review transactions marked as ignored so they are excluded from analysis.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -22,10 +22,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Application Logs</h1>
-            </header>
-            <p class="mb-4">Review recent log entries to monitor system activity. Filtering by time or keyword helps you trace what happened during a specific event.</p>
+<p class="mb-4">Review recent log entries to monitor system activity. Filtering by time or keyword helps you trace what happened during a specific event.</p>
             <div class="mb-4 flex items-center space-x-2">
                 <label class="text-sm">Days to keep/show:
                     <input type="number" id="log-days" value="30" class="border p-1 w-20 rounded ml-1" data-help="Number of days of log entries to display and retain when pruning">
@@ -37,6 +34,15 @@
         </main>
     </div>
 
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Application Logs',
+    breadcrumb: 'Administration',
+    subtitle: 'Inspect application log output to troubleshoot issues.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>

--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -21,15 +21,21 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Missing Tags</h1>
-            </header>
-            <p class="mb-4">Identify transactions that have not yet been tagged so you can assign categories before they slip through your reports.</p>
+<p class="mb-4">Identify transactions that have not yet been tagged so you can assign categories before they slip through your reports.</p>
             <section class="cards cards-tight">
                 <div id="untagged-table"></div>
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Missing Tags',
+    breadcrumb: 'Transactions / Data Quality',
+    subtitle: 'Find transactions that still need tags so reports stay accurate.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -21,10 +21,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Monthly Dashboard</h1>
-            </header>
-            <p class="mb-4">View income and outgoings for a chosen month. Compare different months to spot trends and track progress toward your goals.</p>
+<p class="mb-4">View income and outgoings for a chosen month. Compare different months to spot trends and track progress toward your goals.</p>
             <section class="ops-section">
                 <form class="ops-form-grid cols-3" aria-label="Monthly dashboard filters">
                     <label for="year-select" class="ops-field"><span class="ops-label">Year</span>
@@ -98,6 +95,15 @@
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Monthly Dashboard',
+    breadcrumb: 'Dashboards / Monthly',
+    subtitle: 'Review monthly income, expenses, and trends with chart and table summaries.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>

--- a/frontend/monthly_statement.html
+++ b/frontend/monthly_statement.html
@@ -87,6 +87,14 @@
         </main>
     </div>
     <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Monthly Statement',
+    breadcrumb: 'Transactions / Statements',
+    subtitle: 'Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
@@ -100,11 +108,6 @@ const monthSelect = document.getElementById('month');
 const yearSelect = document.getElementById('year');
 const form = document.getElementById('statement-form');
 const untaggedOnly = document.getElementById('untagged-only');
-const pageMain = document.querySelector('main.ops-main');
-window.renderPageHeader(pageMain, {
-    title: 'Monthly Statement',
-    subtitle: 'Select a month to view a detailed list of transactions. Reviewing each line ensures the data is accurate and properly tagged.'
-});
 let table;
 
 // fetch available transaction groups once

--- a/frontend/palette.html
+++ b/frontend/palette.html
@@ -6,9 +6,9 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
   <title>Palette Settings</title>
   <script>
-      window.tailwind = window.tailwind || {};
-      window.tailwind.config = {};
-  </script>
+        window.tailwind = window.tailwind || {};
+        window.tailwind.config = {};
+    </script>
 
   <script src="https://cdn.tailwindcss.com"></script>
 
@@ -18,11 +18,7 @@
   <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                  <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Palette Settings</h1>
-            </header>
-
-      <div class="cards space-y-4">
+<div class="cards space-y-4">
         <ul class="list-disc pl-5 text-gray-700">
           <li>Set segment colours using the picker beside each name. Ticking <em>Lock</em> keeps your choice.</li>
           <li>To reset a segment, untick its <em>Lock</em> box and press <strong>Refresh</strong>.</li>
@@ -37,7 +33,16 @@
       </div>
     </main>
   </div>
-  <script src="js/menu.js"></script>
+  <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Palette Settings',
+    breadcrumb: 'Settings / Appearance',
+    subtitle: 'Adjust chart and interface palette behaviour using hue, lightness, and chroma controls.'
+});
+</script>
+    <script src="js/menu.js"></script>
   <script src="js/input_help.js"></script>
   <script src="js/overlay.js"></script>
   <script type="module" src="js/palette_ui.js"></script>

--- a/frontend/pivot.html
+++ b/frontend/pivot.html
@@ -22,10 +22,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Pivot Analysis</h1>
-            </header>
-            <p class="mb-4">Explore transactions using a flexible pivot table. Choose a year or analyse all recorded data.</p>
+<p class="mb-4">Explore transactions using a flexible pivot table. Choose a year or analyse all recorded data.</p>
             <section class="cards cards-tight space-y-4">
                 <div class="flex flex-col md:flex-row md:items-end md:space-x-4 space-y-4 md:space-y-0">
                     <div class="flex flex-col">
@@ -55,6 +52,15 @@
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Pivot Analysis',
+    breadcrumb: 'Reports & Analysis',
+    subtitle: 'Explore transaction data with pivoted summaries across key dimensions.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="js/overlay.js"></script>

--- a/frontend/processes.html
+++ b/frontend/processes.html
@@ -20,10 +20,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Run Processes</h1>
-            </header>
-            <p class="mb-4">Run background tasks like auto-tagging, category or segment assignment. These automated processes tidy your data so reports stay accurate without manual effort.</p>
+<p class="mb-4">Run background tasks like auto-tagging, category or segment assignment. These automated processes tidy your data so reports stay accurate without manual effort.</p>
             <div class="space-x-4">
                 <button id="tagging-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-tags inline w-4 h-4 mr-1"></i>Run Tagging</button>
                 <button id="categories-btn" class="bg-indigo-600 text-white px-4 py-2 rounded"><i class="fas fa-folder-open inline w-4 h-4 mr-1"></i>Apply Categories</button>
@@ -35,6 +32,15 @@
             </div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Run Processes',
+    breadcrumb: 'Administration',
+    subtitle: 'Run maintenance and analysis processes to keep data and insights up to date.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script>
     // Trigger a backend process with a progress indicator

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -20,10 +20,7 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-                    <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Add Project</h1>
-            </header>
-        <p class="mb-4">Capture ideas for home projects and detail their costs and benefits.</p>
+<p class="mb-4">Capture ideas for home projects and detail their costs and benefits.</p>
 
         <section class="cards">
             <h2 class="text-xl font-semibold mb-4">Project Details</h2>
@@ -69,7 +66,16 @@
     </main>
 </div>
 
-<script src="js/menu.js"></script>
+<script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Add Project',
+    breadcrumb: 'Projects',
+    subtitle: 'Create a new project and set its core details and benefit assumptions.'
+});
+</script>
+    <script src="js/menu.js"></script>
 <script src="js/input_help.js"></script>
 <script>
 async function loadProject(){

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -23,10 +23,7 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-                    <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Projects</h1>
-            </header>
-        <p class="mb-4">Review your planned projects, explore costs and compare their priorities.</p>
+<p class="mb-4">Review your planned projects, explore costs and compare their priorities.</p>
 
         <section class="grid gap-6 xl:grid-cols-3 auto-rows-min">
             <div class="cards cards-snug flex flex-col space-y-6">
@@ -95,7 +92,16 @@
     </main>
 </div>
 
-<script src="js/menu.js"></script>
+<script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Projects',
+    breadcrumb: 'Projects',
+    subtitle: 'Manage active projects, update details, and track outcomes.'
+});
+</script>
+    <script src="js/menu.js"></script>
 <script src="js/input_help.js"></script>
 <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
 <script src="js/tabulator-tailwind.js"></script>

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -21,17 +21,23 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-                    <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Archived Projects</h1>
-            </header>
-        <p class="mb-4">Review projects that have been archived. Restore any project to make it active again.</p>
+<p class="mb-4">Review projects that have been archived. Restore any project to make it active again.</p>
         <section class="cards">
             <div id="archived-projects-table"></div>
         </section>
     </main>
 </div>
 
-<script src="js/menu.js"></script>
+<script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Archived Projects',
+    breadcrumb: 'Projects',
+    subtitle: 'Review archived projects and restore them when needed.'
+});
+</script>
+    <script src="js/menu.js"></script>
 <script src="js/input_help.js"></script>
 <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
 <script src="js/tabulator-tailwind.js"></script>

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -21,10 +21,7 @@
 <div class="flex min-h-screen">
     <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
     <main class="ops-main flex-1 min-w-0 overflow-x-auto space-y-6">
-                    <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Project Board</h1>
-            </header>
-        <p class="mb-4">Browse all active projects in a card layout.</p>
+<p class="mb-4">Browse all active projects in a card layout.</p>
 
         <section class="cards cards-solid cards-tight space-y-4">
             <div class="flex flex-col lg:flex-row lg:items-end gap-3">
@@ -63,7 +60,16 @@
     </main>
 </div>
 
-<script src="js/menu.js"></script>
+<script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Project Board',
+    breadcrumb: 'Projects',
+    subtitle: 'View active projects as cards with key status details and quick actions.'
+});
+</script>
+    <script src="js/menu.js"></script>
 <script src="js/input_help.js"></script>
 <script>
 function fmtMoney(v){

--- a/frontend/recurring_spend.html
+++ b/frontend/recurring_spend.html
@@ -22,10 +22,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Recurring Spend Detection</h1>
-            </header>
-            <p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses. The results highlight ongoing commitments so you know where money leaves your account regularly.</p>
+<p class="mb-4">Run an analysis of the last 12 months to find subscriptions and other repeat expenses. The results highlight ongoing commitments so you know where money leaves your account regularly.</p>
             <button id="run-analysis" class="bg-indigo-600 text-white px-4 py-2 rounded mb-4"><i class="fas fa-chart-line inline w-4 h-4 mr-2"></i>Run Analysis</button>
             <h2 class="text-xl font-semibold mt-6 mb-2">Recurring Outgoings</h2>
             <div id="outgoing-grid"></div>
@@ -38,6 +35,15 @@
             <p id="income-next" class="text-right"></p>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Recurring Spend Detection',
+    breadcrumb: 'Reports & Analysis',
+    subtitle: 'Identify recurring expenses and understand repeated spending commitments.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
     <script src="js/tabulator-tailwind.js"></script>

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -23,10 +23,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Transaction Reports</h1>
-            </header>
-            <p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>
+<p class="mb-4">Generate detailed transaction reports filtered by your chosen criteria. Use the results to review spending habits or export data for further analysis.</p>
             <form id="report-form" class="cards cards-tight grid grid-cols-1 md:grid-cols-3 gap-4">
                 <label class="block md:col-span-3">Ask in plain English:
                     <input type="text" id="nl-query" class="border p-2 rounded w-full" placeholder="e.g., costs for cars in the last 12 months" data-help="Describe the report you want in plain English">
@@ -68,6 +65,15 @@
             </div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Transaction Reports',
+    breadcrumb: 'Reports & Analysis',
+    subtitle: 'Build and save transaction reports with charts and category breakdowns.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://code.highcharts.com/highcharts.js"></script>

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -22,10 +22,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Search Transactions</h1>
-            </header>
-            <p class="mb-4">Find specific transactions using keywords and view the results below. Quick searches help you jump straight to the entries you need.</p>
+<p class="mb-4">Find specific transactions using keywords and view the results below. Quick searches help you jump straight to the entries you need.</p>
             <section class="cards cards-tight">
             <form id="search-form" class="space-y-4">
                 <input type="text" id="term" placeholder="Search value" class="border p-2 rounded w-full" data-help="Value to search across transactions">
@@ -43,6 +40,15 @@
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Search Transactions',
+    breadcrumb: 'Transactions',
+    subtitle: 'Search across transactions using flexible filters and keywords.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>

--- a/frontend/segments.html
+++ b/frontend/segments.html
@@ -20,10 +20,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Manage Segments</h1>
-            </header>
-            <p class="mb-4">Create segments to group categories for broader analysis. Drag categories between segments to adjust their grouping.</p>
+<p class="mb-4">Create segments to group categories for broader analysis. Drag categories between segments to adjust their grouping.</p>
             <section class="cards cards-tight">
             <form id="segment-form" class="space-y-4">
                 <label class="block">Segment Name<br><input type="text" id="segment-name" class="border p-2 rounded w-full" data-help="Name for the segment"></label>
@@ -39,6 +36,15 @@
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Manage Segments',
+    breadcrumb: 'Transactions / Configuration',
+    subtitle: 'Maintain spending segments used for deeper analysis and reporting.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="js/segment_drag.js"></script>

--- a/frontend/tags.html
+++ b/frontend/tags.html
@@ -22,10 +22,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Manage Tags</h1>
-            </header>
-            <p class="mb-4">Create new tags and manage existing ones for categorising transactions. Tags act like labels that make reports and searches more meaningful.</p>
+<p class="mb-4">Create new tags and manage existing ones for categorising transactions. Tags act like labels that make reports and searches more meaningful.</p>
             <section class="cards cards-tight">
             <form id="tag-form" class="space-y-4">
                 <label class="block">Tag Name<br><input type="text" id="tag-name" class="border p-2 rounded w-full" data-help="Name for the tag"></label>
@@ -40,6 +37,15 @@
             </div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Manage Tags',
+    breadcrumb: 'Transactions / Configuration',
+    subtitle: 'Create and update tags used to classify transactions.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>

--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -26,13 +26,18 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Transaction Details</h1>
-            </header>
-            <p class="mb-4">Review or edit the information for a single transaction. Changes here immediately update dashboards, reports and budgets.</p>
-            <div id="transaction-details" class="mt-4"></div>
+<div id="transaction-details" class="mt-4"></div>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Transaction Details',
+    breadcrumb: 'Transactions',
+    subtitle: 'Review or edit the information for a single transaction. Changes here immediately update dashboards, reports and budgets.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script>

--- a/frontend/transfers.html
+++ b/frontend/transfers.html
@@ -20,21 +20,9 @@
 <body class="ops-body">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
-        <main class="flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
+        <main class="ops-main flex-1 min-w-0 overflow-x-auto p-6 space-y-6">
             <section class="cards cards-tight">
-                            <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 flex items-center justify-between text-indigo-700 page-title">
-                                    Detected Transfers
-                
-                                    <span class="space-x-2">
-                                        <button id="assist-btn" class="bg-indigo-600 text-white px-3 py-1 rounded text-sm"><i class="fas fa-magic inline w-4 h-4 mr-1"></i>Assist</button>
-                                        <button id="mark-all" class="bg-green-600 text-white px-3 py-1 rounded text-sm"><i class="fas fa-check-double inline w-4 h-4 mr-1"></i>Mark All</button>
-                                    </span>
-                
-                                </h1>
-            </header>
-                <p class="mb-4">Manage possible transfers between accounts and mark them so they don't count toward income or outgoings.</p>
-                <div id="transfers-table"></div>
+<div id="transfers-table"></div>
             </section>
             <section class="cards cards-tight">
                 <h2 class="text-xl font-semibold mb-4 flex items-center justify-between">
@@ -53,6 +41,16 @@
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Detected Transfers',
+    breadcrumb: 'Transactions / Data Quality',
+    subtitle: "Manage possible transfers between accounts and mark them so they don't count toward income or outgoings.",
+    actions: '<span class="space-x-2"><button id="assist-btn" class="bg-indigo-600 text-white px-3 py-1 rounded text-sm" aria-label="Assist with transfer matching"><i class="fas fa-magic inline w-4 h-4 mr-1"></i>Assist</button><button id="mark-all" class="bg-green-600 text-white px-3 py-1 rounded text-sm" aria-label="Mark all detected transfers"><i class="fas fa-check-double inline w-4 h-4 mr-1"></i>Mark All</button></span>'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>

--- a/frontend/upload.html
+++ b/frontend/upload.html
@@ -19,11 +19,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Upload OFX Files</h1>
-            </header>
-        <p class="mb-4">Upload one or more OFX statements from your bank to import transactions into the system. The file contents will be processed and your data added to the database for review.</p>
-            <form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data" class="space-y-4">
+<form action="../php_backend/public/upload_ofx.php" method="POST" enctype="multipart/form-data" class="space-y-4">
                 <input type="file" name="ofx_files[]" accept=".ofx" multiple required class="block w-full" data-help="Select one or more OFX files to upload">
                 <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded">Upload</button>
                 <div id="progress-container" class="space-y-2"></div>
@@ -31,6 +27,15 @@
         </main>
     </div>
 
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Upload OFX Files',
+    breadcrumb: 'Data Management',
+    subtitle: 'Upload one or more OFX statements from your bank to import transactions into the system. The file contents will be processed and your data added to the database for review.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="js/overlay.js"></script>

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -21,11 +21,7 @@
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">
-                        <header class="page-header">
-                <h1 class="text-2xl font-semibold mb-4 text-indigo-700 page-title">Yearly Dashboard</h1>
-            </header>
-            <p class="mb-4">Analyse totals for a single year through charts and tables to understand how income and spending evolved month by month.</p>
-            <section class="ops-section">
+<section class="ops-section">
                 <form class="ops-form-grid cols-2" aria-label="Yearly dashboard filters">
                     <label for="year-select" class="ops-field"><span class="ops-label">Year</span>
                         <select id="year-select" class="ops-select" data-help="Select year to display"></select>
@@ -79,6 +75,15 @@
             </section>
         </main>
     </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Yearly Dashboard',
+    breadcrumb: 'Dashboards / Yearly',
+    subtitle: 'Analyse totals for a single year through charts and tables to understand how income and spending evolved month by month.'
+});
+</script>
     <script src="js/menu.js"></script>
     <script src="js/input_help.js"></script>
     <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>


### PR DESCRIPTION
### Motivation
- Standardise page headers across operational pages by replacing bespoke header markup with the shared header component to improve consistency and simplify future styling/behaviour changes. 
- Remove redundant per-page top-level header wrappers so each page is governed by a single `main.ops-main` layout container for consistent spacing and alignment. 
- Preserve existing per-page actions and dynamic behaviour (e.g. 2FA help, Transfers assist/mark-all, account title updates) while moving them into the shared header API.

### Description
- Replaced bespoke `<header class="page-header">` blocks with calls to `window.renderPageHeader(pageMain, { title, breadcrumb, subtitle, actions })` across 35 frontend pages and added `js/page_header.js` where missing. 
- Removed extra wrapper markup that produced a second top-level container on each page so content now sits under a single `main.ops-main` container. 
- Preserved and moved per-page header actions into the shared header `actions` slot (notably the 2FA help button and Transfers `Assist` / `Mark All` controls). 
- Updated `account.html` to dynamically update the shared header title using `window.updatePageHeader(pageMain, { title: data.name })` when account data loads.

### Testing
- Verified old static headers were removed with `rg -n "<header class=\"page-header\""` and confirmed `window.renderPageHeader(pageMain, ...)` calls were present across the migrated files using `rg -n "window.renderPageHeader\(pageMain"` (expected matches found). 
- Started a local PHP server with `php -S 0.0.0.0:8000` and rendered a migrated page to capture a screenshot to validate header rendering; the server responded and the screenshot was generated successfully. 
- No tests requiring the database were executed in accordance with constraints; automated validation steps above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698736ff8748832ea5ff0b063ba7d18b)