### PR TITLE
Handle PDF page-break checks for report charts and tables

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -566,8 +566,20 @@ window.renderPageHeader(pageMain, {
             pdfDoc.text(`Page ${pageNum} of ${totalPagesExp}`, pageWidth - margins.right, footerY, { align: 'right' });
         }
 
+        function ensureSpace(pdfDoc, currentY, neededHeight, meta) {
+            const footerReserve = 18;
+            const contentBottom = pageHeight - footerReserve;
+            if (currentY + neededHeight <= contentBottom) {
+                return currentY;
+            }
+            pdfDoc.addPage();
+            drawPageChrome(pdfDoc, meta);
+            return 26;
+        }
+
         drawPageChrome(doc, { title: reportTitle, subtitle: reportDesc, icon: iconData, generatedAt });
         doc.setProperties({ title: `${reportTitle} - ${reportDesc}` });
+        const pageMeta = { title: reportTitle, subtitle: reportDesc, icon: iconData, generatedAt };
 
         // Description
         doc.setTextColor(0, 0, 0);
@@ -630,13 +642,14 @@ window.renderPageHeader(pageMain, {
         y += 8;
 
         // Include charts before tables
-        let chartY = y;
+        let chartY = ensureSpace(doc, y, 80, pageMeta);
         const chartEl = document.getElementById('chart');
         if (chartEl) {
             const canvas = await html2canvas(chartEl, { scale: 2 });
             const imgData = canvas.toDataURL('image/png');
             const imgWidth = pageWidth - 28;
             const imgHeight = canvas.height * imgWidth / canvas.width;
+            chartY = ensureSpace(doc, chartY, imgHeight + 10, pageMeta);
             doc.addImage(imgData, 'PNG', 14, chartY, imgWidth, imgHeight);
             chartY += imgHeight + 10;
         }
@@ -647,6 +660,7 @@ window.renderPageHeader(pageMain, {
             const imgData = canvas.toDataURL('image/png');
             const imgWidth = pageWidth - 28;
             const imgHeight = canvas.height * imgWidth / canvas.width;
+            chartY = ensureSpace(doc, chartY, imgHeight + 10, pageMeta);
             doc.addImage(imgData, 'PNG', 14, chartY, imgWidth, imgHeight);
             chartY += imgHeight + 10;
         }
@@ -696,10 +710,11 @@ window.renderPageHeader(pageMain, {
             return '';
         })];
 
+        y = ensureSpace(doc, y, 20, pageMeta);
         doc.autoTable({
             startY: y,
             margin: { left: margins.left, right: margins.right, top: 26, bottom: 18 },
-            didDrawPage: () => drawPageChrome(doc, { title: reportTitle, subtitle: reportDesc, icon: iconData, generatedAt }),
+            didDrawPage: () => drawPageChrome(doc, pageMeta),
             head: [columns.map(c => c.header)],
             body,
             foot,
@@ -730,10 +745,11 @@ window.renderPageHeader(pageMain, {
         addSummary('segment_name', 'Segment');
 
         if (summary.length) {
+            const summaryStartY = ensureSpace(doc, doc.lastAutoTable.finalY + 10, 20, pageMeta);
             doc.autoTable({
-                startY: doc.lastAutoTable.finalY + 10,
+                startY: summaryStartY,
                 margin: { left: margins.left, right: margins.right, top: 26, bottom: 18 },
-                didDrawPage: () => drawPageChrome(doc, { title: reportTitle, subtitle: reportDesc, icon: iconData, generatedAt }),
+                didDrawPage: () => drawPageChrome(doc, pageMeta),
                 head: [['Type', 'Name', 'Total']],
                 body: summary.map(r => [r.type, r.name, formatCurrency(r.total)]),
                 theme: 'grid',


### PR DESCRIPTION
### Motivation
- Prevent chart images and tables from overlapping the footer or being cut off when exporting the transaction report PDF by checking remaining page space and adding page breaks as needed.
- Ensure page chrome (header/footer) is redrawn consistently after any programmatic page addition.

### Description
- Added a new helper `ensureSpace(pdfDoc, currentY, neededHeight, meta)` in `frontend/report.html` to compare the current Y cursor against the page bottom (respecting a footer reserve), add a new page and redraw chrome when required, and return an updated cursor.
- Introduced a shared `pageMeta` object and updated `didDrawPage` callbacks to reuse it for consistent header/footer rendering.
- Applied `ensureSpace` at the narrative/meta → charts transition and before each chart image insertion so charts are placed on the current page only if space permits, otherwise on a new page.
- Applied `ensureSpace` immediately before the main table and before the summary table start to guarantee enough vertical space and avoid footer collisions.

### Testing
- No automated tests were executed for this change because the test run was avoided per the requirement to not run database-dependent tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24275033c832e9a684c6fb8e83bb4)