### PR TITLE
Unify page header card with shared glass effect

### DIFF
--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -23,11 +23,16 @@
     gap: 0.35rem;
     margin: 0;
     width: 100%;
-    background: transparent;
-    border: 1px solid #e2e8f0;
-    border-radius: 0.75rem;
+    background-color: rgba(255, 255, 255, 0.15);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 1.5rem;
     padding: 1.5rem;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+    box-shadow:
+        0 0 0 1px rgba(255, 255, 255, 0.4),
+        0 10px 15px -3px rgba(15, 23, 42, 0.1),
+        0 4px 6px -4px rgba(15, 23, 42, 0.1);
 }
 
 .page-title {


### PR DESCRIPTION
### Motivation
- Ensure the top-of-page header uses the same glassmorphism styling as other cards so the main header is not fully transparent and visually matches the rest of the UI.

### Description
- Updated `.page-header` in `frontend/operational_ui.css` to use a translucent white background and `backdrop-filter` blur to match the shared card treatment.
- Replaced the flat border with a white ring-style border and increased `border-radius` to align with the standard card rounding.
- Replaced the single flat shadow with the multi-layer card-consistent shadow used by other `.cards` surfaces.

### Testing
- Started a local PHP server with `php -S 0.0.0.0:8000` and confirmed the server started successfully.
- Rendered `frontend/index.html` and captured a screenshot via a Playwright script to validate the new header appearance, which succeeded.
- The project test suite `php tests/run_tests.php` was not executed because tests requiring database access were intentionally skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698747be6e74832ea5fe93fcdb1a3c3f)