### PR TITLE
Fix page title to respect configured theme color and heading font

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -74,6 +74,10 @@ const attachSidebarSearchHandler = (root = document) => {
       });
     }
     const colors = colorMap[colorScheme] || colorMap.indigo;
+    const cssRoot = document.documentElement;
+    cssRoot.style.setProperty('--brand-color-600', colors[600]);
+    cssRoot.style.setProperty('--brand-color-700', colors[700]);
+    cssRoot.style.setProperty('--page-title-color', colors[700]);
     hoverStyle.textContent = `
       a { transition: color 0.2s ease; }
       a:hover { color: ${colors[600]}; }

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -40,7 +40,8 @@
     text-align: left;
     font-size: 200% !important;
     line-height: 1.2;
-    color: var(--segment-1-base, #4338ca);
+    color: var(--page-title-color, var(--brand-color-700, #4338ca));
+    font-family: var(--heading-font, inherit);
 }
 
 .page-header-hero {


### PR DESCRIPTION
### Motivation

- The page title was using a hardcoded palette segment color and not following the colour scheme or heading font selected in Settings, causing inconsistent branding and typography.

### Description

- Updated `.page-title` in `frontend/operational_ui.css` to use `--page-title-color` with a `--brand-color-700` fallback and to use the `--heading-font` variable for heading typography so titles follow configured settings.
- Extended `applyColorScheme` in `frontend/js/menu.js` to publish `--brand-color-600`, `--brand-color-700`, and `--page-title-color` on `:root` when brand settings are loaded so the title color is driven by the active colour scheme.

### Testing

- Ran `git diff --check` to ensure no whitespace/style issues and it succeeded. 
- Started the built-in PHP server with `php -S 0.0.0.0:8000` and used a Playwright script to load `http://127.0.0.1:8000/frontend/index.html` and capture a screenshot, which validated the title renders with the new theme variables (screenshot saved). 
- No database-dependent tests were run in accordance with the testing constraints and all executed checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874bece2bc832ea48f2376f58aa9ce)