### PR TITLE
Add theme-aware table grid and transparency styling

### DIFF
--- a/frontend/operational_ui.css
+++ b/frontend/operational_ui.css
@@ -221,18 +221,18 @@
 }
 
 
-/* Standard table presentation: parent surface controls background while headers stay high-contrast */
+/* Standard table presentation defaults to a transparent, borderless surface. */
 .ops-standard-table {
-    border: 1px solid #dbe3ef;
+    border: 0;
     border-radius: 0.75rem;
     background: transparent;
-    box-shadow: 0 8px 20px -18px rgba(15, 23, 42, 0.55);
+    box-shadow: none;
 }
 
 .ops-standard-table .tabulator-header {
-    background: #e2e8f0;
+    background: transparent;
     color: #0f172a;
-    border-bottom: 1px solid #cbd5e1;
+    border-bottom: 0;
 }
 
 .ops-standard-table .tabulator-header .tabulator-col {
@@ -248,25 +248,40 @@
 .ops-standard-table .tabulator-tableholder .tabulator-table,
 .ops-standard-table .tabulator-footer,
 .ops-standard-table .tabulator-paginator {
-    background: #ffffff;
+    background: transparent;
 }
 
 .ops-standard-table .tabulator-cell {
     font-size: 0.8125rem;
     color: #1e293b;
-    border-color: #e2e8f0;
+    border-color: transparent;
 }
 
 .ops-table-row {
-    background: #ffffff !important;
+    background: transparent !important;
 }
 
 .ops-table-row:nth-child(even) {
-    background: #f8fafc !important;
+    background: transparent !important;
 }
 
 .ops-table-row:hover {
-    background: #eef2ff !important;
+    background: transparent !important;
+}
+
+.ops-standard-table .tabulator-paginator {
+    border-top: 0;
+}
+
+.ops-standard-table .tabulator-col,
+.ops-standard-table .tabulator-row,
+.ops-standard-table .tabulator-cell {
+    border-right-color: transparent !important;
+    border-left-color: transparent !important;
+}
+
+.ops-standard-table .tabulator-row {
+    border-bottom-color: transparent !important;
 }
 
 /* Dashboard pages keep table body surfaces transparent so page cards show through. */
@@ -282,45 +297,109 @@
 
 .ops-standard-table .tabulator-calcs-row,
 .ops-standard-table .tabulator-calcs-row .tabulator-cell {
-    background: #e2e8f0 !important;
+    background: transparent !important;
     color: #0f172a;
     font-weight: 600;
 }
 
-.ops-table-paginator {
+
+/* Professional mode uses visible grid lines and a solid table surface. */
+.theme-professional .ops-standard-table {
+    border: 1px solid #dbe3ef;
+    box-shadow: 0 8px 20px -18px rgba(15, 23, 42, 0.55);
+}
+
+.theme-professional .ops-standard-table .tabulator-header {
+    background: #e2e8f0;
+    border-bottom: 1px solid #cbd5e1;
+}
+
+.theme-professional .ops-standard-table .tabulator-tableholder,
+.theme-professional .ops-standard-table .tabulator-tableholder .tabulator-table,
+.theme-professional .ops-standard-table .tabulator-footer,
+.theme-professional .ops-standard-table .tabulator-paginator {
+    background: #ffffff;
+}
+
+.theme-professional .ops-standard-table .tabulator-cell,
+.theme-professional .ops-standard-table .tabulator-col,
+.theme-professional .ops-standard-table .tabulator-row {
+    border-color: #e2e8f0 !important;
+}
+
+.theme-professional .ops-table-row {
+    background: #ffffff !important;
+}
+
+.theme-professional .ops-table-row:nth-child(even) {
+    background: #f8fafc !important;
+}
+
+.theme-professional .ops-table-row:hover {
+    background: #eef2ff !important;
+}
+
+.theme-professional .ops-standard-table .tabulator-calcs-row,
+.theme-professional .ops-standard-table .tabulator-calcs-row .tabulator-cell {
+    background: #e2e8f0 !important;
+}
+
+.theme-professional .ops-table-paginator {
     border-top: 1px solid #e2e8f0;
 }
 
 .ops-native-table {
     width: 100%;
     border-collapse: collapse;
-    border: 1px solid #dbe3ef;
+    border: 0;
     border-radius: 0.5rem;
     overflow: hidden;
     font-size: 0.8125rem;
     color: #1e293b;
-    background: #ffffff;
+    background: transparent;
 }
 
 .ops-native-table th,
 .ops-native-table td {
     padding: 0.45rem 0.6rem;
-    border-bottom: 1px solid #e2e8f0;
+    border-bottom: 0;
     vertical-align: top;
 }
 
 .ops-native-table th {
     width: 20%;
-    background: #e2e8f0;
+    background: transparent;
     color: #0f172a;
     font-weight: 700;
     text-align: left;
 }
 
 .ops-native-table tbody tr:nth-child(even) td {
-    background: #f8fafc;
+    background: transparent;
 }
 
 .ops-native-table tbody tr:hover td {
+    background: transparent;
+}
+
+.theme-professional .ops-native-table {
+    border: 1px solid #dbe3ef;
+    background: #ffffff;
+}
+
+.theme-professional .ops-native-table th,
+.theme-professional .ops-native-table td {
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.theme-professional .ops-native-table th {
+    background: #e2e8f0;
+}
+
+.theme-professional .ops-native-table tbody tr:nth-child(even) td {
+    background: #f8fafc;
+}
+
+.theme-professional .ops-native-table tbody tr:hover td {
     background: #e2e8f0;
 }


### PR DESCRIPTION
### Motivation
- Provide two table presentations so tables render with a visible grid and solid surfaces when the professional theme is enabled and remain 100% transparent and gridless by default.

### Description
- Updated `frontend/operational_ui.css` to make `.ops-standard-table` and `.ops-native-table` borderless, transparent, and shadowless by default, removing grid lines, row striping and hover fills.
- Added `.theme-professional` overrides that restore borders, solid backgrounds, cell/row grid lines, row striping, hover states, calc-row emphasis, and paginator borders for professional mode.
- Ensured Tabulator-specific elements such as `.tabulator-header`, `.tabulator-cell`, `.tabulator-row`, calc rows, and paginator follow the selected theme state.

### Testing
- Launched a local dev server with `php -S 0.0.0.0:8000` and verified the app served successfully.
- Ran an automated Playwright visual check that loaded `frontend/groups.html` and captured screenshots for both default (transparent/no-grid) and professional (gridded/solid) modes, both successful.
- No database-requiring tests were executed in accordance with project constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698860c301f0832ea9801c6126d74a1c)