### PR TITLE
Increase spacing between receipt and dropdowns on transaction details

### DIFF
--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -139,9 +139,11 @@ window.renderPageHeader(pageMain, {
                         <div id="assigned-meta" class="flex flex-wrap gap-2"></div>
                     </div>
                 </div>
-                <label class="block">Tag: <input type="text" id="tag" class="border p-2 rounded w-full" data-help="Enter a new tag name to auto-tag similar transactions"></label>
-                <label class="block">Category Group: <select id="category" class="border p-2 rounded w-full" data-help="Assign a category group"></select></label>
-                <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Assign a group"></select></label>
+                <div class="pt-6 space-y-4">
+                    <label class="block">Tag: <input type="text" id="tag" class="border p-2 rounded w-full" data-help="Enter a new tag name to auto-tag similar transactions"></label>
+                    <label class="block">Category Group: <select id="category" class="border p-2 rounded w-full" data-help="Assign a category group"></select></label>
+                    <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Assign a group"></select></label>
+                </div>
                 <div class="flex space-x-2 justify-center no-print">
                     <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded" aria-label="Save transaction">Save</button>
                     <button type="button" id="print" class="bg-gray-600 text-white px-4 py-2 rounded" aria-label="Print receipt">Print Receipt</button>


### PR DESCRIPTION
### Motivation
- Increase vertical gap between the receipt card and the Tag/Category Group/Group controls on the transaction details page for improved readability.

### Description
- Wrap the Tag/Category/Group fields in a container with `pt-6 space-y-4` in `frontend/transaction.html` to add padding-top and consistent vertical spacing while preserving field order and behavior.

### Testing
- Launched a local server with `php -S 0.0.0.0:8000` and captured a screenshot of `frontend/transaction.html?id=1` via a Playwright script to visually verify the updated spacing, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698751f09f38832e86debc695c1f8c30)