### PR TITLE
Add mark-as-transfer button to transaction details page

### DIFF
--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -144,8 +144,9 @@ window.renderPageHeader(pageMain, {
                     <label class="block">Category Group: <select id="category" class="border p-2 rounded w-full" data-help="Assign a category group"></select></label>
                     <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Assign a group"></select></label>
                 </div>
-                <div class="flex space-x-2 justify-center no-print">
+                <div class="flex flex-wrap gap-2 justify-center no-print">
                     <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded" aria-label="Save transaction">Save</button>
+                    <button type="button" id="mark-transfer" class="bg-blue-600 text-white px-4 py-2 rounded" aria-label="Mark transaction as transfer">Mark as Transfer</button>
                     <button type="button" id="print" class="bg-gray-600 text-white px-4 py-2 rounded" aria-label="Print receipt">Print Receipt</button>
                 </div>
             `;
@@ -155,6 +156,30 @@ window.renderPageHeader(pageMain, {
             const printBtn = form.querySelector('#print');
             if (printBtn) {
                 printBtn.addEventListener('click', () => window.print());
+            }
+            const markTransferBtn = form.querySelector('#mark-transfer');
+            if (markTransferBtn) {
+                if (tx.transfer_id) {
+                    markTransferBtn.disabled = true;
+                    markTransferBtn.classList.remove('bg-blue-600');
+                    markTransferBtn.classList.add('bg-gray-400', 'cursor-not-allowed');
+                    markTransferBtn.textContent = 'Already marked as transfer';
+                } else {
+                    markTransferBtn.addEventListener('click', () => {
+                        fetch('../php_backend/public/mark_transaction_transfer.php', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ id: tx.id })
+                        }).then(r => r.json()).then(res => {
+                            if (res && res.status === 'ok') {
+                                showMessage('Transaction marked as transfer');
+                                setTimeout(() => window.location.reload(), 500);
+                            } else {
+                                alert(res.error || 'Failed to mark transfer');
+                            }
+                        }).catch(() => alert('Failed to mark transfer'));
+                    });
+                }
             }
             const tagInput = form.querySelector('#tag');
             if (tx.tag_name) {

--- a/php_backend/public/mark_transaction_transfer.php
+++ b/php_backend/public/mark_transaction_transfer.php
@@ -1,0 +1,40 @@
+<?php
+
+// API endpoint to mark a single transaction as a transfer.
+
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
+require_once __DIR__ . '/../models/Transaction.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true);
+$id = isset($data['id']) ? (int)$data['id'] : 0;
+
+if ($id <= 0) {
+    http_response_code(400);
+    echo json_encode(['error' => 'A valid transaction id is required']);
+    exit;
+}
+
+try {
+    $updated = Transaction::markTransfers([$id]);
+    if ($updated < 1) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Transaction could not be marked as a transfer']);
+        exit;
+    }
+
+    echo json_encode(['status' => 'ok', 'updated' => $updated]);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Mark single transfer error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>


### PR DESCRIPTION
### Motivation
- Allow marking a single transaction as a transfer directly from the Transaction Details page so transfers can be excluded from reports without navigating to the transfers UI.

### Description
- Added a `Mark as Transfer` button to `frontend/transaction.html` with `id="mark-transfer"` and an `aria-label`, placed alongside the Save and Print controls.
- The button is disabled and relabeled when `tx.transfer_id` is present, and otherwise issues a POST of `{ id: tx.id }` to a new backend endpoint.
- Implemented `php_backend/public/mark_transaction_transfer.php` which validates the request and calls `Transaction::markTransfers([$id])`, returning JSON and logging errors on failure.
- On success the client shows feedback via `showMessage` and reloads the page so the updated transfer state is immediately visible.

### Testing
- Linted the modified files with `php -l frontend/transaction.html` and `php -l php_backend/public/mark_transaction_transfer.php`, and both passed.
- Started the built-in PHP server and ran a headless browser script that loaded `frontend/transaction.html?id=1` and saved a screenshot (`artifacts/transaction-details-mark-transfer.png`), which completed successfully.
- No database-dependent automated tests were run per request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876bbdac68832e925f4dbf34ed0d95)