### PR TITLE
Add selectable AI model dropdown with dynamic model discovery

### DIFF
--- a/php_backend/public/ai_models.php
+++ b/php_backend/public/ai_models.php
@@ -1,0 +1,61 @@
+<?php
+require_once __DIR__ . '/../auth.php';
+require_once __DIR__ . '/../models/Setting.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['user_id'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+$apiKey = Setting::get('openai_api_token');
+if (!$apiKey) {
+    http_response_code(400);
+    echo json_encode(['error' => 'OpenAI API token not configured']);
+    exit;
+}
+
+$ch = curl_init('https://api.openai.com/v1/models');
+curl_setopt_array($ch, [
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => [
+        'Authorization: Bearer ' . $apiKey,
+    ],
+    CURLOPT_TIMEOUT => 20,
+]);
+
+$response = curl_exec($ch);
+$status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+$error = curl_error($ch);
+curl_close($ch);
+
+if ($response === false || $status >= 400) {
+    http_response_code(502);
+    echo json_encode(['error' => $error ?: 'Failed to fetch models']);
+    exit;
+}
+
+$payload = json_decode($response, true);
+if (!is_array($payload) || !isset($payload['data']) || !is_array($payload['data'])) {
+    http_response_code(502);
+    echo json_encode(['error' => 'Invalid model list response']);
+    exit;
+}
+
+$models = [];
+foreach ($payload['data'] as $item) {
+    if (!isset($item['id']) || !is_string($item['id'])) {
+        continue;
+    }
+    if (strpos($item['id'], 'gpt-') !== 0 && strpos($item['id'], 'o') !== 0) {
+        continue;
+    }
+    $models[] = $item['id'];
+}
+
+$models = array_values(array_unique($models));
+sort($models);
+
+echo json_encode(['models' => $models]);

--- a/settings.php
+++ b/settings.php
@@ -28,6 +28,13 @@ $message = '';
 $openai = Setting::get('openai_api_token') ?? '';
 $batch = Setting::get('ai_tag_batch_size') ?? '20';
 $aiModel = Setting::get('ai_model') ?? 'gpt-5-nano';
+$recommendedModels = [
+    'gpt-5',
+    'gpt-5-mini',
+    'gpt-5-nano',
+    'o4-mini',
+    'o3',
+];
 $aiTemp = Setting::get('ai_temperature') ?? '1';
 $aiDebug = Setting::get('ai_debug') === '1';
 $retention = Setting::get('log_retention_days') ?? '30';
@@ -219,7 +226,18 @@ $bg600 = "bg-{$colorScheme}-600";
                 <input type="number" name="ai_tag_batch_size" value="<?= htmlspecialchars($batch) ?>" class="border p-2 rounded w-full" data-help="How many transactions to submit for AI tagging at once">
             </label>
             <label class="block">AI Model:
-                <input type="text" name="ai_model" value="<?= htmlspecialchars($aiModel) ?>" class="border p-2 rounded w-full" data-help="Model name for OpenAI responses">
+                <select id="ai-model-select" class="border p-2 rounded w-full" data-help="Choose from recommended models or models available to your API token">
+                    <?php foreach ($recommendedModels as $modelOption): ?>
+                        <option value="<?= htmlspecialchars($modelOption) ?>" <?= $modelOption === $aiModel ? 'selected' : '' ?>><?= htmlspecialchars($modelOption) ?></option>
+                    <?php endforeach; ?>
+                    <?php if (!in_array($aiModel, $recommendedModels, true) && $aiModel !== ''): ?>
+                        <option value="<?= htmlspecialchars($aiModel) ?>" selected><?= htmlspecialchars($aiModel) ?> (Saved)</option>
+                    <?php endif; ?>
+                    <option value="__custom__">Custom model…</option>
+                </select>
+                <input type="text" id="ai-model-input" name="ai_model" value="<?= htmlspecialchars($aiModel) ?>" class="border p-2 rounded w-full mt-2" data-help="Model name for OpenAI responses">
+                <button type="button" id="refresh-models" class="mt-2 text-sm px-3 py-1 border rounded" aria-label="Refresh available AI models">Refresh available models</button>
+                <p id="ai-model-status" class="text-xs text-gray-600 mt-1"></p>
             </label>
             <label class="block">AI Temperature:
                 <input type="number" step="0.1" name="ai_temperature" value="<?= htmlspecialchars($aiTemp) ?>" class="border p-2 rounded w-full" data-help="Creativity level for AI responses">
