### PR TITLE
Add tag aliases (DB, API, UI) and alias-first matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ sequenceDiagram
 - Explore yearly and monthly dashboards to analyse spending.
 - Visualise trends with interactive graphs.
 - Automatically tag transactions and propose budgets using AI.
+- Map multiple transaction descriptors to a canonical tag using tag aliases (for example `Tesco` and `Sainsbury's` can both map to `Supermarkets`).
 - Analyse recurring expenses and break down spending by segments and categories.
 - Secure access with two-factor authentication.
 
@@ -221,6 +222,13 @@ It allows running a report to list all transactions filtered by category, tag or
 Reports can be saved to the server with optional descriptions for reuse and removed when no longer needed.
 The page sends requests to `php_backend/public/report.php` which returns matching
 transactions as JSON.
+
+
+## Tag Aliases
+
+Tag aliases let you map many bank descriptors to one canonical tag without renaming the tag itself. For example, you can create aliases `Tesco`, `Sainsbury's`, and `Aldi` that all resolve to `Supermarkets`.
+
+Use `frontend/tag_aliases.html` to manage mappings and the backend endpoint `php_backend/public/tag_aliases.php` for CRUD operations.
 
 ## Running Tests
 

--- a/frontend/js/tag_aliases.js
+++ b/frontend/js/tag_aliases.js
@@ -1,0 +1,154 @@
+let tagAliasTable;
+let tagOptions = [];
+
+async function fetchJson(url, options) {
+    const response = await fetch(url, options);
+    const data = await response.json();
+    if (!response.ok) {
+        throw new Error(data.error || 'Request failed');
+    }
+    return data;
+}
+
+async function loadTags() {
+    const tags = await fetchJson('../php_backend/public/tags.php');
+    tagOptions = tags.map(tag => ({ value: Number(tag.id), label: tag.name }));
+
+    const select = document.getElementById('tag_id');
+    select.innerHTML = '';
+    tagOptions.forEach(option => {
+        const element = document.createElement('option');
+        element.value = option.value;
+        element.textContent = option.label;
+        select.appendChild(element);
+    });
+}
+
+function getTagNameById(tagId) {
+    const match = tagOptions.find(option => option.value === Number(tagId));
+    return match ? match.label : `Tag #${tagId}`;
+}
+
+async function loadAliases() {
+    const aliases = await fetchJson('../php_backend/public/tag_aliases.php');
+
+    if (tagAliasTable) {
+        tagAliasTable.setData(aliases);
+        return;
+    }
+
+    tagAliasTable = tailwindTabulator('#tag-alias-table', {
+        data: aliases,
+        layout: 'fitDataStretch',
+        columns: [
+            { title: 'Alias', field: 'alias' },
+            { title: 'Canonical Tag', field: 'tag_name', formatter: badgeFormatter('bg-indigo-200 text-indigo-800') },
+            { title: 'Match Type', field: 'match_type' },
+            {
+                title: 'Active',
+                field: 'active',
+                formatter: cell => Number(cell.getValue()) === 1 ? 'Yes' : 'No'
+            },
+            {
+                title: 'Actions',
+                formatter: function(cell) {
+                    const container = document.createElement('div');
+                    const row = cell.getRow().getData();
+
+                    const edit = document.createElement('button');
+                    edit.innerHTML = '<i class="fas fa-edit w-4 h-4"></i>';
+                    edit.className = 'bg-indigo-600 text-white px-2 py-1 rounded mr-2';
+                    edit.setAttribute('aria-label', `Edit alias ${row.alias}`);
+                    edit.addEventListener('click', async () => {
+                        const alias = prompt('Alias', row.alias);
+                        if (alias === null) return;
+                        const tagInput = prompt('Canonical tag ID', String(row.tag_id));
+                        if (tagInput === null) return;
+                        const matchType = prompt('Match type (contains/exact)', row.match_type || 'contains');
+                        if (matchType === null) return;
+                        const activeInput = prompt('Active? (yes/no)', Number(row.active) === 1 ? 'yes' : 'no');
+                        if (activeInput === null) return;
+
+                        try {
+                            await fetchJson('../php_backend/public/tag_aliases.php', {
+                                method: 'PUT',
+                                headers: {'Content-Type': 'application/json'},
+                                body: JSON.stringify({
+                                    id: row.id,
+                                    alias,
+                                    tag_id: Number(tagInput),
+                                    match_type: matchType,
+                                    active: activeInput.toLowerCase() === 'yes' || activeInput === '1' || activeInput.toLowerCase() === 'true'
+                                })
+                            });
+                            await loadAliases();
+                            showMessage('Tag alias updated');
+                        } catch (error) {
+                            showMessage(error.message, 'error');
+                        }
+                    });
+
+                    const del = document.createElement('button');
+                    del.innerHTML = '<i class="fas fa-trash w-4 h-4"></i>';
+                    del.className = 'bg-red-600 text-white px-2 py-1 rounded';
+                    del.setAttribute('aria-label', `Delete alias ${row.alias}`);
+                    del.addEventListener('click', async () => {
+                        if (!confirm('Delete this alias mapping?')) return;
+                        try {
+                            await fetchJson('../php_backend/public/tag_aliases.php', {
+                                method: 'DELETE',
+                                headers: {'Content-Type': 'application/json'},
+                                body: JSON.stringify({ id: row.id })
+                            });
+                            await loadAliases();
+                            showMessage('Tag alias deleted');
+                        } catch (error) {
+                            showMessage(error.message, 'error');
+                        }
+                    });
+
+                    container.appendChild(edit);
+                    container.appendChild(del);
+                    return container;
+                }
+            }
+        ]
+    });
+}
+
+document.getElementById('tag-alias-form').addEventListener('submit', async event => {
+    event.preventDefault();
+    const payload = {
+        alias: document.getElementById('alias').value,
+        tag_id: Number(document.getElementById('tag_id').value),
+        match_type: document.getElementById('match_type').value,
+        active: document.getElementById('active').checked
+    };
+
+    try {
+        await fetchJson('../php_backend/public/tag_aliases.php', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(payload)
+        });
+
+        event.target.reset();
+        document.getElementById('active').checked = true;
+        if (tagOptions.length > 0) {
+            document.getElementById('tag_id').value = String(tagOptions[0].value);
+        }
+        await loadAliases();
+        showMessage(`Alias created for ${getTagNameById(payload.tag_id)}`);
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+});
+
+(async function init() {
+    try {
+        await loadTags();
+        await loadAliases();
+    } catch (error) {
+        showMessage(error.message, 'error');
+    }
+})();

