### PR TITLE
Add alias-aware canonical tag handling to AI tagging pipeline

### DIFF
--- a/php_backend/AiTaggingPipeline.php
+++ b/php_backend/AiTaggingPipeline.php
@@ -1,0 +1,118 @@
+<?php
+// Helpers for AI tagging prompt context and canonical tag resolution.
+require_once __DIR__ . '/models/TagAlias.php';
+
+class AiTaggingPipeline {
+    /**
+     * Build canonical and alias lookup maps and prompt context text.
+     *
+     * @param array $rows Rows containing tag_id, tag_name and optional alias.
+     * @return array{text:string,canonicalByName:array,aliasToCanonical:array,truncated:bool}
+     */
+    public static function buildAliasAwareTagContext(array $rows, int $maxAliasesPerTag = 5, int $maxChars = 2500): array {
+        $canonicalByName = [];
+        $aliasToCanonical = [];
+        $aliasesByTag = [];
+
+        foreach ($rows as $row) {
+            $tagId = (int)($row['tag_id'] ?? 0);
+            $tagName = trim((string)($row['tag_name'] ?? ''));
+            if ($tagId <= 0 || $tagName === '') {
+                continue;
+            }
+
+            $canonical = ['id' => $tagId, 'name' => $tagName];
+            $canonicalByName[self::normalizeText($tagName)] = $canonical;
+
+            if (!isset($aliasesByTag[$tagId])) {
+                $aliasesByTag[$tagId] = ['name' => $tagName, 'aliases' => []];
+            }
+
+            $alias = trim((string)($row['alias'] ?? ''));
+            if ($alias === '') {
+                continue;
+            }
+
+            $aliasNormalized = TagAlias::normalizeAlias($alias);
+            if ($aliasNormalized === '') {
+                continue;
+            }
+
+            if (!isset($aliasToCanonical[$aliasNormalized])) {
+                $aliasToCanonical[$aliasNormalized] = $canonical;
+            }
+            $aliasesByTag[$tagId]['aliases'][$aliasNormalized] = $alias;
+        }
+
+        $lines = [];
+        foreach ($aliasesByTag as $entry) {
+            $name = $entry['name'];
+            $aliases = array_values($entry['aliases']);
+            if (empty($aliases)) {
+                continue;
+            }
+            $aliases = array_slice($aliases, 0, $maxAliasesPerTag);
+            $lines[] = $name . ': ' . implode(', ', $aliases);
+        }
+
+        $text = '';
+        $truncated = false;
+        if (!empty($lines)) {
+            $joined = implode("\n", $lines);
+            if (strlen($joined) > $maxChars) {
+                $text = substr($joined, 0, $maxChars);
+                $lastBreak = strrpos($text, "\n");
+                if ($lastBreak !== false) {
+                    $text = substr($text, 0, $lastBreak);
+                }
+                $text .= "\n... (alias context truncated)";
+                $truncated = true;
+            } else {
+                $text = $joined;
+            }
+        }
+
+        return [
+            'text' => $text,
+            'canonicalByName' => $canonicalByName,
+            'aliasToCanonical' => $aliasToCanonical,
+            'truncated' => $truncated,
+        ];
+    }
+
+    /**
+     * Resolve model output to a canonical tag by exact tag name or alias.
+     *
+     * @return array|null ['id' => int, 'name' => string, 'source' => 'canonical'|'alias']
+     */
+    public static function resolveCanonicalTag(string $modelTag, array $canonicalByName, array $aliasToCanonical): ?array {
+        $normalized = self::normalizeText($modelTag);
+        if ($normalized === '') {
+            return null;
+        }
+        if (isset($canonicalByName[$normalized])) {
+            $canonical = $canonicalByName[$normalized];
+            return ['id' => (int)$canonical['id'], 'name' => (string)$canonical['name'], 'source' => 'canonical'];
+        }
+
+        $aliasNormalized = TagAlias::normalizeAlias($modelTag);
+        if ($aliasNormalized !== '' && isset($aliasToCanonical[$aliasNormalized])) {
+            $canonical = $aliasToCanonical[$aliasNormalized];
+            return ['id' => (int)$canonical['id'], 'name' => (string)$canonical['name'], 'source' => 'alias'];
+        }
+
+        return null;
+    }
+
+    private static function normalizeText(string $value): string {
+        $value = trim($value);
+        if ($value === '') {
+            return '';
+        }
+        if (function_exists('mb_strtolower')) {
+            return mb_strtolower($value, 'UTF-8');
+        }
+        return strtolower($value);
+    }
+}
+?>


### PR DESCRIPTION
### Motivation

- Improve AI tag suggestions by giving the model alias-aware context so vendor-specific names can be mapped to existing canonical tags and reduce mis-tagging. 
- Add a deterministic fallback to resolve alias literals returned by the model back to canonical tag ids before assignment. 

### Description

- Added `php_backend/AiTaggingPipeline.php` which builds a bounded alias-aware prompt context and provides `resolveCanonicalTag()` to map model output to canonical tags and `buildAliasAwareTagContext()` to produce a truncated human-readable alias block for prompts. 
- Updated `php_backend/public/ai_tags.php` to query active aliases from `tag_aliases`, inject a canonical-alias examples block into the prompt, and instruct the model to return canonical tag names while preserving the Responses API contract (`text.format.type = json_object`). 
- Implemented post-processing that uses the new pipeline to deterministically resolve model-returned aliases back to canonical tags before creating/assigning tags, and preserved the existing fallback (create/new-tag behavior) when unresolved. 
- Extended AI debug output to include `alias_context`, `alias_context_truncated` and `alias_resolutions` when `ai_debug` is enabled, and added light-weight tests in `tests/run_tests.php` to validate alias behaviour without requiring an external DB. 

### Testing

- Performed syntax checks with `php -l` on `php_backend/AiTaggingPipeline.php`, `php_backend/public/ai_tags.php`, and `tests/run_tests.php`, which succeeded. 
- Ran the test suite with `php tests/run_tests.php`; added alias-related assertions passed (alias-in-text maps to canonical tag, alias model output resolves to canonical id, unknown alias does not resolve), and the full test run succeeded. 
- Confirmed the AI endpoint still uses the Responses API JSON text format (`text.format.type = json_object`) and that debug payload now contains alias context when `ai_debug` is enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698776185140832e87cc756c3c87068a)