### PR TITLE
Make single-colour schemes fade to white and add glassy sidebar (non‑professional)

### DIFF
--- a/frontend/css/theme-professional.css
+++ b/frontend/css/theme-professional.css
@@ -63,3 +63,12 @@ body.theme-professional.ops-body {
   stroke-width: 0 !important;
   stroke: transparent !important;
 }
+
+
+.theme-professional .menu-surface {
+  background: #ffffff !important;
+  border-right: 1px solid #e2e8f0 !important;
+  box-shadow: none !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}

--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -50,13 +50,13 @@ const attachSidebarSearchHandler = (root = document) => {
   let colorScheme = 'indigo';
   let siteName = 'Finance Manager';
   const colorMap = {
-    indigo: {600: '#4f46e5', 700: '#4338ca'},
-    blue:   {600: '#2563eb', 700: '#1d4ed8'},
-    green:  {600: '#059669', 700: '#047857'},
-    red:    {600: '#dc2626', 700: '#b91c1c'},
-    purple: {600: '#9333ea', 700: '#7e22ce'},
-    teal:   {600: '#0d9488', 700: '#0f766e'},
-    orange: {600: '#ea580c', 700: '#c2410c'},
+    indigo: {600: '#4f46e5', 700: '#4338ca', gradient: 'linear-gradient(160deg, #4f46e5 0%, #ffffff 100%)'},
+    blue:   {600: '#2563eb', 700: '#1d4ed8', gradient: 'linear-gradient(160deg, #2563eb 0%, #ffffff 100%)'},
+    green:  {600: '#059669', 700: '#047857', gradient: 'linear-gradient(160deg, #059669 0%, #ffffff 100%)'},
+    red:    {600: '#dc2626', 700: '#b91c1c', gradient: 'linear-gradient(160deg, #dc2626 0%, #ffffff 100%)'},
+    purple: {600: '#9333ea', 700: '#7e22ce', gradient: 'linear-gradient(160deg, #9333ea 0%, #ffffff 100%)'},
+    teal:   {600: '#0d9488', 700: '#0f766e', gradient: 'linear-gradient(160deg, #0d9488 0%, #ffffff 100%)'},
+    orange: {600: '#ea580c', 700: '#c2410c', gradient: 'linear-gradient(160deg, #ea580c 0%, #ffffff 100%)'},
     sunset: {600: '#f97316', 700: '#ec4899', gradient: 'linear-gradient(135deg, #f97316 0%, #ec4899 100%)'},
     ocean: {600: '#0891b2', 700: '#2563eb', gradient: 'linear-gradient(135deg, #0891b2 0%, #2563eb 100%)'},
     'violet-rose': {600: '#8b5cf6', 700: '#e11d48', gradient: 'linear-gradient(135deg, #8b5cf6 0%, #e11d48 100%)'}
@@ -203,12 +203,7 @@ const attachSidebarSearchHandler = (root = document) => {
       'shadow-2xl',
       `to-${colorScheme}-100/30`
     );
-    menu.classList.add(
-      'bg-white',
-      'border-r',
-      'border-slate-200',
-      'shadow-sm'
-    );
+    menu.classList.add('menu-surface', 'border-r');
 
     fetchNoCache(resolveFrontendAsset('menu.php'))
       .then(resp => resp.text())

--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -13,6 +13,17 @@
     margin-top: 1.5rem;
 }
 
+
+.menu-surface {
+    background: linear-gradient(165deg, rgba(255, 255, 255, 0.58) 0%, rgba(255, 255, 255, 0.32) 100%);
+    border-right: 1px solid rgba(255, 255, 255, 0.45);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.55),
+        8px 0 24px -18px rgba(15, 23, 42, 0.35);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+}
+
 /* Reusable page header pattern: title plus optional subtitle/actions */
 .page-header {
     display: flex;


### PR DESCRIPTION
### Motivation
- Ensure single-colour brand schemes keep the glassy page background by fading each single colour to white rather than a solid two‑colour gradient. 
- Give the side navigation a subtle glass effect so the UI reads as a layered, translucent surface in normal mode. 
- Preserve a flat, neutral look for the optional professional theme by disabling blur/transparency there.

### Description
- Updated the single-colour entries in `frontend/js/menu.js` (indigo/blue/green/red/purple/teal/orange) to include a colour→white `gradient` value and use that for `--brand-gradient` when applied. 
- Replaced the previous flat sidebar class usage with a new `menu-surface` class by changing the menu element class assignment in `frontend/js/menu.js`. 
- Added `menu-surface` CSS in `frontend/operational_ui.css` implementing a translucent white gradient, border, soft inset highlight, blur (`backdrop-filter`) and a subtle shadow to create the glass effect. 
- Added a professional-theme override in `frontend/css/theme-professional.css` which forces `menu-surface` to be solid white with no blur or shadow so professional mode remains flat.

### Testing
- Ran `node --check frontend/js/menu.js` to validate the modified JS syntax and it succeeded. 
- Captured the UI with an automated Playwright script using Firefox which succeeded and produced a verification screenshot at `artifacts/menu-glass-gradient.png`. 
- A Playwright Chromium run crashed in this environment (SIGSEGV) and therefore failed; the Firefox capture was used for visual verification instead. 
- No database-dependent tests were run per the project/testing constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875be31d28832ea8c3eae6da2fae35)