### PR TITLE
Polish transaction PDF report presentation

### DIFF
--- a/frontend/report.html
+++ b/frontend/report.html
@@ -541,7 +541,7 @@ window.renderPageHeader(pageMain, {
             // Ignore icon errors and fall back to text-only header
         }
 
-        const generatedAt = new Date().toLocaleString();
+        const generatedAt = new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'medium' }).format(new Date());
 
         function drawPageChrome(pdfDoc, meta) {
             const pageNum = pdfDoc.internal.getNumberOfPages();
@@ -581,22 +581,40 @@ window.renderPageHeader(pageMain, {
             return 26;
         }
 
+        function drawCard(pdfDoc, x, y, width, height) {
+            pdfDoc.setFillColor(248, 250, 252);
+            pdfDoc.setDrawColor(226, 232, 240);
+            pdfDoc.roundedRect(x, y, width, height, 2, 2, 'FD');
+        }
+
+        function drawSectionHeading(pdfDoc, text, yPos) {
+            pdfDoc.setFontSize(10);
+            pdfDoc.setTextColor(71, 85, 105);
+            pdfDoc.text(text, margins.left + 3, yPos);
+        }
+
         drawPageChrome(doc, { title: reportTitle, subtitle: reportDesc, icon: iconData, generatedAt });
         doc.setProperties({ title: reportTitle });
         const pageMeta = { title: reportTitle, subtitle: reportDesc, icon: iconData, generatedAt };
 
         // Description
-        doc.setTextColor(0, 0, 0);
+        doc.setTextColor(15, 23, 42);
         doc.setFontSize(11);
         let y = 26;
-        doc.text('This report summarises transactions matching your selected filters.', 14, y);
+        doc.text('Transaction activity summary based on your selected filters.', margins.left, y);
         y += 6;
 
+        drawCard(doc, margins.left, y, pageWidth - margins.left - margins.right, 18);
         doc.setFontSize(9);
         doc.setTextColor(71, 85, 105);
-        doc.text(`Report ID: ${reportIdLabel}`, 14, y);
-        doc.text(`Source: ${reportSource}`, pageWidth - margins.right, y, { align: 'right' });
-        y += 6;
+        doc.text(`Report ID`, margins.left + 3, y + 6);
+        doc.text(`Source`, margins.left + 3, y + 12);
+        doc.setTextColor(15, 23, 42);
+        doc.text(`${reportIdLabel}`, margins.left + 30, y + 6);
+        doc.text(`${reportSource}`, margins.left + 30, y + 12);
+        doc.setTextColor(100, 116, 139);
+        doc.text(`Generated ${generatedAt}`, pageWidth - margins.right - 3, y + 12, { align: 'right' });
+        y += 24;
 
         const startVal = document.getElementById('start').value;
         const endVal = document.getElementById('end').value;
@@ -604,7 +622,7 @@ window.renderPageHeader(pageMain, {
         const formatFilterDate = (value) => {
             if (!value) return '';
             const parsedDate = new Date(value + 'T00:00:00');
-            return Number.isNaN(parsedDate.getTime()) ? value : dateFormat.format(parsedDate);
+            return Number.isNaN(parsedDate.getTime()) ? value : dateFormat.format(parsedDate).replace(/\s+/g, ' ');
         };
 
         const catLabels = getSelectedLabels(window.catChoices);
@@ -615,7 +633,7 @@ window.renderPageHeader(pageMain, {
         const memoVal = document.getElementById('memo').value.trim();
 
         const reportDetails = [
-            { label: 'Date Range', value: (startVal || endVal) ? `${formatFilterDate(startVal) || 'Any'} → ${formatFilterDate(endVal) || 'Any'}` : '' },
+            { label: 'Date Range', value: (startVal || endVal) ? `${formatFilterDate(startVal) || 'Any'} to ${formatFilterDate(endVal) || 'Any'}` : '' },
             { label: 'Categories', value: catLabels.join(', ') },
             { label: 'Tags', value: tagLabels.join(', ') },
             { label: 'Groups', value: grpLabels.join(', ') },
@@ -629,27 +647,28 @@ window.renderPageHeader(pageMain, {
         ].filter((item) => item.value);
 
         if (reportDetails.length) {
-            doc.setFontSize(10);
-            doc.setTextColor(100, 116, 139);
-            doc.text('Report Details', 14, y);
-            y += 5;
+            const detailLines = reportDetails.map((item) => {
+                const wrappedValue = doc.splitTextToSize(item.value, pageWidth - 28 - 38);
+                return { item, wrappedValue };
+            });
+            const detailsHeight = detailLines.reduce((h, line) => h + Math.max(5, line.wrappedValue.length * 4.5), 0) + 9;
+            y = ensureSpace(doc, y, detailsHeight + 5, pageMeta);
+            drawCard(doc, margins.left, y, pageWidth - margins.left - margins.right, detailsHeight);
+            drawSectionHeading(doc, 'Report Details', y + 6);
 
-            const labelWidth = 28;
-            reportDetails.forEach((item) => {
+            let detailsY = y + 11;
+            detailLines.forEach(({ item, wrappedValue }) => {
                 doc.setFontSize(9);
                 doc.setTextColor(71, 85, 105);
-                doc.text(`${item.label}:`, 14, y);
+                doc.text(`${item.label}:`, margins.left + 3, detailsY);
 
                 doc.setTextColor(15, 23, 42);
-                const wrappedValue = doc.splitTextToSize(item.value, pageWidth - 28 - labelWidth);
-                doc.text(wrappedValue, 14 + labelWidth, y);
-                y += Math.max(5, wrappedValue.length * 5);
+                doc.text(wrappedValue, margins.left + 38, detailsY);
+                detailsY += Math.max(5, wrappedValue.length * 4.5);
             });
 
-            y += 3;
+            y += detailsHeight + 6;
         }
-        doc.text('Generated on ' + generatedAt, 14, y);
-        y += 8;
 
         // Include charts before tables
         let chartY = ensureSpace(doc, y, 80, pageMeta);


### PR DESCRIPTION
### Motivation
- Improve the visual polish and readability of the generated transaction PDF so the first page reads and looks more professional. 
- Make timestamp and date-range formatting consistent and remove awkward whitespace/characters in rendered text. 
- Group report metadata and filter details into clearer, card-like blocks to improve information hierarchy.

### Description
- Updated PDF timestamp/date formatting to use `new Intl.DateTimeFormat('en-GB', { dateStyle: 'medium', timeStyle: 'medium' })` and normalised date-range output to use `to` with whitespace fixes in `frontend/report.html`.
- Added reusable drawing helpers `drawCard` and `drawSectionHeading` and applied them to render a card-style header/info area and a boxed "Report Details" section.
- Reworked the description/details rendering to use clearer copy, improved wrapping and spacing for multi-line detail values, and tightened typography/colour choices for headings and body text.
- Changes are limited to the PDF generation logic in `frontend/report.html` (layout, formatting and presentation only).

### Testing
- No automated tests were executed for this change.
- Database-dependent tests were intentionally not run per project/user constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f30b620cf4832e8a5b788c9f108bdd)