### PR TITLE
Fix missing-tags alias popup save flow and trigger tagging backend

### DIFF
--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -160,28 +160,38 @@ window.renderPageHeader(pageMain, {
             return;
         }
 
-        const aliasRes = await fetch('../php_backend/public/tag_aliases.php', {
-            method: 'POST',
-            headers: {'Content-Type':'application/json'},
-            body: JSON.stringify({
-                alias: description,
-                tag_id: selectedTag.id,
-                match_type: 'contains',
-                active: true
-            })
-        });
-        const aliasData = await aliasRes.json();
-        if (!aliasRes.ok) {
-            showMessage(aliasData.error || 'Unable to create alias');
-            return;
-        }
+        try {
+            const aliasRes = await fetch('../php_backend/public/tag_aliases.php', {
+                method: 'POST',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({
+                    alias: description,
+                    tag_id: selectedTag.id,
+                    match_type: 'contains',
+                    active: true
+                })
+            });
+            const aliasData = await aliasRes.json();
+            if (!aliasRes.ok) {
+                showMessage(aliasData.error || 'Unable to create alias', 'error');
+                return;
+            }
 
-        await fetch('../php_backend/public/tags.php', {
-            method: 'POST',
-            headers: {'Content-Type':'application/json'},
-            body: JSON.stringify({action: 'remap_aliases', dry_run: false})
-        });
-        showMessage('Tag alias created');
+            const taggingRes = await fetch('../php_backend/public/run_processes.php', {
+                method: 'POST',
+                headers: {'Content-Type':'application/json'},
+                body: JSON.stringify({action: 'tagging'})
+            });
+            const taggingData = await taggingRes.json();
+            if (!taggingRes.ok) {
+                showMessage(taggingData.error || 'Alias saved but tagging failed', 'error');
+                return;
+            }
+
+            showMessage(`Tag alias created and tagging run (${taggingData.tagged || 0} transactions updated)`);
+        } catch (error) {
+            showMessage('Unable to save alias right now', 'error');
+        }
     }
 
     // Retrieve untagged transaction summaries and display them


### PR DESCRIPTION
### Motivation
- The alias popup on the Missing Tags page suggested a tag but clicking **Save Alias** appeared to do nothing because the flow did not surface errors or trigger the tagging process.
- The intended behaviour is to create the alias mapping and then run the tagging backend so newly created aliases are immediately applied to transactions.

### Description
- Updated `createAliasForDescription` in `frontend/missing_tags.html` to wrap the alias creation flow in a `try/catch` and provide explicit user feedback on errors. 
- The code now posts the new alias to `php_backend/public/tag_aliases.php` and, on success, immediately calls `php_backend/public/run_processes.php` with `{ action: 'tagging' }` to apply tagging. 
- Failure at either stage (alias creation or tagging run) shows a clear error via `showMessage`, and a success message now includes the number of transactions updated.

### Testing
- No automated database-dependent tests were run in accordance with the instruction to avoid tests that require DB access. 
- The change is limited to frontend behaviour in `frontend/missing_tags.html` and uses existing API endpoints `tag_aliases.php` and `run_processes.php` for server interactions. 
- Basic repository status and commit operations were executed during the change (non-test verification) and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698865ddd324832e9f49af60d90d7c92)