### PR TITLE
Fix missing-tags Save Alias action resolving selected tag

### DIFF
--- a/frontend/missing_tags.html
+++ b/frontend/missing_tags.html
@@ -109,7 +109,12 @@ window.renderPageHeader(pageMain, {
 
             const close = (tagId) => {
                 modal.remove();
-                resolve(availableTags.find((tag) => tag.id === Number(tagId)) || null);
+                if (!tagId) {
+                    resolve(null);
+                    return;
+                }
+                const selectedTag = availableTags.find((tag) => String(tag.id) === String(tagId)) || null;
+                resolve(selectedTag);
             };
 
             modal.addEventListener('click', (event) => {


### PR DESCRIPTION
### Motivation
- The Missing Tags modal sometimes appeared to do nothing when clicking `Save Alias` because the selected tag lookup failed when tag IDs were string-typed and there was no explicit null guard.

### Description
- Update `frontend/missing_tags.html` modal `close` handler to return early on empty selections and to match tag IDs using string comparison (`String(tag.id) === String(tagId)`).
- This change makes the `Save Alias` action reliably resolve the selected tag and preserves cancel/overlay-close behavior.

### Testing
- Inspected and validated the edit with `git diff -- frontend/missing_tags.html` which shows the new null guard and string comparison logic.
- No database-dependent automated tests were run per project instruction to avoid tests requiring DB access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69886737d7e0832e8bdae178213af5c6)