### PR TITLE
Add tag alias creation flow to Missing Tags page

### DIFF
--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -41,8 +41,66 @@ window.renderPageHeader(pageMain, {
     <script src="js/tabulator-tailwind.js"></script>
     <script>
     let table;
+    let tags = [];
+
+    async function fetchTags() {
+        const res = await fetch('../php_backend/public/tags.php');
+        tags = await res.json();
+    }
+
+    async function createTagForDescription(description) {
+        const name = prompt('New tag name', description);
+        if (!name) return;
+        await fetch('../php_backend/public/tags.php', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({name: name, keyword: description})
+        });
+        showMessage('Tag created');
+    }
+
+    async function createAliasForDescription(description) {
+        if (!tags.length) {
+            await fetchTags();
+        }
+
+        const available = tags.map((tag) => tag.name).sort((a, b) => a.localeCompare(b));
+        const tagName = prompt(`Create alias "${description}" for which existing tag?\n\nAvailable tags:\n${available.join('\n')}`);
+        if (!tagName) return;
+
+        const selectedTag = tags.find((tag) => tag.name.toLowerCase() === tagName.trim().toLowerCase());
+        if (!selectedTag) {
+            showMessage('Tag not found. Please use an existing tag name.');
+            return;
+        }
+
+        const aliasRes = await fetch('../php_backend/public/tag_aliases.php', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({
+                alias: description,
+                tag_id: selectedTag.id,
+                match_type: 'contains',
+                active: true
+            })
+        });
+        const aliasData = await aliasRes.json();
+        if (!aliasRes.ok) {
+            showMessage(aliasData.error || 'Unable to create alias');
+            return;
+        }
+
+        await fetch('../php_backend/public/tags.php', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({action: 'remap_aliases', dry_run: false})
+        });
+        showMessage('Tag alias created');
+    }
+
     // Retrieve untagged transaction summaries and display them
     async function loadUntagged(){
+        await fetchTags();
         const res = await fetch('../php_backend/public/untagged_transactions.php');
         const data = await res.json();
         if (table) {
@@ -65,16 +123,20 @@ window.renderPageHeader(pageMain, {
                     { title: 'Memo', field: 'memo' },
                     { title: 'Count', field: 'count', hozAlign: 'right', sorter: 'number' },
                     { title: 'Amount', field: 'total', formatter: 'money', formatterParams: { symbol: '£', precision: 2 }, hozAlign: 'right' },
-                    { title: 'Action', formatter: () => '<button class="bg-indigo-600 text-white px-2 py-1 rounded">Auto Tag</button>', width: 120, align: 'center', cellClick: async (e, cell) => {
+                    { title: 'Action', formatter: () => (
+                        '<div class="flex gap-2">'
+                        + '<button class="bg-indigo-600 text-white px-2 py-1 rounded js-create-tag" aria-label="Create new tag">New Tag</button>'
+                        + '<button class="bg-slate-700 text-white px-2 py-1 rounded js-create-alias" aria-label="Create tag alias">Alias</button>'
+                        + '</div>'
+                    ), width: 230, align: 'center', cellClick: async (e, cell) => {
                         const desc = cell.getRow().getData().description;
-                        const name = prompt('Tag Name', desc);
-                        if (!name) return;
-                        await fetch('../php_backend/public/tags.php', {
-                            method: 'POST',
-                            headers: {'Content-Type':'application/json'},
-                            body: JSON.stringify({name: name, keyword: desc})
-                        });
-                        showMessage('Tag created');
+                        if (e.target.classList.contains('js-create-alias')) {
+                            await createAliasForDescription(desc);
+                        } else if (e.target.classList.contains('js-create-tag')) {
+                            await createTagForDescription(desc);
+                        } else {
+                            return;
+                        }
                         loadUntagged();
                     }}
                 ]


### PR DESCRIPTION
### Motivation
- Allow the Missing Tags workflow to create a tag alias (mapping a descriptor to an existing canonical tag) rather than forcing the user to create an entirely new tag. 
- Enable immediate application of newly-created aliases so reclassification can run automatically after an alias is made.

### Description
- Updated `frontend/missing_tags.html` to add client-side functions `fetchTags()`, `createTagForDescription()` and `createAliasForDescription()` to support both creating new tags and creating aliases from an untagged description.
- Replaced the single action button in the untagged table with two actions: `New Tag` and `Alias`, and wired their clicks to the new functions so users can choose either flow directly from the table.
- Alias creation is performed via `POST` to `php_backend/public/tag_aliases.php` with `alias`, `tag_id`, `match_type` and `active` fields, and the UI then triggers a canonical remap by calling `php_backend/public/tags.php` with `action: remap_aliases` to apply the new alias immediately.
- Preloads the list of existing canonical tags to prompt the user to select the correct canonical tag when creating an alias, and surfaces API error messages to the user (e.g. duplicate alias errors).

### Testing
- Ran `git diff --check` to validate patch formatting and found no issues.
- Launched the local PHP development server and manually loaded `frontend/missing_tags.html` to verify the new UI and flows rendered correctly; this manual check succeeded.
- Captured an automated Playwright screenshot of `http://127.0.0.1:8000/frontend/missing_tags.html` to validate the page appearance; capture succeeded.
- No automated tests requiring database access were run as requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698777527bb4832eb838471ad562c42c)