### PR TITLE
Fix white-on-white icon contrast in menu icon theming

### DIFF
--- a/frontend/js/menu.js
+++ b/frontend/js/menu.js
@@ -94,12 +94,13 @@ const attachSidebarSearchHandler = (root = document) => {
       if (icon.closest('header')) return;
       const parent = icon.closest('button, a');
       const parentClasses = parent ? Array.from(parent.classList) : [];
-      const coloredBg = parentClasses.some(c => c.startsWith('bg-') && c !== 'bg-white');
+      const hasExplicitParentText = parentClasses.some(c => c.startsWith('text-'));
+      const darkBg = parentClasses.some(c => /^(bg-(?:black|gray|slate|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-[5-9]00)$/.test(c));
       const hasColor = Array.from(icon.classList).some(c => c.startsWith('text-'));
-      if (coloredBg) {
+      if (darkBg && !hasExplicitParentText) {
         icon.classList.forEach(c => { if (c.startsWith('text-')) icon.classList.remove(c); });
         icon.classList.add('text-white');
-      } else if (!hasColor) {
+      } else if (!hasColor && !hasExplicitParentText) {
         icon.classList.add(`text-${colorScheme}-600`);
       }
     });


### PR DESCRIPTION
### Motivation
- Prevent icons from being recolored to white on light/transparent surfaces which produced unreadable white-on-white icons and buttons, while keeping white icons on genuinely dark action buttons for contrast.

### Description
- Updated `applyIconColor` in `frontend/js/menu.js` so icons are only forced to `text-white` when their parent has a dark solid Tailwind background utility (matched for `bg-*-500` through `bg-*-900`).
- Preserved explicit parent `text-*` classes by skipping icon recoloring when the parent already defines a text colour.
- Kept default icon tinting for neutral/light backgrounds by applying the brand tint `text-<colorScheme>-600` only when appropriate.

### Testing
- Ran `git diff --check` to validate there are no whitespace or index issues and it passed.
- Launched the dev server with `php -S 0.0.0.0:8000` and verified the site loaded successfully.
- Captured a Playwright screenshot of `http://127.0.0.1:8000/frontend/index.html` (mobile viewport) to visually confirm the menu toggle and icons have correct contrast, and the capture confirmed the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876a22ce38832e9ea037e6e53f4387)