### PR TITLE
Add two-tone colour schemes with gradient support

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -56,7 +56,10 @@ const attachSidebarSearchHandler = (root = document) => {
     red:    {600: '#dc2626', 700: '#b91c1c'},
     purple: {600: '#9333ea', 700: '#7e22ce'},
     teal:   {600: '#0d9488', 700: '#0f766e'},
-    orange: {600: '#ea580c', 700: '#c2410c'}
+    orange: {600: '#ea580c', 700: '#c2410c'},
+    sunset: {600: '#f97316', 700: '#ec4899', gradient: 'linear-gradient(135deg, #f97316 0%, #ec4899 100%)'},
+    ocean: {600: '#0891b2', 700: '#2563eb', gradient: 'linear-gradient(135deg, #0891b2 0%, #2563eb 100%)'},
+    'violet-rose': {600: '#8b5cf6', 700: '#e11d48', gradient: 'linear-gradient(135deg, #8b5cf6 0%, #e11d48 100%)'}
   };
 
   const hoverStyle = document.createElement('style');
@@ -78,6 +81,7 @@ const attachSidebarSearchHandler = (root = document) => {
     cssRoot.style.setProperty('--brand-color-600', colors[600]);
     cssRoot.style.setProperty('--brand-color-700', colors[700]);
     cssRoot.style.setProperty('--page-title-color', colors[700]);
+    cssRoot.style.setProperty('--brand-gradient', colors.gradient || `linear-gradient(135deg, ${colors[600]} 0%, ${colors[700]} 100%)`);
     hoverStyle.textContent = `
       a { transition: color 0.2s ease; }
       a:hover { color: ${colors[600]}; }

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -1,7 +1,7 @@
 /* Shared canonical authenticated-page background */
 .ops-body {
     min-height: 100vh;
-    background-image: linear-gradient(to bottom, #c7d2fe, #f1f5f9, #ffffff);
+    background-image: var(--brand-gradient, linear-gradient(to bottom, #c7d2fe, #f1f5f9, #ffffff));
 }
 
 /* Shared operational UI patterns for dashboard and planning screens */
@@ -50,7 +50,7 @@
     padding: 1.5rem;
     border-radius: 1.5rem;
     border: 1px solid rgba(191, 219, 254, 0.8);
-    background: linear-gradient(145deg, rgba(224, 231, 255, 0.88), rgba(219, 234, 254, 0.65));
+    background: var(--brand-gradient, linear-gradient(145deg, rgba(224, 231, 255, 0.88), rgba(219, 234, 254, 0.65)));
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55);
 }
 

--- a/settings.php
+++ b/settings.php
@@ -75,7 +75,18 @@ $fontOptions = ['' => 'Default',
     'Source Serif Pro' => 'Source Serif Pro',
 ];
 $weightOptions = ['' => 'Default', '100' => 'Thin', '300' => 'Light', '700' => 'Bold'];
-$colorOptions = ['indigo', 'blue', 'green', 'red', 'purple', 'teal', 'orange'];
+$colorOptions = [
+    'indigo',
+    'blue',
+    'green',
+    'red',
+    'purple',
+    'teal',
+    'orange',
+    'sunset',
+    'ocean',
+    'violet-rose',
+];
 $colorMap = [
     'indigo' => '#4f46e5',
     'blue'   => '#2563eb',
@@ -84,6 +95,14 @@ $colorMap = [
     'purple' => '#9333ea',
     'teal'   => '#0d9488',
     'orange' => '#ea580c',
+    'sunset' => '#f97316',
+    'ocean' => '#0891b2',
+    'violet-rose' => '#8b5cf6',
+];
+$colorLabels = [
+    'sunset' => 'Sunset (Orange → Pink)',
+    'ocean' => 'Ocean (Cyan → Blue)',
+    'violet-rose' => 'Violet Rose (Violet → Rose)',
 ];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -132,7 +151,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         Setting::set('site_name', $siteName);
         Log::write('Updated site name');
     }
-    if ($newColorScheme !== '') {
+    if ($newColorScheme !== '' && in_array($newColorScheme, $colorOptions, true)) {
         if ($newColorScheme !== $colorScheme) {
             Setting::set('color_scheme', $newColorScheme);
             Log::write('Updated color scheme');
@@ -220,7 +239,7 @@ $bg600 = "bg-{$colorScheme}-600";
             <label class="block">Color Scheme:
                 <select name="color_scheme" class="border p-2 rounded w-full" data-help="Primary Tailwind color">
                     <?php foreach ($colorOptions as $opt): ?>
-                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $colorScheme ? 'selected' : '' ?>><?= ucfirst($opt) ?></option>
+                        <option value="<?= htmlspecialchars($opt) ?>" <?= $opt === $colorScheme ? 'selected' : '' ?>><?= htmlspecialchars($colorLabels[$opt] ?? ucfirst($opt)) ?></option>
                     <?php endforeach; ?>
                 </select>
             </label>


### PR DESCRIPTION
### Motivation
- Provide two-tone (gradient) brand schemes so the UI can use blended gradients instead of single flat colours. 
- Make new schemes selectable from the Settings page and ensure only known schemes are persisted. 
- Surface a single CSS variable so multiple UI surfaces can share the same gradient with a safe fallback.

### Description
- Added three new schemes `sunset`, `ocean`, and `violet-rose` to the settings chooser and display-friendly labels via a new `$colorLabels` map in `settings.php`. 
- Protect saving of `color_scheme` with an allowlist check so only known options are persisted (`in_array` guard) in `settings.php`. 
- Extended `frontend/js/menu.js` `colorMap` entries to include gradient strings for the new two-tone schemes and publish a shared `--brand-gradient` CSS variable (falls back to a generated gradient using the scheme's 600/700 values). 
- Updated `frontend/operational_ui.css` to consume `--brand-gradient` for the page background and hero header while keeping the original gradient fallbacks.

### Testing
- Ran `php -l settings.php` to validate PHP syntax and it succeeded. 
- Ran `node --check frontend/js/menu.js` to validate the modified JS and it succeeded. 
- Launched the dev server and captured a browser screenshot showing a two-tone gradient applied to the operational page background; visual verification artifact produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698758be57f4832ea409bc46c29550f6)