### PR TITLE
Allow PATCH in CORS preflight to fix project archive requests

### DIFF
--- a/php_backend/auth.php
+++ b/php_backend/auth.php
@@ -44,7 +44,7 @@ if (PHP_SAPI === 'cli') {
             http_response_code(403);
             exit;
         }
-        header('Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS');
+        header('Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS');
         header('Access-Control-Allow-Headers: Content-Type, X-Requested-With');
         http_response_code(204);
         exit;


### PR DESCRIPTION
### Motivation
- Browser preflight `OPTIONS` responses did not include `PATCH`, which can cause valid `fetch(..., { method: 'PATCH' })` calls (used by the Projects UI to archive projects) to be blocked.

### Description
- Add `PATCH` to `Access-Control-Allow-Methods` in the `OPTIONS` handling inside `php_backend/auth.php` so CORS preflight responses permit `PATCH` requests.

### Testing
- Ran `php -l php_backend/auth.php` to check syntax and it passed; no database-dependent tests were run per instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987638e9c50832eb9f3240ec5394345)