### PR TITLE
Fix double vertical scrollbar on authenticated pages

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -356,6 +356,10 @@ const attachSidebarSearchHandler = (root = document) => {
 
   const content = document.querySelector('body > div.flex');
   if (content) {
+    // Prevent the document itself from scrolling so only the main content
+    // panel owns vertical scrolling. This avoids double right-edge scrollbars.
+    document.body.classList.add('m-0', 'h-screen', 'overflow-hidden');
+
     // Ensure wrapper always uses column layout on small screens with a
     // sidebar on larger displays so the menu and utility bar position
     // consistently across pages.


### PR DESCRIPTION
### Motivation
- Pages using the app shell were showing two vertical scrollbars because both the document body and the `main` content area could scroll at the same time.

### Description
- Lock body scrolling when the app shell is present by adding `document.body.classList.add('m-0', 'h-screen', 'overflow-hidden')` in `frontend/js/menu.js` so vertical scrolling is scoped to `main` only.
- Leave the existing `main` classes including `overflow-y-auto` in place so the primary content panel continues to scroll as intended.
- Added a short inline comment in `frontend/js/menu.js` explaining the intent to avoid duplicate right-edge scrollbars.

### Testing
- Launched the development server with `php -S 0.0.0.0:8000` and ran a Playwright script that opened `frontend/index.html` and produced a screenshot to visually confirm the duplicate scrollbar was removed, and the visual check succeeded.
- No database-dependent tests were executed as requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874df558c4832e92160f5f05f50a34)