### PR TITLE
Add test-runner task for link preview auth issue

### DIFF
--- a/wiki/CodebaseReviewTasks.md
+++ b/wiki/CodebaseReviewTasks.md
@@ -19,3 +19,8 @@
 **Task:** Expand `frontend/js/upload.test.js` to cover edge cases for user-agent detection (iPhone, iPad, empty/undefined UA, and case-insensitive inputs).
 
 **Why:** The current test only checks one macOS and one Windows user agent, leaving the known false-positive risk and fallback behavior untested.
+
+## 5) Test runner bug fix task
+**Task:** Refactor the link preview test in `tests/run_tests.php` so it does not include the authenticated endpoint file directly (for example, by extracting metadata parsing into a reusable function/class and testing that unit instead).
+
+**Why:** Running `php tests/run_tests.php` currently exits before reporting PASS/FAIL lines because the `link_preview.php` include triggers API auth flow (`require_api_auth()`), which can terminate execution during test setup.


### PR DESCRIPTION
### Motivation
- Record a follow-up task to address a test-runner failure where `tests/run_tests.php` directly includes the authenticated endpoint `php_backend/public/link_preview.php`, which invokes `require_api_auth()` and can terminate the test run early.

### Description
- Add a new entry `## 5) Test runner bug fix task` to `wiki/CodebaseReviewTasks.md` recommending refactoring the link preview logic (for example by extracting metadata parsing into a reusable function/class) so it can be unit-tested without pulling in endpoint auth bootstrap.

### Testing
- Ran PHP lint across the codebase with `php -l` and observed no syntax errors.
- Ran the JavaScript upload unit tests with `node frontend/js/upload.test.js` and they passed.
- Executed `php tests/run_tests.php` and reproduced the issue: the script produced no PASS/FAIL output due to the `link_preview.php` include triggering the auth flow, demonstrating the reported problem.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abf39a6d44832e855fd381d2113b43)