### PR TITLE
Render PDF report filters as aligned `Report Details` rows

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -576,28 +576,55 @@ window.renderPageHeader(pageMain, {
         doc.text('This report summarises transactions matching your selected filters.', 14, y);
         y += 6;
 
-        const filters = [];
-        const catLabels = getSelectedLabels(window.catChoices);
-        if (catLabels.length) filters.push('Category: ' + catLabels.join(', '));
-        const tagLabels = getSelectedLabels(window.tagChoices);
-        if (tagLabels.length) filters.push('Tag: ' + tagLabels.join(', '));
-        const grpLabels = getSelectedLabels(window.groupChoices);
-        if (grpLabels.length) filters.push('Group: ' + grpLabels.join(', '));
-        const segLabels = getSelectedLabels(window.segmentChoices);
-        if (segLabels.length) filters.push('Segment: ' + segLabels.join(', '));
-        const textVal = document.getElementById('text').value.trim();
-        if (textVal) filters.push('Description contains: ' + textVal);
-        const memoVal = document.getElementById('memo').value.trim();
-        if (memoVal) filters.push('Memo contains: ' + memoVal);
         const startVal = document.getElementById('start').value;
-        if (startVal) filters.push('Start: ' + startVal);
         const endVal = document.getElementById('end').value;
-        if (endVal) filters.push('End: ' + endVal);
-        if (filters.length) {
-            const filterText = 'Filters: ' + filters.join(', ');
-            const wrapped = doc.splitTextToSize(filterText, pageWidth - 28);
-            doc.text(wrapped, 14, y);
-            y += wrapped.length * 6;
+        const dateFormat = new Intl.DateTimeFormat('en-GB', { day: '2-digit', month: 'short', year: 'numeric' });
+        const formatFilterDate = (value) => {
+            if (!value) return '';
+            const parsedDate = new Date(value + 'T00:00:00');
+            return Number.isNaN(parsedDate.getTime()) ? value : dateFormat.format(parsedDate);
+        };
+
+        const catLabels = getSelectedLabels(window.catChoices);
+        const tagLabels = getSelectedLabels(window.tagChoices);
+        const grpLabels = getSelectedLabels(window.groupChoices);
+        const segLabels = getSelectedLabels(window.segmentChoices);
+        const textVal = document.getElementById('text').value.trim();
+        const memoVal = document.getElementById('memo').value.trim();
+
+        const reportDetails = [
+            { label: 'Date Range', value: (startVal || endVal) ? `${formatFilterDate(startVal) || 'Any'} → ${formatFilterDate(endVal) || 'Any'}` : '' },
+            { label: 'Categories', value: catLabels.join(', ') },
+            { label: 'Tags', value: tagLabels.join(', ') },
+            { label: 'Groups', value: grpLabels.join(', ') },
+            { label: 'Segments', value: segLabels.join(', ') },
+            {
+                label: 'Text filters',
+                value: [textVal ? `Description: ${textVal}` : '', memoVal ? `Memo: ${memoVal}` : '']
+                    .filter(Boolean)
+                    .join(' • ')
+            }
+        ].filter((item) => item.value);
+
+        if (reportDetails.length) {
+            doc.setFontSize(10);
+            doc.setTextColor(100, 116, 139);
+            doc.text('Report Details', 14, y);
+            y += 5;
+
+            const labelWidth = 28;
+            reportDetails.forEach((item) => {
+                doc.setFontSize(9);
+                doc.setTextColor(71, 85, 105);
+                doc.text(`${item.label}:`, 14, y);
+
+                doc.setTextColor(15, 23, 42);
+                const wrappedValue = doc.splitTextToSize(item.value, pageWidth - 28 - labelWidth);
+                doc.text(wrappedValue, 14 + labelWidth, y);
+                y += Math.max(5, wrappedValue.length * 5);
+            });
+
+            y += 3;
         }
         doc.text('Generated on ' + generatedAt, 14, y);
         y += 8;


### PR DESCRIPTION
### Motivation
- Improve readability of exported PDFs by replacing a single wrapped `Filters:` paragraph with a structured metadata block rendered as aligned rows. 
- Surface grouped filter metadata (dates, categories, tags, groups, segments, text filters) so key report criteria are easier to scan in the PDF. 
- Display dates in a reader-friendly format while keeping the underlying filter logic and behaviour unchanged.

### Description
- Reworked the PDF filter rendering in `frontend/report.html` to build a `reportDetails` array of label/value objects for `Date Range`, `Categories`, `Tags`, `Groups`, `Segments`, and `Text filters` instead of concatenating a `filters` string. 
- Added `formatFilterDate` using `Intl.DateTimeFormat('en-GB')` and a `Date` parse fallback to format displayed dates as `DD Mon YYYY` while preserving source values used for filtering. 
- Rendered a subtle `Report Details` heading and aligned two-column label/value rows with a fixed label width and wrapped values via `doc.splitTextToSize`, and added small vertical spacing before charts/tables. 
- All changes are confined to `frontend/report.html` and do not alter the core filtering logic or data used for report generation.

### Testing
- No automated tests were executed; database-dependent test runs were intentionally skipped per instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f240358c74832ea1ec6ba4731ef4ae)