### PR TITLE
Make page header card background transparent

### DIFF
--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -23,7 +23,7 @@
     gap: 0.35rem;
     margin: 0;
     width: 100%;
-    background: #ffffff;
+    background: transparent;
     border: 1px solid #e2e8f0;
     border-radius: 0.75rem;
     padding: 1.5rem;


### PR DESCRIPTION
### Motivation
- Allow page header cards to show the underlying page background/gradient by switching the header surface from an opaque white fill to transparent so the new header treatment visually integrates with the page while preserving border and elevation.

### Description
- Updated the `.page-header` rule in `frontend/operational_ui.css` to use `background: transparent` instead of `#ffffff`, keeping the existing border, padding and box-shadow.

### Testing
- Performed automated frontend checks using Playwright screenshots: the Chromium run crashed (failed) but the Firefox run succeeded and produced a screenshot showing the transparent header.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698743161da4832eab2e7e4eab9c1c9a)