### PR TITLE
Refine report PDF table styling and overflow behavior

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -662,12 +662,37 @@ window.renderPageHeader(pageMain, {
             }));
         const data = window.reportTable.getData();
 
-        // Calculate totals for the main table
+        // Calculate totals and table styles for the main table
         const totalAmount = data.reduce((sum, row) => sum + parseFloat(row.amount || 0), 0);
-        const body = data.map(row => columns.map(c => row[c.dataKey]));
+        const isCurrencyColumn = field => /amount|total|balance|value/i.test(field);
+        const formatCurrency = value => {
+            const numeric = parseFloat(value);
+            return Number.isFinite(numeric) ? `£${numeric.toFixed(2)}` : '£0.00';
+        };
+
+        const body = data.map(row => columns.map(c => {
+            const value = row[c.dataKey];
+            return isCurrencyColumn(c.dataKey) ? formatCurrency(value) : (value ?? '');
+        }));
+
+        const descriptionColumnIndex = columns.findIndex(c => c.dataKey === 'description');
+        const memoColumnIndex = columns.findIndex(c => c.dataKey === 'memo');
+        const columnStyles = {};
+        if (descriptionColumnIndex >= 0) {
+            columnStyles[descriptionColumnIndex] = { cellWidth: 50, overflow: 'linebreak' };
+        }
+        if (memoColumnIndex >= 0) {
+            columnStyles[memoColumnIndex] = { cellWidth: 46, overflow: 'linebreak' };
+        }
+        columns.forEach((c, index) => {
+            if (isCurrencyColumn(c.dataKey)) {
+                columnStyles[index] = { ...(columnStyles[index] || {}), halign: 'right' };
+            }
+        });
+
         const foot = [columns.map(c => {
             if (c.dataKey === 'description') return 'Total';
-            if (c.dataKey === 'amount') return '£' + totalAmount.toFixed(2);
+            if (isCurrencyColumn(c.dataKey)) return formatCurrency(totalAmount);
             return '';
         })];
 
@@ -679,9 +704,12 @@ window.renderPageHeader(pageMain, {
             body,
             foot,
             theme: 'grid',
-            headStyles: { fillColor: [79, 70, 229], textColor: 255 },
-            footStyles: { fillColor: [226, 232, 240], textColor: 0, fontStyle: 'bold' },
-            alternateRowStyles: { fillColor: [243, 244, 246] }
+            styles: { fontSize: 8.8, cellPadding: { top: 1.8, right: 2.2, bottom: 1.8, left: 2.2 }, lineWidth: 0.1, lineColor: [203, 213, 225], overflow: 'linebreak' },
+            columnStyles,
+            headStyles: { fillColor: [55, 48, 163], textColor: 255, fontStyle: 'bold', lineWidth: 0.1 },
+            footStyles: { fillColor: [226, 232, 240], textColor: 15, fontStyle: 'bold', lineWidth: 0.1 },
+            alternateRowStyles: { fillColor: [248, 250, 252] },
+            showHead: 'everyPage'
         });
 
         // Summary table (totals by category, tag, group, and segment)
@@ -707,10 +735,16 @@ window.renderPageHeader(pageMain, {
                 margin: { left: margins.left, right: margins.right, top: 26, bottom: 18 },
                 didDrawPage: () => drawPageChrome(doc, { title: reportTitle, subtitle: reportDesc, icon: iconData, generatedAt }),
                 head: [['Type', 'Name', 'Total']],
-                body: summary.map(r => [r.type, r.name, '£' + r.total.toFixed(2)]),
+                body: summary.map(r => [r.type, r.name, formatCurrency(r.total)]),
                 theme: 'grid',
-                headStyles: { fillColor: [79, 70, 229], textColor: 255 },
-                alternateRowStyles: { fillColor: [243, 244, 246] }
+                styles: { fontSize: 8.9, cellPadding: { top: 1.8, right: 2.2, bottom: 1.8, left: 2.2 }, lineWidth: 0.1, lineColor: [203, 213, 225], overflow: 'linebreak' },
+                columnStyles: {
+                    1: { cellWidth: 78, overflow: 'linebreak' },
+                    2: { halign: 'right', cellWidth: 30 }
+                },
+                headStyles: { fillColor: [55, 48, 163], textColor: 255, fontStyle: 'bold', lineWidth: 0.1 },
+                alternateRowStyles: { fillColor: [248, 250, 252] },
+                showHead: 'everyPage'
             });
         }
 


### PR DESCRIPTION
### Motivation
- Improve readability and visual consistency of the PDF export tables by tightening typography, padding and borders for a more professional output.
- Ensure long text in verbose columns (`description`, `memo`) wraps cleanly in the PDF using `overflow: 'linebreak'` and constrained `cellWidth` to prevent layout breaks.
- Guarantee numeric values are consistently formatted as currency and right-aligned so totals and amounts are easier to scan.

### Description
- Updated `frontend/report.html` to add a shared `formatCurrency` helper and `isCurrencyColumn` predicate to normalize `£` currency formatting across rows, footers and summary rows.
- Reworked the main `doc.autoTable` call to include explicit `styles`, `columnStyles`, repeated headers (`showHead: 'everyPage'`), smaller body font (`fontSize: 8.8`), controlled padding and thinner grid lines, and subtle zebra striping.
- Added `columnStyles` entries for verbose text columns (`description`, `memo`) with `cellWidth` constraints and `overflow: 'linebreak'`, and set `halign: 'right'` for numeric/currency columns.
- Applied the same styling and overflow handling to the summary `doc.autoTable` (totals by category/tag/group/segment) with adjusted font size and column widths.

### Testing
- No automated tests were executed for database-related functionality; database-dependent tests were intentionally skipped per the request not to run DB-required tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f241308778832e80728d79e0e97ec0)