### PR TITLE
Project Board: use format-less table for card details

### DIFF
--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -15,6 +15,30 @@
 
     <link rel="stylesheet" href="operational_ui.css">
 
+    <style>
+        .project-board-layout-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: inherit;
+            color: inherit;
+            background: transparent;
+        }
+
+        .project-board-layout-table th,
+        .project-board-layout-table td {
+            padding: 0.15rem 0;
+            border: 0;
+            vertical-align: top;
+            background: transparent;
+            text-align: left;
+        }
+
+        .project-board-layout-table th {
+            width: 20%;
+            font-weight: 600;
+        }
+    </style>
+
     <!-- Font Awesome icons loaded via menu.js -->
 </head>
 <body class="ops-body">
@@ -217,7 +241,7 @@ async function loadProjects(){
         details.appendChild(rationale);
 
         const table = document.createElement('table');
-        table.className = 'ops-native-table';
+        table.className = 'project-board-layout-table';
         table.innerHTML = `
             <tbody>
                 <tr>


### PR DESCRIPTION
### Motivation
- The Project Board cards use semantic tables for arranging key/value details but currently inherit global table chrome; these should be visually neutral so the table acts purely as layout.

### Description
- Added a project-scoped CSS class `.project-board-layout-table` in `frontend/projects_board.html` that removes borders, backgrounds, row striping and other table chrome while keeping semantic structure. 
- Replaced the card details table class from `ops-native-table` to `project-board-layout-table` so the change only affects the Project Board page.

### Testing
- Launched a local PHP server with `php -S 0.0.0.0:8000` and the server started successfully. 
- Used a Playwright script to load `/frontend/projects_board.html` and capture a screenshot to validate the details table appears format-less, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69874ed51764832e86e4416854bdac8c)