@@ -343,6 +361,70 @@ $bg600 = "bg-{$colorScheme}-600";
       updateWeightPreview();
       if (weightSelect) {
         weightSelect.addEventListener('change', updateWeightPreview);
+      }
+
+      const modelSelect = document.getElementById('ai-model-select');
+      const modelInput = document.getElementById('ai-model-input');
+      const refreshModelsBtn = document.getElementById('refresh-models');
+      const modelStatus = document.getElementById('ai-model-status');
+
+      const syncModelSelect = () => {
+        if (!modelSelect || !modelInput) {
+            return;
+        }
+        const hasOption = Array.from(modelSelect.options).some(option => option.value === modelInput.value);
+        modelSelect.value = hasOption ? modelInput.value : '__custom__';
+      };
+
+      if (modelSelect && modelInput) {
+        modelSelect.addEventListener('change', () => {
+            if (modelSelect.value !== '__custom__') {
+                modelInput.value = modelSelect.value;
+            }
+        });
+        modelInput.addEventListener('input', syncModelSelect);
+        syncModelSelect();
+      }
+
+      const renderModelOptions = (models) => {
+        if (!modelSelect || !Array.isArray(models)) {
+            return;
+        }
+        const selectedValue = modelInput ? modelInput.value : '';
+        const staticValues = <?= json_encode($recommendedModels) ?>;
+        const merged = Array.from(new Set(staticValues.concat(models))).sort();
+        modelSelect.innerHTML = '';
+        merged.forEach(model => {
+            const option = document.createElement('option');
+            option.value = model;
+            option.textContent = model;
+            if (model === selectedValue) {
+                option.selected = true;
+            }
+            modelSelect.appendChild(option);
+        });
+        const customOption = document.createElement('option');
+        customOption.value = '__custom__';
+        customOption.textContent = 'Custom model…';
+        modelSelect.appendChild(customOption);
+        syncModelSelect();
+      };
+
+      if (refreshModelsBtn) {
+        refreshModelsBtn.addEventListener('click', async () => {
+            if (modelStatus) modelStatus.textContent = 'Loading models…';
+            try {
+                const res = await fetch('php_backend/public/ai_models.php');
+                const data = await res.json();
+                if (!res.ok || data.error) {
+                    throw new Error(data.error || 'Failed to load models');
+                }
+                renderModelOptions(data.models || []);
+                if (modelStatus) modelStatus.textContent = 'Model list updated.';
+            } catch (error) {
+                if (modelStatus) modelStatus.textContent = error.message;
+            }
+        });
       }
     </script>
   </body>


### PR DESCRIPTION
### Motivation
- Provide a user-friendly way to choose modern AI models and let the app use the latest available models from the OpenAI API instead of relying on a free-text field. 
- Make it easy to pick a recommended model or a model actually available to the configured API token. 
- Preserve existing saved model values and allow custom model names when needed.

### Description
- Replaced the free-text `ai_model` input on the settings page with a hybrid selector (dropdown + custom input) and added a `Refresh available models` button to update options dynamically, implemented in `settings.php`.
- Added a small recommended model list (`gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `o4-mini`, `o3`) and client-side JS to merge recommended and discovered models and keep the dropdown and custom input synchronized.
- Implemented a new authenticated backend endpoint `php_backend/public/ai_models.php` which queries `https://api.openai.com/v1/models` using the configured `openai_api_token`, filters model IDs, and returns a JSON list of model IDs for the frontend refresh flow.
- Kept existing behaviour so saved `ai_model` values are supported even if they are not present in the recommended/discovered list, and the form still submits `ai_model` unchanged.

### Testing
- Ran PHP lint on modified files with `php -l settings.php`, which passed successfully.
- Ran PHP lint on the new endpoint with `php -l php_backend/public/ai_models.php`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23678d6e8832e9ee3dbb03be299d2)