### PR TITLE
Normalize PDF report naming and add audit metadata row

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -514,14 +514,18 @@ window.renderPageHeader(pageMain, {
         const totalPagesExp = '{total_pages_count_string}';
 
         const siteTitle = document.querySelector('#site-title')?.textContent?.trim() || 'Accounts';
-        let reportTitle;
+        const reportTitle = `${siteTitle} — Transaction Report`;
         let reportDesc;
+        let reportSource;
+        let reportIdLabel;
         if (currentReportName && currentReportDesc) {
-            reportTitle = currentReportName;
-            reportDesc = currentReportDesc;
+            reportDesc = `${currentReportName} — ${currentReportDesc}`;
+            reportSource = 'Saved Report';
+            reportIdLabel = document.getElementById('saved-reports').value || 'Unknown';
         } else {
-            reportTitle = siteTitle;
-            reportDesc = 'Transaction Report';
+            reportDesc = 'Ad hoc report';
+            reportSource = 'On-the-fly';
+            reportIdLabel = 'N/A';
         }
 
         let iconData = null;
@@ -578,7 +582,7 @@ window.renderPageHeader(pageMain, {
         }
 
         drawPageChrome(doc, { title: reportTitle, subtitle: reportDesc, icon: iconData, generatedAt });
-        doc.setProperties({ title: `${reportTitle} - ${reportDesc}` });
+        doc.setProperties({ title: reportTitle });
         const pageMeta = { title: reportTitle, subtitle: reportDesc, icon: iconData, generatedAt };
 
         // Description
@@ -586,6 +590,12 @@ window.renderPageHeader(pageMain, {
         doc.setFontSize(11);
         let y = 26;
         doc.text('This report summarises transactions matching your selected filters.', 14, y);
+        y += 6;
+
+        doc.setFontSize(9);
+        doc.setTextColor(71, 85, 105);
+        doc.text(`Report ID: ${reportIdLabel}`, 14, y);
+        doc.text(`Source: ${reportSource}`, pageWidth - margins.right, y, { align: 'right' });
         y += 6;
 
         const startVal = document.getElementById('start').value;


### PR DESCRIPTION
### Motivation
- Standardise the PDF header so the primary title always reflects product/report identity (e.g. `Accounts — Transaction Report`).
- Provide clearer subtitle behaviour so saved reports surface their saved name/description and unsaved exports show `Ad hoc report`.
- Improve auditability by exposing report source and identifier in the generated PDF output.

### Description
- Updated `frontend/report.html` to set the primary PDF title to ``${siteTitle} — Transaction Report`` and always use that as the document `title` metadata via `doc.setProperties`.
- When a saved report is loaded the subtitle is now ``<saved name> — <saved description>``, otherwise it shows `Ad hoc report` for on-the-fly exports.
- Added `reportSource` and `reportIdLabel` and rendered a compact metadata row (`Report ID` and `Source`) near the top of the PDF body for audit clarity.
- These are presentation-only changes; no report filtering, data selection, or export content logic was altered.

### Testing
- No automated tests were executed because the test suite requires database access and was intentionally skipped per instructions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f24326b238832eb459015ad0300480)