--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -70,6 +70,7 @@
     <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Organise Data</h3>
     <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
         <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="tags.html"><i class="fas fa-tags w-4 text-center text-slate-400"></i> Manage Tags</a></li>
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="tag_aliases.html"><i class="fas fa-link w-4 text-center text-slate-400"></i> Tag Aliases</a></li>
         <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="ai_tags.html"><i class="fas fa-robot w-4 text-center text-slate-400"></i> AI Tags</a></li>
         <li>
           <a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="missing_tags.html">

--- a/frontend/tag_aliases.html
+++ b/frontend/tag_aliases.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<!-- Page for managing alias mappings to canonical tags -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <title>Tag Aliases</title>
+    <script>
+        window.tailwind = window.tailwind || {};
+        window.tailwind.config = {};
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="operational_ui.css">
+    <link rel="stylesheet" href="https://unpkg.com/tabulator-tables@6.3.0/dist/css/tabulator_simple.min.css">
+</head>
+<body class="ops-body">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
+        <main class="ops-main flex-1 min-w-0 overflow-x-auto">
+            <p class="mb-4">Map multiple merchant descriptors to a single canonical tag so similar spending (for example Tesco and Aldi) is grouped consistently.</p>
+
+            <section class="cards cards-tight">
+                <form id="tag-alias-form" class="space-y-4">
+                    <label class="block">Alias
+                        <input type="text" id="alias" class="border p-2 rounded w-full" data-help="Descriptor to match in transaction descriptions, for example Tesco.">
+                    </label>
+                    <label class="block">Canonical Tag
+                        <select id="tag_id" class="border p-2 rounded w-full" data-help="Tag that should be applied when this alias matches."></select>
+                    </label>
+                    <label class="block">Match Type
+                        <select id="match_type" class="border p-2 rounded w-full" data-help="Contains matches text fragments; Exact only matches full descriptor.">
+                            <option value="contains">Contains</option>
+                            <option value="exact">Exact</option>
+                        </select>
+                    </label>
+                    <label class="inline-flex items-center gap-2" data-help="Disable an alias without deleting it.">
+                        <input type="checkbox" id="active" checked>
+                        <span>Active</span>
+                    </label>
+                    <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded" aria-label="Create tag alias">Create Alias</button>
+                </form>
+            </section>
+
+            <section class="mt-6 cards cards-tight">
+                <h2 class="text-xl font-semibold mb-2">Existing Aliases</h2>
+                <div id="tag-alias-table"></div>
+            </section>
+        </main>
+    </div>
+    <script src="js/page_header.js"></script>
+    <script>
+const pageMain = document.querySelector('main.ops-main');
+window.renderPageHeader(pageMain, {
+    title: 'Tag Aliases',
+    breadcrumb: 'Organisation',
+    subtitle: 'Create alias rules so multiple descriptors resolve to one canonical tag.'
+});
+</script>
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@6.3.0/dist/js/tabulator.min.js"></script>
+    <script src="js/tabulator-tailwind.js"></script>
+    <script src="js/tag_aliases.js"></script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/php_backend/models/TagAlias.php
+++ b/php_backend/models/TagAlias.php
@@ -1,0 +1,96 @@
+<?php
+// Model for mapping transaction descriptor aliases to canonical tags.
+require_once __DIR__ . '/../Database.php';
+
+class TagAlias {
+    /**
+     * Retrieve aliases with canonical tag names.
+     */
+    public static function all(): array {
+        $db = Database::getConnection();
+        $sql = 'SELECT ta.id, ta.tag_id, t.name AS tag_name, ta.alias, ta.match_type, ta.active, ta.created_at, ta.updated_at '
+             . 'FROM tag_aliases ta '
+             . 'INNER JOIN tags t ON t.id = ta.tag_id '
+             . 'ORDER BY ta.alias ASC';
+        $stmt = $db->query($sql);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Create a new alias mapping.
+     */
+    public static function create(int $tagId, string $alias, string $matchType = 'contains', bool $active = true): int {
+        $db = Database::getConnection();
+        $normalized = self::normalizeAlias($alias);
+        $stmt = $db->prepare('INSERT INTO tag_aliases (tag_id, alias, alias_normalized, match_type, active) VALUES (:tag_id, :alias, :alias_normalized, :match_type, :active)');
+        $stmt->execute([
+            'tag_id' => $tagId,
+            'alias' => trim($alias),
+            'alias_normalized' => $normalized,
+            'match_type' => self::normalizeMatchType($matchType),
+            'active' => $active ? 1 : 0,
+        ]);
+        return (int)$db->lastInsertId();
+    }
+
+    /**
+     * Update an existing alias mapping.
+     */
+    public static function update(int $id, int $tagId, string $alias, string $matchType = 'contains', bool $active = true): bool {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('UPDATE tag_aliases SET tag_id = :tag_id, alias = :alias, alias_normalized = :alias_normalized, match_type = :match_type, active = :active WHERE id = :id');
+        return $stmt->execute([
+            'id' => $id,
+            'tag_id' => $tagId,
+            'alias' => trim($alias),
+            'alias_normalized' => self::normalizeAlias($alias),
+            'match_type' => self::normalizeMatchType($matchType),
+            'active' => $active ? 1 : 0,
+        ]);
+    }
+
+    /**
+     * Delete alias mapping.
+     */
+    public static function delete(int $id): bool {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('DELETE FROM tag_aliases WHERE id = :id');
+        return $stmt->execute(['id' => $id]);
+    }
+
+    /**
+     * Return active aliases sorted by match precedence.
+     */
+    public static function activeMappings(): array {
+        $db = Database::getConnection();
+        $sql = 'SELECT ta.tag_id, ta.alias, ta.alias_normalized, ta.match_type '
+             . 'FROM tag_aliases ta '
+             . 'INNER JOIN tags t ON t.id = ta.tag_id '
+             . 'WHERE ta.active = 1 '
+             . 'ORDER BY CASE WHEN ta.match_type = "exact" THEN 0 ELSE 1 END, ta.id ASC';
+        $stmt = $db->query($sql);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Check whether tag exists.
+     */
+    public static function tagExists(int $tagId): bool {
+        $db = Database::getConnection();
+        $stmt = $db->prepare('SELECT id FROM tags WHERE id = :id LIMIT 1');
+        $stmt->execute(['id' => $tagId]);
+        return $stmt->fetchColumn() !== false;
+    }
+
+    /**
+     * Trim and lowercase alias for dedupe matching.
+     */
+    public static function normalizeAlias(string $alias): string {
+        return strtolower(trim($alias));
+    }
+
+    private static function normalizeMatchType(string $matchType): string {
+        return $matchType === 'exact' ? 'exact' : 'contains';
+    }
+}
+?>

--- a/php_backend/public/tag_aliases.php
+++ b/php_backend/public/tag_aliases.php
@@ -1,0 +1,99 @@
+<?php
+// API endpoint for creating, listing, updating, and deleting tag aliases.
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
+require_once __DIR__ . '/../models/TagAlias.php';
+require_once __DIR__ . '/../models/Tag.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+$method = $_SERVER['REQUEST_METHOD'];
+
+if ($method === 'GET') {
+    try {
+        echo json_encode(TagAlias::all());
+    } catch (Exception $e) {
+        http_response_code(500);
+        Log::write('Tag alias error: ' . $e->getMessage(), 'ERROR');
+        echo json_encode([]);
+    }
+    exit;
+}
+
+$data = json_decode(file_get_contents('php://input'), true) ?? [];
+
+$alias = trim($data['alias'] ?? '');
+$tagId = (int)($data['tag_id'] ?? 0);
+$matchType = $data['match_type'] ?? 'contains';
+$active = isset($data['active'])
+    ? filter_var($data['active'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)
+    : true;
+if ($active === null) {
+    $active = true;
+}
+
+try {
+    if ($method === 'POST') {
+        if ($alias === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'Alias is required']);
+            return;
+        }
+        if ($tagId <= 0 || !TagAlias::tagExists($tagId)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Please select a valid canonical tag']);
+            return;
+        }
+
+        $id = TagAlias::create($tagId, $alias, $matchType, $active);
+        Tag::clearMatchCaches();
+        Log::write('Created tag alias ' . $alias . ' for tag ' . $tagId);
+        echo json_encode(['id' => $id]);
+    } elseif ($method === 'PUT') {
+        $id = (int)($data['id'] ?? 0);
+        if ($id <= 0 || $alias === '') {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID and alias are required']);
+            return;
+        }
+        if ($tagId <= 0 || !TagAlias::tagExists($tagId)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Please select a valid canonical tag']);
+            return;
+        }
+
+        TagAlias::update($id, $tagId, $alias, $matchType, $active);
+        Tag::clearMatchCaches();
+        Log::write('Updated tag alias ' . $id);
+        echo json_encode(['status' => 'ok']);
+    } elseif ($method === 'DELETE') {
+        $id = (int)($data['id'] ?? 0);
+        if ($id <= 0) {
+            http_response_code(400);
+            echo json_encode(['error' => 'ID required']);
+            return;
+        }
+
+        TagAlias::delete($id);
+        Tag::clearMatchCaches();
+        Log::write('Deleted tag alias ' . $id);
+        echo json_encode(['status' => 'ok']);
+    } else {
+        http_response_code(405);
+    }
+} catch (PDOException $e) {
+    if ((int)$e->getCode() === 23000) {
+        http_response_code(409);
+        echo json_encode(['error' => 'That alias already exists. Please choose a different alias.']);
+        return;
+    }
+    http_response_code(500);
+    Log::write('Tag alias error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+} catch (Exception $e) {
+    http_response_code(500);
+    Log::write('Tag alias error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Server error']);
+}
+?>

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -10,5 +10,6 @@ Welcome to the Accounts project wiki. Use these pages to learn about the system 
 - Import OFX files to record bank transactions.
 - Explore dashboards to analyse spending by month or year.
 - Tag transactions automatically and suggest budgets with AI.
+- Configure tag aliases so different merchant descriptors (for example Tesco and Sainsbury's) map to one canonical tag such as Supermarkets.
 - Generate reports and export data in OFX, CSV, or XLSX formats.
 


### PR DESCRIPTION
### Motivation
- Provide a way to map many transaction descriptors (e.g. `Tesco`, `Sainsbury's`, `Aldi`) to a single canonical tag so similar spending is grouped consistently.
- Allow alias-based matching to be maintained independently of tag definitions and to be evaluated before legacy keyword matching for more accurate auto-tagging.

### Description
- Database: added `tag_aliases` table (columns: `id`, `tag_id`, `alias`, `alias_normalized`, `match_type`, `active`, `created_at`, `updated_at`) to `php_backend/create_tables.php` with migration guards, normalization backfill, unique index on `alias_normalized`, index on `tag_id`, and FK to `tags` with `ON DELETE CASCADE`.
- Backend: new model `php_backend/models/TagAlias.php` and API `php_backend/public/tag_aliases.php` implement list/create/update/delete with validation (trimmed alias required, `tag_id` must exist), normalization, duplicate alias handling (409 response), and cache invalidation hooks.
- Matching: `php_backend/models/Tag.php` updated to evaluate active aliases (exact/contains precedence) before existing keyword matching and added `clearMatchCaches()` so changes apply immediately.
- Frontend: added Organisation menu entry and management UI at `frontend/tag_aliases.html` plus JS module `frontend/js/tag_aliases.js` using Tabulator with columns (Alias, Canonical Tag, Match Type, Active, Actions), create/edit/delete flows, `data-help` hints, and `aria-label` attributes to match existing UX patterns.
- Documentation: README and `wiki/Home.md` updated with a short section describing alias purpose and an example mapping (`Tesco`, `Sainsbury's`, `Aldi` -> `Supermarkets`).

### Testing
- Ran PHP syntax checks: `php -l` on `php_backend/models/TagAlias.php`, `php_backend/public/tag_aliases.php`, `php_backend/models/Tag.php`, and `php_backend/create_tables.php`; all returned no syntax errors.
- Launched a local PHP dev server (`php -S ...`) and rendered `frontend/tag_aliases.html` to verify the page loads and captured a screenshot successfully; UI wiring and Tabulator table load paths were exercised in the browser preview.
- No tests requiring a live database were run, and no DB migration was executed as part of these automated checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698773567168832e8b898e45075435c5)