### PR TITLE
Trigger segment mapping after tag/category updates

### DIFF
--- a/php_backend/public/update_transaction.php
+++ b/php_backend/public/update_transaction.php
@@ -5,6 +5,7 @@ require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';
+require_once __DIR__ . '/../models/Segment.php';
 require_once __DIR__ . '/../models/TransactionGroup.php';
 require_once __DIR__ . '/../models/Log.php';
 
@@ -92,13 +93,15 @@ try {
 
     $applied = $tagChanged ? Tag::applyToAccountTransactions((int)$accountId) : 0;
     $categorised = ($tagChanged || $categoryChanged) ? CategoryTag::applyToAccountTransactions((int)$accountId) : 0;
+    $segmented = ($tagChanged || $categoryChanged) ? Segment::applyToTransactions() : 0;
 
     echo json_encode([
         'status' => 'ok',
         'tag_id' => $tagId ? (int)$tagId : null,
         'group_id' => $groupId === '' ? null : ($groupId !== null ? (int)$groupId : null),
         'auto_tagged' => $applied,
-        'auto_categorised' => $categorised
+        'auto_categorised' => $categorised,
+        'auto_segmented' => $segmented
     ]);
 } catch (Exception $e) {
     http_response_code(500);

--- a/php_backend/public/update_transaction_tag.php
+++ b/php_backend/public/update_transaction_tag.php
@@ -5,6 +5,7 @@ require_api_auth();
 require_once __DIR__ . '/../models/Transaction.php';
 require_once __DIR__ . '/../models/Tag.php';
 require_once __DIR__ . '/../models/CategoryTag.php';
+require_once __DIR__ . '/../models/Segment.php';
 require_once __DIR__ . '/../models/Log.php';
 
 header('Content-Type: application/json');
@@ -48,12 +49,14 @@ try {
 
     $applied = Tag::applyToAccountTransactions((int)$accountId);
     $categorised = CategoryTag::applyToAccountTransactions((int)$accountId);
+    $segmented = Segment::applyToTransactions();
 
     echo json_encode([
         'status' => 'ok',
         'tag_id' => (int)$tagId,
         'auto_tagged' => $applied,
         'auto_categorised' => $categorised,
+        'auto_segmented' => $segmented,
     ]);
 } catch (Exception $e) {
     http_response_code(500);


### PR DESCRIPTION
### Motivation
- Ensure segment assignments are kept in sync immediately after a transaction is tagged or its category is changed so segmentation reports and dashboards reflect updates without requiring a separate manual process.

### Description
- Import the `Segment` model and invoke `Segment::applyToTransactions()` after auto-tagging and category mapping in both `php_backend/public/update_transaction_tag.php` and `php_backend/public/update_transaction.php` so segments are (re)applied in the same flow.
- Only run the segment mapping in `update_transaction.php` when a tag or category change occurred, and always run it after the tagging flow in `update_transaction_tag.php`.
- Expose the number of transactions updated by segmentation via a new `auto_segmented` integer in both endpoint JSON responses.

### Testing
- Ran PHP syntax checks which passed for both modified endpoints: `php -l php_backend/public/update_transaction_tag.php` and `php -l php_backend/public/update_transaction.php` (both succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698867f47470832e80811be92ef795e2)