### PR TITLE
Fix archived boolean parsing in projects API

### DIFF
--- a/php_backend/public/projects.php
+++ b/php_backend/public/projects.php
@@ -9,19 +9,47 @@ header('Content-Type: application/json');
 
 $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
 
+/**
+ * Parse API boolean inputs consistently across query strings and JSON payloads.
+ */
+function parseBooleanInput($value, bool $default = false): bool {
+    if (is_bool($value)) {
+        return $value;
+    }
+
+    if (is_int($value)) {
+        return $value !== 0;
+    }
+
+    if (is_string($value)) {
+        $parsed = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if ($parsed !== null) {
+            return $parsed;
+        }
+    }
+
+    return $default;
+}
+
 try {
     switch ($method) {
         case 'GET':
-            $archived = isset($_GET['archived']) ? (bool)$_GET['archived'] : false;
+            $archived = isset($_GET['archived']) ? parseBooleanInput($_GET['archived']) : false;
             echo json_encode(Project::all($archived));
             break;
         case 'POST':
             $data = json_decode(file_get_contents('php://input'), true) ?? [];
+            if (isset($data['archived'])) {
+                $data['archived'] = parseBooleanInput($data['archived']) ? 1 : 0;
+            }
             $id = Project::create($data);
             echo json_encode(['status' => 'ok', 'id' => $id]);
             break;
         case 'PUT':
             $data = json_decode(file_get_contents('php://input'), true) ?? [];
+            if (isset($data['archived'])) {
+                $data['archived'] = parseBooleanInput($data['archived']) ? 1 : 0;
+            }
             if (isset($data['id'])) {
                 $ok = Project::update((int)$data['id'], $data);
                 echo json_encode(['status' => $ok ? 'ok' : 'error']);
@@ -32,7 +60,7 @@ try {
         case 'PATCH':
             $data = json_decode(file_get_contents('php://input'), true) ?? [];
             if (isset($data['id']) && isset($data['archived'])) {
-                $ok = Project::setArchived((int)$data['id'], (bool)$data['archived']);
+                $ok = Project::setArchived((int)$data['id'], parseBooleanInput($data['archived']));
                 echo json_encode(['status' => $ok ? 'ok' : 'error']);
             } else {
                 echo json_encode(['status' => 'error', 'error' => 'Missing id or archived']);
@@ -58,4 +86,3 @@ try {
 }
 
 ?>
-


### PR DESCRIPTION
### Motivation
- The Projects API treated incoming boolean-like values as raw PHP truthy strings, so inputs like `"false"` or `"0"` could be misinterpreted as true and cause incorrect filtering or archiving behaviour.
- Clients may send `archived` via query strings or JSON payloads in multiple forms, so a consistent parser is required to avoid surprises.

### Description
- Add a `parseBooleanInput` helper in `php_backend/public/projects.php` that normalises booleans from strings, integers, and real booleans using `filter_var(..., FILTER_VALIDATE_BOOLEAN)` with a safe default.
- Use the helper for `GET /projects` to correctly interpret `$_GET['archived']` values.
- Normalize `archived` in `POST` and `PUT` payloads to stored numeric flags (`1`/`0`).
- Use the helper for `PATCH` archive toggles so `setArchived` receives a proper boolean value.

### Testing
- Ran the full test suite with `php tests/run_tests.php`, and all tests passed.
- Checked syntax with `php -l php_backend/public/projects.php`, which reported no syntax errors.
- Verified `parseBooleanInput` behaviour with a small CLI invocation (confirmed `"false"` and `"0"` evaluate to false and `"true"` to true), noting that including the API bootstrap in CLI emits expected header/session warnings in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698757da7d0c832e8c39c9c70710ab50)