### PR TITLE
Include transaction segment_id and ofx_type in backup and restore

### DIFF
--- a/php_backend/public/backup.php
+++ b/php_backend/public/backup.php
@@ -58,7 +58,7 @@ try {
         $data['segments'] = $getAll('SELECT id, name, description FROM segments ORDER BY id');
     }
     if (in_array('transactions', $parts)) {
-        $data['transactions'] = $getAll('SELECT id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id, bank_ofx_id FROM transactions ORDER BY id');
+        $data['transactions'] = $getAll('SELECT id, account_id, date, amount, description, memo, category_id, segment_id, tag_id, group_id, transfer_id, ofx_id, ofx_type, bank_ofx_id FROM transactions ORDER BY id');
     }
     if (in_array('budgets', $parts)) {
         $data['budgets'] = $getAll('SELECT category_id, month, year, amount FROM budgets ORDER BY category_id, year, month');

--- a/php_backend/public/restore.php
+++ b/php_backend/public/restore.php
@@ -232,7 +232,7 @@ try {
     }
 
     if (isset($data['transactions'])) {
-        $stmtTx = $db->prepare('INSERT IGNORE INTO transactions (id, account_id, date, amount, description, memo, category_id, tag_id, group_id, transfer_id, ofx_id, bank_ofx_id) VALUES (:id, :account_id, :date, :amount, :description, :memo, :category_id, :tag_id, :group_id, :transfer_id, :ofx_id, :bank_ofx_id)');
+        $stmtTx = $db->prepare('INSERT IGNORE INTO transactions (id, account_id, date, amount, description, memo, category_id, segment_id, tag_id, group_id, transfer_id, ofx_id, ofx_type, bank_ofx_id) VALUES (:id, :account_id, :date, :amount, :description, :memo, :category_id, :segment_id, :tag_id, :group_id, :transfer_id, :ofx_id, :ofx_type, :bank_ofx_id)');
         foreach ($data['transactions'] as $row) {
             $stmtTx->execute([
                 'id' => $row['id'],
@@ -242,10 +242,12 @@ try {
                 'description' => $row['description'],
                 'memo' => $row['memo'],
                 'category_id' => $row['category_id'],
+                'segment_id' => $row['segment_id'] ?? null,
                 'tag_id' => $row['tag_id'],
                 'group_id' => $row['group_id'],
                 'transfer_id' => $row['transfer_id'],
                 'ofx_id' => $row['ofx_id'],
+                'ofx_type' => $row['ofx_type'] ?? null,
                 'bank_ofx_id' => $row['bank_ofx_id'] ?? null
             ]);
         }


### PR DESCRIPTION
### Motivation
- Preserve additional transaction metadata (`segment_id` and `ofx_type`) when exporting and importing backups so segmentation and OFX import details are not lost.
- Maintain data integrity and compatibility when restoring older or newer backups that may include these fields.

### Description
- Updated the transactions `SELECT` in `php_backend/public/backup.php` to include `segment_id` and `ofx_type` in the exported JSON payload.
- Updated the `INSERT IGNORE` statement in `php_backend/public/restore.php` to accept `segment_id` and `ofx_type` and added corresponding parameter bindings with null-coalescing fallbacks for compatibility with older backups.
- Kept existing backup parts (users, accounts, categories, tags, category_tags, budgets, projects, etc.) unchanged and preserved logging behavior during backup and restore.

### Testing
- Ran the PHP unit test suite via `phpunit` and the run completed successfully without regressions.
- Performed an end-to-end backup and restore integration test by creating transactions containing `segment_id` and `ofx_type`, running the backup, and restoring the payload, and confirmed the fields were preserved after restore.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7e066874c832e9df484297b84906a)