### PR TITLE
Style page headers as cards and enlarge titles

### DIFF
--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -22,11 +22,19 @@
     text-align: left;
     gap: 0.35rem;
     margin: 0;
+    width: 100%;
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
 .page-title {
     margin: 0 !important;
     text-align: left;
+    font-size: 200% !important;
+    line-height: 1.2;
 }
 
 .page-header-hero {


### PR DESCRIPTION
### Motivation
- Ensure every page header appears inside a consistent card container and make page titles visibly larger (approx. 100% bigger) to improve emphasis and layout consistency across the app.

### Description
- Updated `frontend/operational_ui.css` to render `.page-header` as a white card with full-width background, border, rounded corners, padding, and a subtle shadow so headers appear as cards across pages.
- Increased `.page-title` to `200%` with `line-height: 1.2` so h1 titles are roughly 100% larger and remain readable.

### Testing
- Started a local server with `php -S 0.0.0.0:8000` and captured a visual verification using Playwright against `frontend/index.html`, which succeeded.
- No automated tests requiring a database were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873a3b63c0832eb8b982b64abb752d)