### PR TITLE
Improve auto-tag matching coverage and efficiency

### DIFF
--- a/php_backend/models/Tag.php
+++ b/php_backend/models/Tag.php
@@ -167,6 +167,18 @@ class Tag {
     }
 
     /**
+     * Combine description and memo text so alias/keyword matching can use both.
+     */
+    public static function buildMatchText(string $description, ?string $memo = null): string {
+        $description = trim($description);
+        $memo = $memo !== null ? trim($memo) : '';
+        if ($memo === '') {
+            return $description;
+        }
+        return $description . ' ' . $memo;
+    }
+
+    /**
      * Look up a tag's id by its exact name.
      */
     public static function getIdByName(string $name): ?int {
@@ -254,16 +266,16 @@ class Tag {
      */
     public static function applyToAccountTransactions(int $accountId): int {
         $db = Database::getConnection();
-        $stmt = $db->prepare('SELECT `id`, `description`, `ofx_type` FROM `transactions` WHERE `account_id` = :acc AND `tag_id` IS NULL');
+        $stmt = $db->prepare('SELECT `id`, `description`, `memo`, `ofx_type` FROM `transactions` WHERE `account_id` = :acc AND `tag_id` IS NULL');
         $stmt->execute(['acc' => $accountId]);
+        $upd = $db->prepare('UPDATE `transactions` SET `tag_id` = :tag WHERE `id` = :id');
         $updated = 0;
         foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $tx) {
-            $tagId = self::findMatch($tx['description']);
+            $tagId = self::findMatch(self::buildMatchText($tx['description'], $tx['memo']));
             if ($tagId === null && $tx['ofx_type'] === 'INT') {
                 $tagId = self::getInterestChargeId();
             }
             if ($tagId !== null) {
-                $upd = $db->prepare('UPDATE `transactions` SET `tag_id` = :tag WHERE `id` = :id');
                 $upd->execute(['tag' => $tagId, 'id' => $tx['id']]);
                 $updated++;
             }
@@ -293,7 +305,7 @@ class Tag {
      */
     public static function remapAllTransactionsToCanonicalTags(bool $applyChanges = false): array {
         $db = Database::getConnection();
-        $stmt = $db->query('SELECT `id`, `description`, `ofx_type`, `tag_id` FROM `transactions`');
+        $stmt = $db->query('SELECT `id`, `description`, `memo`, `ofx_type`, `tag_id` FROM `transactions`');
         $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
         $moves = [];
@@ -302,7 +314,7 @@ class Tag {
 
         foreach ($rows as $tx) {
             $currentTagId = $tx['tag_id'] !== null ? (int)$tx['tag_id'] : null;
-            $newTagId = self::findMatch($tx['description']);
+            $newTagId = self::findMatch(self::buildMatchText($tx['description'], $tx['memo']));
             if ($newTagId === null && $tx['ofx_type'] === 'INT') {
                 $newTagId = self::getInterestChargeId();
             }

--- a/php_backend/models/Transaction.php
+++ b/php_backend/models/Transaction.php
@@ -28,7 +28,7 @@ class Transaction {
      */
     public static function create(int $account, string $date, float $amount, string $description, ?string $memo = null, ?int $category = null, ?int $tag = null, ?int $group = null, ?string $ofx_id = null, ?string $ofx_type = null, ?string $bank_ofx_id = null): int {
         if ($tag === null) {
-            $tag = Tag::findMatch($description);
+            $tag = Tag::findMatch(Tag::buildMatchText($description, $memo));
             if ($tag === null && $ofx_type === 'INT') {
                 $tag = Tag::getInterestChargeId();
             }


### PR DESCRIPTION
### Motivation
- Increase tagging accuracy and step-change efficiency across the site by using richer transaction text (description + memo) for alias/keyword matching so transactions that only include tag cues in the memo are correctly classified.
- Reduce per-transaction DB overhead during bulk auto-tagging to improve performance when applying tags across accounts.

### Description
- Added `Tag::buildMatchText(string $description, ?string $memo)` to combine description and memo into a single matching string used by alias and keyword matching.
- Updated transaction ingestion to use the combined description+memo match by calling `Tag::findMatch(Tag::buildMatchText(...))` inside `Transaction::create` so new transactions can be auto-tagged from memo content at import time.
- Improved `Tag::applyToAccountTransactions` to select `memo` from `transactions`, build combined match text, and prepare the `UPDATE` statement once per batch to avoid repeated prepares inside the loop.
- Included `memo` in canonical remapping (`Tag::remapAllTransactionsToCanonicalTags`) so remap suggestions and applied changes consider memo text as well.

### Testing
- Ran lint checks with `php -l php_backend/models/Tag.php` which succeeded.
- Ran lint checks with `php -l php_backend/models/Transaction.php` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f45c550cd0832e824f6bfbf0b826bc)