### PR TITLE
Transaction tag select-or-create: add tag list, new-name input and submit logic

### DIFF
--- a/frontend/transaction.html
+++ b/frontend/transaction.html
@@ -95,8 +95,9 @@ window.renderPageHeader(pageMain, {
         Promise.all([
             fetch('../php_backend/public/transaction.php?id=' + id).then(r => r.json()),
             fetch('../php_backend/public/groups.php').then(r => r.json()),
-            fetch('../php_backend/public/categories.php').then(r => r.json())
-        ]).then(([tx, groups, categories]) => {
+            fetch('../php_backend/public/categories.php').then(r => r.json()),
+            fetch('../php_backend/public/tags.php').then(r => r.json())
+        ]).then(([tx, groups, categories, tags]) => {
             if (tx.error) {
                 container.textContent = 'Transaction not found.';
                 return;
@@ -155,7 +156,14 @@ window.renderPageHeader(pageMain, {
                     </div>
                 </div>
                 <div class="pt-6 space-y-4">
-                    <label class="block">Tag: <input type="text" id="tag" class="border p-2 rounded w-full" data-help="Enter a new tag name to auto-tag similar transactions"></label>
+                    <div>
+                        <label for="tag-select" class="block font-medium">Tag (select existing or create new)</label>
+                        <p class="text-sm text-slate-500 mb-2">Choose an existing tag from the list, or type a new name below if no match exists.</p>
+                        <select id="tag-select" class="border p-2 rounded w-full" data-help="Choose an existing tag name to reuse it">
+                            <option value="">-- Select existing tag --</option>
+                        </select>
+                    </div>
+                    <label for="tag" class="block">New tag name (only for new tags): <input type="text" id="tag" class="border p-2 rounded w-full" data-help="Only fill this in when you need to create a brand new tag"></label>
                     <label class="block">Category Group: <select id="category" class="border p-2 rounded w-full" data-help="Assign a category group"></select></label>
                     <label class="block">Group: <select id="group" class="border p-2 rounded w-full" data-help="Assign a group"></select></label>
                 </div>
@@ -197,12 +205,27 @@ window.renderPageHeader(pageMain, {
                 }
             }
             const tagInput = form.querySelector('#tag');
-            if (tx.tag_name) {
-                tagInput.parentElement.classList.add('hidden');
-            }
+            const tagSelect = form.querySelector('#tag-select');
             const groupSel = form.querySelector('#group');
             const catSel = form.querySelector('#category');
-            tagInput.value = tx.tag_name || '';
+            const tagByName = {};
+            tags.forEach(tag => {
+                const opt = document.createElement('option');
+                opt.value = tag.id;
+                opt.textContent = tag.name;
+                tagSelect.appendChild(opt);
+                tagByName[(tag.name || '').toLowerCase()] = String(tag.id);
+            });
+            if (tx.tag_id) {
+                tagSelect.value = String(tx.tag_id);
+            } else if (tx.tag_name) {
+                const matchingTagId = tagByName[tx.tag_name.toLowerCase()];
+                if (matchingTagId) {
+                    tagSelect.value = matchingTagId;
+                } else {
+                    tagInput.value = tx.tag_name;
+                }
+            }
             const blankGrp = document.createElement('option');
             blankGrp.value = '';
             blankGrp.textContent = '-- None --';
@@ -277,8 +300,13 @@ window.renderPageHeader(pageMain, {
                 };
                 if (groupSel.value !== '') payload.group_id = groupSel.value;
                 if (catSel.value !== '') payload.category_id = catSel.value;
-                if (tx.tag_id) payload.tag_id = tx.tag_id;
-                else if (tagInput.value.trim() !== '') payload.tag_name = tagInput.value.trim();
+                const selectedTagId = tagSelect.value;
+                const enteredTagName = tagInput.value.trim();
+                if (selectedTagId !== '') {
+                    payload.tag_id = selectedTagId;
+                } else if (enteredTagName !== '') {
+                    payload.tag_name = enteredTagName;
+                }
 
                 fetch('../php_backend/public/update_transaction.php', {
                     method: 'POST',


### PR DESCRIPTION
### Motivation
- Provide a clearer combo flow for tagging transactions so users can reuse existing tags or create new ones without ambiguity.
- Ensure the frontend sends `tag_id` when reusing a tag and only sends `tag_name` when creating a brand new tag so backend logic in `update_transaction.php` behaves correctly.
- Keep tag controls visible for already-tagged transactions to allow reassignment and avoid hiding controls completely.

### Description
- Fetch available tags from `php_backend/public/tags.php` alongside transaction, groups and categories in `frontend/transaction.html`.
- Replace the single `#tag` text input with an existing-tag `<select id="tag-select">` plus a separate free-text `#tag` input and explanatory label/help text.
- Populate the `<select>` from the `tags` API and preselect the transaction's `tag_id` when present, otherwise prefill the free-text name when the current tag name doesn't match any existing tag.
- Update form submit logic to include `tag_id` when an existing tag is selected, or `tag_name` when no existing tag is chosen and a new name is provided.

### Testing
- Started a local PHP dev server and used an automated Playwright script to load `frontend/transaction.html?id=1` and capture a screenshot for visual verification, which succeeded.
- No database-dependent automated tests were run, per instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886105e830832ea2e5c8be2fdbc893)