### PR TITLE
Reduce card corner roundness in professional theme

### DIFF
--- a/frontend/cards.css
+++ b/frontend/cards.css
@@ -179,7 +179,7 @@
 .theme-professional .cards {
   background-color: #ffffff;
   border: 1px solid #e2e8f0;
-  border-radius: 0.75rem;
+  border-radius: 0.5rem;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;


### PR DESCRIPTION
### Motivation
- Make cards in the professional theme appear more square by reducing the corner radius to better match the restrained professional design.

### Description
- Updated `frontend/cards.css` to change `.cards-professional` / `.theme-professional .cards` `border-radius` from `0.75rem` to `0.5rem`, preserving the existing border, shadow and surface treatments.

### Testing
- Launched a local PHP server with `php -S 0.0.0.0:8000` and ran a Playwright script that loaded `frontend/index.html` with the professional theme enabled and captured `professional-cards-corners.png`, which succeeded.
- Did not run `php tests/run_tests.php` because it requires database access per project/user instruction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874c60a9f8832e9edd0d1ca8a82f93)