### PR TITLE
Make dashboard tables transparent

### DIFF
--- a/frontend/account_dashboard.html
+++ b/frontend/account_dashboard.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="ops-body">
+<body class="ops-body dashboard-page">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">

--- a/frontend/all_years_dashboard.html
+++ b/frontend/all_years_dashboard.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="operational_ui.css">
 
 </head>
-<body class="ops-body">
+<body class="ops-body dashboard-page">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">

--- a/frontend/group_dashboard.html
+++ b/frontend/group_dashboard.html
@@ -18,7 +18,7 @@
     <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
 
 </head>
-<body class="ops-body">
+<body class="ops-body dashboard-page">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">

--- a/frontend/monthly_dashboard.html
+++ b/frontend/monthly_dashboard.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="operational_ui.css">
 
 </head>
-<body class="ops-body">
+<body class="ops-body dashboard-page">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -258,6 +258,17 @@
     background: #eef2ff !important;
 }
 
+/* Dashboard pages keep table body surfaces transparent so page cards show through. */
+.dashboard-page .ops-standard-table .tabulator-tableholder,
+.dashboard-page .ops-standard-table .tabulator-tableholder .tabulator-table,
+.dashboard-page .ops-standard-table .tabulator-footer,
+.dashboard-page .ops-standard-table .tabulator-paginator,
+.dashboard-page .ops-table-row,
+.dashboard-page .ops-table-row:nth-child(even),
+.dashboard-page .ops-table-row:hover {
+    background: transparent !important;
+}
+
 .ops-standard-table .tabulator-calcs-row,
 .ops-standard-table .tabulator-calcs-row .tabulator-cell {
     background: #e2e8f0 !important;

--- a/frontend/yearly_dashboard.html
+++ b/frontend/yearly_dashboard.html
@@ -17,7 +17,7 @@
     <link rel="stylesheet" href="operational_ui.css">
 
 </head>
-<body class="ops-body">
+<body class="ops-body dashboard-page">
     <div class="flex min-h-screen">
         <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
         <main class="ops-main flex-1 min-w-0 overflow-x-auto">


### PR DESCRIPTION
### Motivation
- Dashboard tables should render transparently so the page card surfaces show through and dashboards keep a lighter, integrated visual appearance.

### Description
- Add a dashboard-scoped CSS override in `frontend/operational_ui.css` to make Tabulator table bodies, the tableholder, paginator/footer and row backgrounds transparent using the `.dashboard-page` selector.
- Add `dashboard-page` to the `<body>` class on dashboard pages to scope the transparency to dashboard views in `frontend/account_dashboard.html`, `frontend/monthly_dashboard.html`, `frontend/yearly_dashboard.html`, `frontend/group_dashboard.html`, and `frontend/all_years_dashboard.html`.
- Keep existing table header and calculation row styling intact so only table surfaces and row backgrounds become transparent on dashboard pages.

### Testing
- Verified the presence of the new `dashboard-page` body class and CSS selectors with `rg`, which succeeded.
- Served the frontend using `php -S` and confirmed `monthly_dashboard.html` returned `HTTP/1.1 200 OK` via `curl`, which succeeded.
- Attempted a headless browser screenshot with Playwright to visually confirm transparency; the tooling produced artifacts but was unstable and crashed on retry, so visual verification is inconclusive.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875b5e0a18832ead46d787986f2a59)