### PR TITLE
Use color scheme colour for page header titles

### DIFF
--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -35,6 +35,7 @@
     text-align: left;
     font-size: 200% !important;
     line-height: 1.2;
+    color: var(--segment-1-base, #4338ca);
 }
 
 .page-header-hero {


### PR DESCRIPTION
### Motivation
- Ensure the main page title colour follows the active colour scheme so page headings match the configured palette across the app.

### Description
- Set the `.page-title` colour to `var(--segment-1-base, #4338ca)` in `frontend/operational_ui.css` so titles inherit the active segment palette.

### Testing
- Ran `git diff --check` which passed.
- Captured a UI screenshot using Playwright (Firefox) to verify the title colour; an attempted Chromium run failed in this environment due to browser launch errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698744155bf0832e9079e9234498f42d)