### PR TITLE
Professional theme: white app background and remove chart outlines

### DIFF
--- a/frontend/css/theme-professional.css
+++ b/frontend/css/theme-professional.css
@@ -3,6 +3,14 @@ body.theme-professional {
   background-color: #ffffff;
 }
 
+body.theme-professional.ops-body {
+  background-image: none;
+}
+
+.theme-professional .ops-main {
+  background-color: #ffffff;
+}
+
 .theme-professional .rounded-3xl {
   border-radius: 0.75rem !important;
 }
@@ -41,4 +49,17 @@ body.theme-professional {
 .theme-professional .text-indigo-700,
 .theme-professional .text-indigo-600 {
   color: #334155 !important;
+}
+
+.theme-professional .highcharts-container,
+.theme-professional .highcharts-container.glass-chart {
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+.theme-professional .highcharts-background,
+.theme-professional .highcharts-plot-background,
+.theme-professional .highcharts-plot-border {
+  stroke-width: 0 !important;
+  stroke: transparent !important;
 }

--- a/frontend/graphs.html
+++ b/frontend/graphs.html
@@ -340,7 +340,7 @@ window.renderPageHeader(pageMain, {
 
             Highcharts.chart('scatter-chart', {
                 colors: chartColors,
-                chart: { type: 'bubble', plotBorderWidth: 1 },
+                chart: { type: 'bubble', plotBorderWidth: 0 },
                 title: { text: 'Income vs Outgoings' },
                 xAxis: {
                     title: { text: 'Income (£)' },

--- a/frontend/js/color_map.js
+++ b/frontend/js/color_map.js
@@ -54,6 +54,7 @@ try {
 }
 
 function getChartTheme() {
+    const isProfessionalTheme = document.body.classList.contains('theme-professional');
     const text = '#0f172a';
     const styles = getComputedStyle(document.documentElement);
     const chartFont = styles.getPropertyValue('--chart-font').trim() || 'Inter, sans-serif';
@@ -66,15 +67,18 @@ function getChartTheme() {
             backgroundColor: background,
             plotBackgroundColor: plotBackground,
             borderColor: 'transparent',
+            plotBorderColor: 'transparent',
+            plotBorderWidth: 0,
             borderRadius: 12,
             borderWidth: 0,
-            className: 'glass-chart',
+            className: isProfessionalTheme ? 'glass-chart-professional' : 'glass-chart',
             shadow: false
         },
         credits: { enabled: false },
         legend: {
             enabled: true,
             backgroundColor: 'rgba(255, 255, 255, 0.08)',
+            borderWidth: 0,
             borderRadius: 12,
             itemStyle: { fontSize: '10px', color: text, fontFamily: chartFont }
         },
@@ -104,6 +108,8 @@ function applyChartTheme() {
             plotBackgroundColor: opts.chart.plotBackgroundColor,
             className: opts.chart.className,
             borderColor: opts.chart.borderColor,
+            plotBorderColor: opts.chart.plotBorderColor,
+            plotBorderWidth: opts.chart.plotBorderWidth,
             borderRadius: opts.chart.borderRadius,
             borderWidth: opts.chart.borderWidth,
             shadow: opts.chart.shadow
@@ -111,6 +117,7 @@ function applyChartTheme() {
         legend: {
             itemStyle: opts.legend.itemStyle,
             backgroundColor: opts.legend.backgroundColor,
+            borderWidth: opts.legend.borderWidth,
             borderRadius: opts.legend.borderRadius
         },
         title: opts.title,
@@ -139,6 +146,10 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 document.addEventListener('fonts-applied', () => {
+    applyChartTheme();
+});
+
+document.addEventListener('theme-changed', () => {
     applyChartTheme();
 });
 
@@ -180,6 +191,7 @@ window.chartColors = chartColors;
 window.getSegmentColor = getSegmentColor;
 window.getCategoryColor = getCategoryColor;
 window.getTagColor = getTagColor;
+window.applyChartTheme = applyChartTheme;
 
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('[data-chart-desc]').forEach(el => {

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -269,6 +269,7 @@ const attachSidebarSearchHandler = (root = document) => {
             const enabled = themeToggle.checked;
             document.body.classList.toggle('theme-professional', enabled);
             localStorage.setItem(PROFESSIONAL_THEME_KEY, String(enabled));
+            document.dispatchEvent(new CustomEvent('theme-changed', { detail: { professional: enabled } }));
           });
         }
 

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -138,7 +138,7 @@ function drawBubble(){
     Highcharts.chart('project-bubble-chart', {
         chart: {
             type: 'bubble',
-            plotBorderWidth: 1,
+            plotBorderWidth: 0,
             zoomType: 'xy',
             height: 600,
             backgroundColor: 'rgba(255,255,255,0)',


### PR DESCRIPTION
### Motivation
- Ensure the professional theme presents a fully white page canvas instead of the operational gradient and remove visible chart outlines for a cleaner, print-friendly look.

### Description
- Updated `frontend/css/theme-professional.css` to disable the page gradient (`ops-body`) and force the main content area (`.ops-main`) to white, and to remove Highcharts container borders/shadows and SVG background/plot border strokes.
- Updated chart defaults in `frontend/js/color_map.js` to set `plotBorderColor: 'transparent'` and `plotBorderWidth: 0`, make the chart `className` theme-aware (`glass-chart-professional`), and expose `applyChartTheme` so charts can be re-themed dynamically.
- Modified `frontend/js/menu.js` to dispatch a `theme-changed` event when the professional theme toggle is changed and added a listener in `color_map.js` to reapply chart theming on that event.
- Removed explicit bubble plot borders by changing `plotBorderWidth` to `0` in `frontend/projects.html` and `frontend/graphs.html` so individual charts no longer draw outlines.

### Testing
- Ran `rg -n "plotBorderWidth" frontend/projects.html frontend/graphs.html frontend/js/color_map.js` to verify border settings are zero (succeeded).
- Launched a local PHP server with `php -S 0.0.0.0:8000` and served the frontend to validate visual changes (server started successfully).
- Captured an automated screenshot with Playwright of `frontend/projects.html` with `localStorage.professionalThemeEnabled = true` to verify the white background and absence of chart outlines (screenshot captured successfully).
- Confirmed charts are re-themed on toggle by dispatching the `theme-changed` event and observing updated chart styling (observed via automated reload/screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698743753ef8832ea65140eba9a95bdf)