### PR TITLE
Improve landing page 'How Data Is Organised' diagram to show tag aliases

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -174,24 +174,46 @@
             <section class="mt-8 cards cards-roomy opacity-0 transition-opacity duration-700" data-no-card="true">
 
                 <h2 class="text-2xl font-semibold mb-4 text-indigo-700">How Data Is Organised</h2>
-                <svg role="img" aria-label="Segments link to categories and tags while groups stand alone" class="mx-auto mb-4" width="360" height="120">
+                <svg role="img" aria-label="Segments contain categories and tags, while tag aliases map descriptors to canonical tags used on transactions" class="mx-auto mb-4 w-full max-w-4xl" viewBox="0 0 900 290" preserveAspectRatio="xMidYMid meet">
                     <defs>
                         <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
                             <path d="M0,0 L10,5 L0,10 z" fill="#4338ca"></path>
                         </marker>
+                        <marker id="arrow-green" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto">
+                            <path d="M0,0 L10,5 L0,10 z" fill="#047857"></path>
+                        </marker>
                     </defs>
-                    <rect x="10" y="20" width="100" height="40" fill="#e0e7ff" stroke="#4338ca"></rect>
-                    <text x="60" y="45" text-anchor="middle" font-size="14" fill="#1f2937">Segment</text>
-                    <rect x="130" y="20" width="100" height="40" fill="#e0e7ff" stroke="#4338ca"></rect>
-                    <text x="180" y="45" text-anchor="middle" font-size="14" fill="#1f2937">Category</text>
-                    <rect x="250" y="20" width="100" height="40" fill="#e0e7ff" stroke="#4338ca"></rect>
-                    <text x="300" y="45" text-anchor="middle" font-size="14" fill="#1f2937">Tag</text>
-                    <line x1="110" y1="40" x2="130" y2="40" stroke="#4338ca" stroke-width="2" marker-end="url(#arrow)"></line>
-                    <line x1="230" y1="40" x2="250" y2="40" stroke="#4338ca" stroke-width="2" marker-end="url(#arrow)"></line>
-                    <rect x="130" y="80" width="100" height="40" fill="#d1fae5" stroke="#047857" stroke-dasharray="4 2"></rect>
-                    <text x="180" y="105" text-anchor="middle" font-size="14" fill="#1f2937">Group</text>
+                    <rect x="30" y="28" width="165" height="56" rx="8" fill="#e0e7ff" stroke="#4338ca"></rect>
+                    <text x="112" y="62" text-anchor="middle" font-size="18" fill="#1f2937">Segment</text>
+
+                    <rect x="240" y="28" width="165" height="56" rx="8" fill="#e0e7ff" stroke="#4338ca"></rect>
+                    <text x="322" y="62" text-anchor="middle" font-size="18" fill="#1f2937">Category</text>
+
+                    <rect x="450" y="28" width="165" height="56" rx="8" fill="#e0e7ff" stroke="#4338ca"></rect>
+                    <text x="532" y="62" text-anchor="middle" font-size="18" fill="#1f2937">Tag (canonical)</text>
+
+                    <rect x="450" y="132" width="165" height="56" rx="8" fill="#ede9fe" stroke="#7c3aed" stroke-dasharray="6 3"></rect>
+                    <text x="532" y="166" text-anchor="middle" font-size="18" fill="#1f2937">Tag Aliases</text>
+
+                    <rect x="662" y="28" width="205" height="56" rx="8" fill="#dbeafe" stroke="#1d4ed8"></rect>
+                    <text x="764" y="62" text-anchor="middle" font-size="18" fill="#1f2937">Transactions</text>
+
+                    <rect x="240" y="220" width="165" height="56" rx="8" fill="#d1fae5" stroke="#047857" stroke-dasharray="6 3"></rect>
+                    <text x="322" y="254" text-anchor="middle" font-size="18" fill="#1f2937">Group</text>
+
+                    <line x1="195" y1="56" x2="240" y2="56" stroke="#4338ca" stroke-width="2" marker-end="url(#arrow)"></line>
+                    <line x1="405" y1="56" x2="450" y2="56" stroke="#4338ca" stroke-width="2" marker-end="url(#arrow)"></line>
+                    <line x1="615" y1="56" x2="662" y2="56" stroke="#1d4ed8" stroke-width="2" marker-end="url(#arrow)"></line>
+                    <line x1="615" y1="158" x2="662" y2="84" stroke="#7c3aed" stroke-width="2" stroke-dasharray="6 4" marker-end="url(#arrow)"></line>
+                    <line x1="405" y1="248" x2="662" y2="84" stroke="#047857" stroke-width="2" stroke-dasharray="7 5" marker-end="url(#arrow-green)"></line>
+
+                    <text x="219" y="48" font-size="13" fill="#4338ca">1 → many</text>
+                    <text x="428" y="48" font-size="13" fill="#4338ca">1 → many</text>
+                    <text x="636" y="48" font-size="13" fill="#1d4ed8">stored tag</text>
+                    <text x="614" y="128" font-size="13" fill="#7c3aed">descriptor maps to canonical</text>
+                    <text x="463" y="225" font-size="13" fill="#047857">optional project/holiday roll-up</text>
                 </svg>
-                <p class="text-gray-700">Segments contain categories, and each category holds tags that label your transactions. Groups operate separately from this chain and are perfect for collecting transactions for holidays or projects, letting you see their total cost independently.</p>
+                <p class="text-gray-700">Segments contain categories, and each category contains canonical tags used to classify transactions. Tag aliases provide extra words or merchant descriptors that map back to those canonical tags (for example, an alias like “uber eats” mapping to a “Dining Out” tag). Groups remain separate from the segment/category/tag hierarchy and let you bundle transactions for projects, holidays, or any temporary initiative.</p>
             </section>
 
 


### PR DESCRIPTION
### Motivation
- Make the landing page explanation clearer by showing how canonical tags, tag aliases and groups relate to transactions. 
- Provide a wider, responsive diagram so the relationships are more obvious at a glance.

### Description
- Replaced the compact SVG in `frontend/index.html` with a wider, responsive SVG that shows Segment → Category → Tag (canonical), Tag Aliases mapping descriptors to canonical tags, Transactions using stored tags, and Groups as a separate roll-up. 
- Added a second marker for alias-style arrows, labeled connecting lines and short captions to clarify relationships. 
- Updated the explanatory paragraph below the diagram to explicitly describe canonical tags, alias mapping behavior, and the purpose of Groups.

### Testing
- Verified the updated markup diff for `frontend/index.html` to confirm the new SVG and text were applied. 
- Started a local PHP dev server (`php -S 0.0.0.0:8000 -t frontend`) to serve the modified frontend and confirmed the server started. 
- Attempted an automated visual capture with Playwright, but the Chromium process crashed (SIGSEGV) so a screenshot could not be produced. 
- Ran static searches to confirm tag alias code paths and models exist (e.g. `tag_aliases`, `TagAlias`), which matched the implemented diagram semantics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698777ccffc8832eb378a013b3b7c439)