### PR TITLE
Make AI tag category optional and derive category from tag mapping

### DIFF
--- a/php_backend/public/ai_tags.php
+++ b/php_backend/public/ai_tags.php
@@ -38,9 +38,10 @@ $tagContext = AiTaggingPipeline::buildAliasAwareTagContext($tagContextRows, 5, 2
 $txnMap = [];
 $aliasResolutions = [];
 
-$prompt = "You are a financial assistant. For each transaction provide a short tag, a brief description for the tag and one of the provided categories. If the transaction details are ambiguous, use a generic tag name. ";
+$prompt = "You are a financial assistant. For each transaction provide a short canonical tag and an optional brief description for that tag. If the transaction details are ambiguous, use a generic canonical tag name. ";
 $prompt .= "Aliases are examples that map to canonical tags. Always return the canonical tag name in the tag field, never an alias literal. ";
-$prompt .= "Return JSON only as a top-level array of objects {\"id\":<id>,\"tag\":\"tag name\",\"description\":\"tag description\",\"category\":\"category name\"} ";
+$prompt .= "Prioritise canonical tag selection accuracy over other metadata. Category is optional metadata and may be omitted. ";
+$prompt .= "Return JSON only as a top-level array of objects {\"id\":<id>,\"tag\":\"tag name\",\"description\":\"tag description\",\"category\":\"optional category name\"} ";
 $prompt .= "or as an object {\"transactions\":[...]} containing that array. Do not return a single object.\n\n";
 
 if ($tagContext['text'] !== '') {
@@ -142,7 +143,7 @@ if (json_last_error() !== JSON_ERROR_NONE) {
 if (is_array($suggestions)) {
     if (isset($suggestions['transactions']) && is_array($suggestions['transactions'])) {
         $suggestions = $suggestions['transactions'];
-    } elseif (isset($suggestions['id']) && isset($suggestions['tag']) && isset($suggestions['category'])) {
+    } elseif (isset($suggestions['id']) && isset($suggestions['tag'])) {
         $suggestions = [$suggestions];
     }
 
@@ -161,7 +162,7 @@ foreach ($suggestions as $s) {
     $catName = $s['category'] ?? null;
     $tagDesc = $s['description'] ?? null;
 
-    if (!$txId || !$tagName || !$catName) continue;
+    if (!$txId || !$tagName) continue;
 
     $txn = $txnMap[$txId] ?? null;
     if (!$txn) continue;
@@ -192,19 +193,28 @@ foreach ($suggestions as $s) {
         }
     }
 
-    $stmt = $db->prepare('SELECT id FROM categories WHERE name = :name LIMIT 1');
-    $stmt->execute(['name' => $catName]);
-    $catId = $stmt->fetchColumn();
-    if ($catId === false) continue;
-
-    try {
-        CategoryTag::add((int)$catId, (int)$tagId);
-    } catch (Exception $e) {
-        // Tag may already be assigned; ignore
+    $catId = CategoryTag::getCategoryId((int)$tagId);
+    if ($catId === null && $catName) {
+        $stmt = $db->prepare('SELECT id FROM categories WHERE name = :name LIMIT 1');
+        $stmt->execute(['name' => $catName]);
+        $fallbackCatId = $stmt->fetchColumn();
+        if ($fallbackCatId !== false) {
+            try {
+                CategoryTag::add((int)$fallbackCatId, (int)$tagId);
+            } catch (Exception $e) {
+                // Tag may already be assigned; ignore
+            }
+            $catId = CategoryTag::getCategoryId((int)$tagId);
+        }
     }
 
-    $upd = $db->prepare('UPDATE transactions SET tag_id = :tag, category_id = :cat WHERE description = :desc AND memo <=> :memo AND tag_id IS NULL');
-    $upd->execute(['tag' => $tagId, 'cat' => (int)$catId, 'desc' => $txn['description'], 'memo' => $txn['memo']]);
+    if ($catId !== null) {
+        $upd = $db->prepare('UPDATE transactions SET tag_id = :tag, category_id = :cat WHERE description = :desc AND memo <=> :memo AND tag_id IS NULL');
+        $upd->execute(['tag' => $tagId, 'cat' => (int)$catId, 'desc' => $txn['description'], 'memo' => $txn['memo']]);
+    } else {
+        $upd = $db->prepare('UPDATE transactions SET tag_id = :tag WHERE description = :desc AND memo <=> :memo AND tag_id IS NULL');
+        $upd->execute(['tag' => $tagId, 'desc' => $txn['description'], 'memo' => $txn['memo']]);
+    }
     $processed += $upd->rowCount();
 }
 


### PR DESCRIPTION
### Motivation

- Relax the AI-to-backend contract so the model is required to return only `id` and `tag`, and `category` is optional metadata. 
- Prioritise selecting canonical tags and avoid forcing a category when tag->category mappings already exist or are preferred. 
- Ensure backward compatibility by using any returned `category` only as a fallback when no tag->category mapping exists. 

### Description

- Updated the AI prompt in `php_backend/public/ai_tags.php` to instruct the model to return a canonical `tag` and treat `category` as optional metadata, emphasising canonical tag accuracy. 
- Accept single-object AI responses when they include only `id` and `tag` (no longer require `category`) and validate suggestions requiring only `id + tag`. 
- After resolving or creating the canonical `tag_id`, derive `category_id` via `CategoryTag::getCategoryId($tagId)` and only set `category_id` on transactions when a mapping exists. 
- Added a backward-compatible fallback that, if `CategoryTag::getCategoryId` returns null and the AI supplied a `category`, attempts to look up the category by name and call `CategoryTag::add(...)`, then re-derive the mapping; otherwise updates transactions with `tag_id` only.

### Testing

- Ran PHP syntax check: `php -l php_backend/public/ai_tags.php`, which passed. 
- No database-dependent test suite was executed to avoid requiring DB access per repository constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca2fa70be4832eac5d8f0d8e936ccd)