### PR TITLE
Fix project tracking and admin UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,4 @@
 
 - Page headings use a shared pattern: `<header class="page-header">` with an `h1.page-title` and optional `.page-subtitle` / `.page-header-actions`; keep this header directly on the page canvas above the first content card.
 - Page headers should be rendered via `frontend/js/page_header.js` using `renderPageHeader(main, { title, breadcrumb, subtitle, actions })`; `title` is required, other fields are optional, and output must keep `page-header`, `page-title`, `page-breadcrumb`, and `page-subtitle` classes.
+- Project `spent` totals count outgoing transactions as positive expenses and exclude incoming transactions.

--- a/frontend/js/overlay.js
+++ b/frontend/js/overlay.js
@@ -5,6 +5,9 @@
         const overlay = document.createElement('div');
         overlay.id = 'overlay';
         overlay.className = 'fixed top-6 right-8 z-50 px-4 py-2 rounded-full shadow bg-white text-gray-800 hidden transform translate-x-full transition-transform duration-300 border';
+        overlay.setAttribute('role', 'status');
+        overlay.setAttribute('aria-live', 'polite');
+        overlay.setAttribute('aria-atomic', 'true');
 
         document.body.appendChild(overlay);
         return overlay;
@@ -23,6 +26,8 @@
         const overlay = window.__overlay || document.getElementById('overlay') || createOverlay();
         const rightBar = window.__utilityBar || document.getElementById('utility-bar');
         overlay.textContent = msg;
+        overlay.setAttribute('role', type === 'error' ? 'alert' : 'status');
+        overlay.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
         overlay.classList.remove('hidden', 'border-green-600', 'border-red-600');
         overlay.classList.add(type === 'error' ? 'border-red-600' : 'border-green-600', 'translate-x-full');
 

--- a/frontend/logs.html
+++ b/frontend/logs.html
@@ -25,7 +25,7 @@
 <p class="mb-4">Review recent log entries to monitor system activity. Filtering by time or keyword helps you trace what happened during a specific event.</p>
             <div class="mb-4 flex items-center space-x-2">
                 <label class="text-sm">Days to keep/show:
-                    <input type="number" id="log-days" value="30" class="border p-1 w-20 rounded ml-1" data-help="Number of days of log entries to display and retain when pruning">
+                    <input type="number" id="log-days" value="30" min="1" max="3650" required class="border p-1 w-20 rounded ml-1" data-help="Number of days of log entries to display and retain when pruning">
                 </label>
                 <button id="refresh-logs" class="bg-indigo-600 text-white px-3 py-1 rounded">Refresh</button>
                 <button id="prune-logs" class="bg-red-500 text-white px-3 py-1 rounded">Prune</button>
@@ -48,16 +48,30 @@ window.renderPageHeader(pageMain, {
     <script src="js/tabulator-tailwind.js"></script>
     <script>
     const gridEl = '#logs-grid';
+    let logsTable;
 
-    function loadLogs() {
-        const days = document.getElementById('log-days').value;
-        fetch(`../php_backend/public/logs.php?days=${days}`)
-            .then(resp => resp.json())
-            .then(data => {
-                tailwindTabulator(gridEl, {
+    function selectedDays() {
+        const input = document.getElementById('log-days');
+        if (!input.reportValidity()) return null;
+        return Math.max(1, Math.min(3650, Number.parseInt(input.value, 10)));
+    }
+
+    async function loadLogs() {
+        const days = selectedDays();
+        if (days === null) return;
+        try {
+            const response = await fetch(`../php_backend/public/logs.php?days=${encodeURIComponent(days)}`);
+            if (!response.ok) throw new Error('Logs request failed');
+            const data = await response.json();
+            if (!Array.isArray(data)) throw new Error('Invalid logs response');
+            if (logsTable) {
+                logsTable.setData(data);
+            } else {
+                logsTable = tailwindTabulator(gridEl, {
                     data: data,
                     layout: 'fitColumns',
                     variableHeight: true,
+                    placeholder: 'No log entries found for this period.',
                     columns: [
                         { title: 'Time', field: 'created_at' },
                         { title: 'Level', field: 'level' },
@@ -65,18 +79,41 @@ window.renderPageHeader(pageMain, {
                             const el = cell.getElement();
                             el.style.whiteSpace = 'pre-wrap';
                             el.style.wordBreak = 'break-word';
-                            return cell.getValue();
+                            const text = document.createElement('span');
+                            text.textContent = cell.getValue() || '';
+                            return text;
                         } }
                     ]
                 });
-            });
+            }
+        } catch (error) {
+            showMessage('Could not load logs. Please refresh and try again.', 'error');
+        }
     }
 
     document.getElementById('refresh-logs').addEventListener('click', loadLogs);
-    document.getElementById('prune-logs').addEventListener('click', () => {
-        const days = document.getElementById('log-days').value;
-        fetch(`../php_backend/public/logs.php?prune_days=${days}`)
-            .then(() => loadLogs());
+    document.getElementById('prune-logs').addEventListener('click', async event => {
+        const days = selectedDays();
+        if (days === null || !confirm(`Permanently delete log entries older than ${days} days?`)) return;
+        const button = event.currentTarget;
+        button.disabled = true;
+        try {
+            const response = await fetch('../php_backend/public/logs.php', {
+                method: 'DELETE',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({days})
+            });
+            const result = await response.json().catch(() => ({}));
+            if (!response.ok || result.status !== 'ok') {
+                throw new Error(result.error || 'Log pruning failed');
+            }
+            await loadLogs();
+            showMessage(`Logs older than ${days} days were pruned.`);
+        } catch (error) {
+            showMessage(error.message || 'Could not prune logs.', 'error');
+        } finally {
+            button.disabled = false;
+        }
     });
 
     loadLogs();

--- a/frontend/project_add.html
+++ b/frontend/project_add.html
@@ -39,13 +39,13 @@
                 <label class="block md:col-span-2">Description<br><textarea id="description" name="description" class="border p-2 rounded w-full" rows="2" data-help="Brief description"></textarea></label>
                 <label class="block md:col-span-2">Rationale<br><textarea id="rationale" name="rationale" class="border p-2 rounded w-full" rows="2" data-help="Why this project is needed"></textarea></label>
 
-                <label class="block">Cost Low (£)<br><input type="number" step="0.01" id="cost_low" name="cost_low" class="border p-2 rounded w-full" data-help="Minimum estimated cost"></label>
-                <label class="block">Cost Medium (£)<br><input type="number" step="0.01" id="cost_medium" name="cost_medium" class="border p-2 rounded w-full" data-help="Typical estimated cost"></label>
-                <label class="block">Cost High (£)<br><input type="number" step="0.01" id="cost_high" name="cost_high" class="border p-2 rounded w-full" data-help="Maximum estimated cost"></label>
-                <label class="block">Recurring Cost (£)<br><input type="number" step="0.01" id="recurring_cost" name="recurring_cost" class="border p-2 rounded w-full" data-help="Ongoing maintenance or subscription cost"></label>
+                <label class="block">Cost Low (£)<br><input type="number" min="0" step="0.01" id="cost_low" name="cost_low" class="border p-2 rounded w-full" data-help="Minimum estimated cost"></label>
+                <label class="block">Cost Medium (£)<br><input type="number" min="0" step="0.01" id="cost_medium" name="cost_medium" class="border p-2 rounded w-full" data-help="Typical estimated cost"></label>
+                <label class="block">Cost High (£)<br><input type="number" min="0" step="0.01" id="cost_high" name="cost_high" class="border p-2 rounded w-full" data-help="Maximum estimated cost"></label>
+                <label class="block">Recurring Cost (£)<br><input type="number" min="0" step="0.01" id="recurring_cost" name="recurring_cost" class="border p-2 rounded w-full" data-help="Ongoing maintenance or subscription cost"></label>
 
-                <label class="block">Estimated Time (months)<br><input type="number" id="estimated_time" name="estimated_time" class="border p-2 rounded w-full" data-help="Time to complete"></label>
-                <label class="block">Expected Lifespan (years)<br><input type="number" id="expected_lifespan" name="expected_lifespan" class="border p-2 rounded w-full" data-help="How long the project lasts"></label>
+                <label class="block">Estimated Time (months)<br><input type="number" min="0" id="estimated_time" name="estimated_time" class="border p-2 rounded w-full" data-help="Time to complete"></label>
+                <label class="block">Expected Lifespan (years)<br><input type="number" min="0" id="expected_lifespan" name="expected_lifespan" class="border p-2 rounded w-full" data-help="How long the project lasts"></label>
 
                 <label class="block">Financial Benefit (1-5)<br><input type="number" min="0" max="5" id="benefit_financial" name="benefit_financial" class="border p-2 rounded w-full" data-help="Financial return score"></label>
                 <label class="block">Quality of Life (1-5)<br><input type="number" min="0" max="5" id="benefit_quality" name="benefit_quality" class="border p-2 rounded w-full" data-help="Comfort or enjoyment score"></label>
@@ -60,7 +60,7 @@
                 <label class="block md:col-span-2">Dependencies<br><textarea id="dependencies" name="dependencies" class="border p-2 rounded w-full" rows="2" data-help="Prerequisite projects"></textarea></label>
                 <label class="block md:col-span-2">Risks<br><textarea id="risks" name="risks" class="border p-2 rounded w-full" rows="2" data-help="Potential risks or constraints"></textarea></label>
 
-                <button type="submit" class="bg-indigo-600 text-white px-4 py-2 rounded md:col-span-2">Save Project</button>
+                <button type="submit" id="save-project" class="bg-indigo-600 text-white px-4 py-2 rounded md:col-span-2 disabled:cursor-not-allowed disabled:opacity-60">Save Project</button>
             </form>
         </section>
     </main>
@@ -82,10 +82,23 @@ async function loadProject(){
     const params = new URLSearchParams(location.search);
     const id = params.get('id');
     if(!id) return;
-    const res = await fetch('../php_backend/public/projects.php');
-    const data = await res.json();
-    const p = data.find(pr => pr.id == id);
-    if(!p) return;
+    const saveButton = document.getElementById('save-project');
+    let data;
+    try {
+        const res = await fetch('../php_backend/public/projects.php');
+        if(!res.ok) throw new Error('Could not load projects');
+        data = await res.json();
+    } catch (error) {
+        saveButton.disabled = true;
+        showMessage('Could not load this project. Please refresh and try again.', 'error');
+        return;
+    }
+    const p = data.find(pr => String(pr.id) === id);
+    if(!p){
+        saveButton.disabled = true;
+        showMessage('Project not found. Return to the projects page and choose another project.', 'error');
+        return;
+    }
     const f = document.getElementById('project-form');
     document.getElementById('project_id').value = p.id;
     f.name.value = p.name || '';
@@ -108,11 +121,18 @@ async function loadProject(){
     f.weight_sustainability.value = p.weight_sustainability || '';
     f.dependencies.value = p.dependencies || '';
     f.risks.value = p.risks || '';
+    saveButton.textContent = 'Update Project';
+    document.title = 'Edit Project';
+    window.updatePageHeader(pageMain, {
+        title: 'Edit Project',
+        subtitle: 'Update project details, costs, and benefit assumptions.'
+    });
 }
 
 document.getElementById('project-form').addEventListener('submit', async e => {
     e.preventDefault();
     const f = e.target;
+    const saveButton = document.getElementById('save-project');
     const data = {
         name: f.name.value,
         description: f.description.value,
@@ -141,14 +161,37 @@ document.getElementById('project-form').addEventListener('submit', async e => {
         data.id = id;
         method = 'PUT';
     }
-    await fetch('../php_backend/public/projects.php',{
-        method,
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify(data)
-    });
-    f.reset();
-    document.getElementById('project_id').value = '';
-    showMessage('Project saved');
+    saveButton.disabled = true;
+    const originalLabel = saveButton.textContent;
+    saveButton.textContent = id ? 'Updating…' : 'Saving…';
+    try {
+        const response = await fetch('../php_backend/public/projects.php',{
+            method,
+            headers:{'Content-Type':'application/json'},
+            body:JSON.stringify(data)
+        });
+        const result = await response.json().catch(() => ({}));
+        if(!response.ok || result.status !== 'ok'){
+            throw new Error(result.error || 'Project could not be saved');
+        }
+
+        if(!id && result.id){
+            document.getElementById('project_id').value = result.id;
+            history.replaceState(null, '', `?id=${encodeURIComponent(result.id)}`);
+            document.title = 'Edit Project';
+            window.updatePageHeader(pageMain, {
+                title: 'Edit Project',
+                subtitle: 'Update project details, costs, and benefit assumptions.'
+            });
+        }
+        saveButton.textContent = 'Update Project';
+        showMessage(id ? 'Project updated' : 'Project created');
+    } catch (error) {
+        saveButton.textContent = originalLabel;
+        showMessage(error.message || 'Could not save project. Please try again.', 'error');
+    } finally {
+        saveButton.disabled = false;
+    }
 });
 
 loadProject();

--- a/frontend/projects.html
+++ b/frontend/projects.html
@@ -109,6 +109,36 @@ window.renderPageHeader(pageMain, {
 let projectTable;
 let projectData = [];
 
+function projectActionButton(iconClass, label, colorClass, onClick){
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `${colorClass} rounded p-2 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-50`;
+    button.setAttribute('aria-label', label);
+    const icon = document.createElement('i');
+    icon.className = `fas ${iconClass} w-4 h-4`;
+    icon.setAttribute('aria-hidden', 'true');
+    button.appendChild(icon);
+    button.addEventListener('click', async event => {
+        event.stopPropagation();
+        button.disabled = true;
+        try {
+            await onClick();
+        } finally {
+            button.disabled = false;
+        }
+    });
+    return button;
+}
+
+async function projectRequest(options){
+    const response = await fetch('../php_backend/public/projects.php', options);
+    const result = await response.json().catch(() => ({}));
+    if(!response.ok || result.status !== 'ok'){
+        throw new Error(result.error || 'Project request failed');
+    }
+    return result;
+}
+
 const axisOptions = {
     cost_low: {label: 'Cost (low)', prefix: '£'},
     cost_medium: {label: 'Cost (mid)', prefix: '£'},
@@ -166,8 +196,14 @@ function drawBubble(){
 }
 
 async function loadProjects(){
-    const res = await fetch('../php_backend/public/projects.php');
-    projectData = await res.json();
+    try {
+        const res = await fetch('../php_backend/public/projects.php');
+        if(!res.ok) throw new Error('Could not load projects');
+        projectData = await res.json();
+    } catch (error) {
+        showMessage('Could not load projects. Please refresh and try again.', 'error');
+        return;
+    }
     drawBubble();
     if(projectTable){
         projectTable.setData(projectData);
@@ -175,11 +211,14 @@ async function loadProjects(){
         projectTable = tailwindTabulator('#projects-table',{
             data:projectData,
             layout:'fitDataStretch',
+            placeholder:'No active projects found.',
             columns:[
-                {formatter:()=>'<i class="fas fa-edit w-4 h-4" aria-label="Edit"></i>', width:40, hozAlign:'center', cellClick:(e,cell)=>{
-                    const id = cell.getRow().getData().id;
-                    window.location.href = `project_add.html?id=${id}`;
-                }},
+                {title:'Edit', formatter:cell => {
+                    const project = cell.getRow().getData();
+                    return projectActionButton('fa-edit', `Edit ${project.name || 'project'}`, 'text-indigo-700 hover:bg-indigo-50', () => {
+                        window.location.href = `project_add.html?id=${encodeURIComponent(project.id)}`;
+                    });
+                }, width:70, hozAlign:'center', headerSort:false},
                 {title:'Project', field:'name'},
                 {title:'Cost (mid)', field:'cost_medium', formatter:'money', formatterParams:{symbol:'£',precision:2}, hozAlign:'right'},
                 {title:'Spent', field:'spent', formatter:'money', formatterParams:{symbol:'£',precision:2}, hozAlign:'right'},
@@ -189,27 +228,39 @@ async function loadProjects(){
                 {title:'Sustainability', field:'benefit_sustainability', hozAlign:'right'},
                 {title:'Funding', field:'funding_source'},
                 {title:'Score', field:'score', hozAlign:'right'},
-                {formatter:()=>'<i class="fas fa-box-archive w-4 h-4" aria-label="Archive"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
-                    const id = cell.getRow().getData().id;
-                    await fetch('../php_backend/public/projects.php',{
-                        method:'PATCH',
-                        headers:{'Content-Type':'application/json'},
-                        body:JSON.stringify({id, archived:1})
+                {title:'Archive', formatter:cell => {
+                    const project = cell.getRow().getData();
+                    return projectActionButton('fa-box-archive', `Archive ${project.name || 'project'}`, 'text-amber-700 hover:bg-amber-50', async () => {
+                        try {
+                            await projectRequest({
+                                method:'PATCH',
+                                headers:{'Content-Type':'application/json'},
+                                body:JSON.stringify({id:project.id, archived:1})
+                            });
+                            await loadProjects();
+                            showMessage('Project archived');
+                        } catch (error) {
+                            showMessage(error.message || 'Could not archive project.', 'error');
+                        }
                     });
-                    loadProjects();
-                    showMessage('Project archived');
-                }},
-                {formatter:()=>'<i class="fas fa-trash w-4 h-4" aria-label="Delete"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
-                    if(!confirm('Delete this project?')) return;
-                    const id = cell.getRow().getData().id;
-                    await fetch('../php_backend/public/projects.php',{
-                        method:'DELETE',
-                        headers:{'Content-Type':'application/json'},
-                        body:JSON.stringify({id})
+                }, width:90, hozAlign:'center', headerSort:false},
+                {title:'Delete', formatter:cell => {
+                    const project = cell.getRow().getData();
+                    return projectActionButton('fa-trash', `Delete ${project.name || 'project'}`, 'text-red-700 hover:bg-red-50', async () => {
+                        if(!confirm(`Permanently delete ${project.name || 'this project'}? This cannot be undone.`)) return;
+                        try {
+                            await projectRequest({
+                                method:'DELETE',
+                                headers:{'Content-Type':'application/json'},
+                                body:JSON.stringify({id:project.id})
+                            });
+                            await loadProjects();
+                            showMessage('Project deleted');
+                        } catch (error) {
+                            showMessage(error.message || 'Could not delete project.', 'error');
+                        }
                     });
-                    loadProjects();
-                    showMessage('Project deleted');
-                }}
+                }, width:80, hozAlign:'center', headerSort:false}
             ]
         });
     }

--- a/frontend/projects_archived.html
+++ b/frontend/projects_archived.html
@@ -43,30 +43,62 @@ window.renderPageHeader(pageMain, {
 <script src="js/tabulator-tailwind.js"></script>
 <script>
 let archivedTable;
+
+function restoreButton(project){
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'rounded p-2 text-indigo-700 hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-50';
+    button.setAttribute('aria-label', `Restore ${project.name || 'project'}`);
+    const icon = document.createElement('i');
+    icon.className = 'fas fa-box-open w-4 h-4';
+    icon.setAttribute('aria-hidden', 'true');
+    button.appendChild(icon);
+    button.addEventListener('click', async () => {
+        button.disabled = true;
+        try {
+            const response = await fetch('../php_backend/public/projects.php',{
+                method:'PATCH',
+                headers:{'Content-Type':'application/json'},
+                body:JSON.stringify({id:project.id, archived:0})
+            });
+            const result = await response.json().catch(() => ({}));
+            if(!response.ok || result.status !== 'ok'){
+                throw new Error(result.error || 'Project could not be restored');
+            }
+            await loadArchived();
+            showMessage('Project restored');
+        } catch (error) {
+            showMessage(error.message || 'Could not restore project.', 'error');
+        } finally {
+            button.disabled = false;
+        }
+    });
+    return button;
+}
+
 async function loadArchived(){
-    const res = await fetch('../php_backend/public/projects.php?archived=1');
-    const data = await res.json();
+    let data;
+    try {
+        const res = await fetch('../php_backend/public/projects.php?archived=1');
+        if(!res.ok) throw new Error('Could not load archived projects');
+        data = await res.json();
+    } catch (error) {
+        showMessage('Could not load archived projects. Please refresh and try again.', 'error');
+        return;
+    }
     if(archivedTable){
         archivedTable.setData(data);
     }else{
         archivedTable = tailwindTabulator('#archived-projects-table',{
             data:data,
             layout:'fitDataStretch',
+            placeholder:'No archived projects.',
             columns:[
                 {title:'Project', field:'name'},
                 {title:'Cost (mid)', field:'cost_medium', formatter:'money', formatterParams:{symbol:'£',precision:2}, hozAlign:'right'},
                 {title:'Spent', field:'spent', formatter:'money', formatterParams:{symbol:'£',precision:2}, hozAlign:'right'},
                 {title:'Score', field:'score', hozAlign:'right'},
-                {formatter:()=>'<i class="fas fa-box-open w-4 h-4"></i>', width:40, hozAlign:'center', cellClick:async(e,cell)=>{
-                    const id = cell.getRow().getData().id;
-                    await fetch('../php_backend/public/projects.php',{
-                        method:'PATCH',
-                        headers:{'Content-Type':'application/json'},
-                        body:JSON.stringify({id, archived:0})
-                    });
-                    loadArchived();
-                    showMessage('Project restored');
-                }}
+                {title:'Restore', formatter:cell => restoreButton(cell.getRow().getData()), width:90, hozAlign:'center', headerSort:false}
             ]
         });
     }

--- a/frontend/projects_board.html
+++ b/frontend/projects_board.html
@@ -193,20 +193,28 @@ function renderStars(score, minScore, maxScore){
 
 async function loadProjects(){
     // Client-side filtering keeps the existing render pipeline simple; add query params in projects.php for larger datasets.
-    let projects = [];
-    try {
-        const res = await fetch('../php_backend/public/projects.php');
-        if(!res.ok) throw new Error('Projects request failed');
-        projects = await res.json();
-    } catch (error) {
-        showMessage('Could not load projects. Please refresh and try again.');
-    }
     const searchInput = document.getElementById('project-search');
     const fundingFilter = document.getElementById('funding-filter');
     const sortSelect = document.getElementById('project-sort');
     const board = document.getElementById('projects-board');
     const summary = document.getElementById('summary-chips');
     const statusChips = Array.from(document.querySelectorAll('.status-chip'));
+    let projects = [];
+    try {
+        const res = await fetch('../php_backend/public/projects.php');
+        if(!res.ok) throw new Error('Projects request failed');
+        projects = await res.json();
+    } catch (error) {
+        board.replaceChildren();
+        const errorMessage = document.createElement('div');
+        errorMessage.className = 'cards cards-solid cards-tight text-sm text-red-700';
+        errorMessage.setAttribute('role', 'alert');
+        errorMessage.textContent = 'Could not load projects. Please refresh and try again.';
+        board.appendChild(errorMessage);
+        summary.replaceChildren();
+        showMessage('Could not load projects. Please refresh and try again.', 'error');
+        return;
+    }
 
     const fundingSources = Array.from(new Set(projects.map(p => (p.funding_source || '').trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b));
     fundingFilter.innerHTML = '<option value="">All funding</option>';
@@ -329,7 +337,7 @@ async function loadProjects(){
                 await loadProjects();
                 showMessage('Project archived');
             } catch (error) {
-                showMessage('Could not archive project. Please try again.');
+                showMessage('Could not archive project. Please try again.', 'error');
             }
         });
         deleteIcon.addEventListener('click', async () => {
@@ -344,7 +352,7 @@ async function loadProjects(){
                 await loadProjects();
                 showMessage('Project deleted');
             } catch (error) {
-                showMessage('Could not delete project. Please try again.');
+                showMessage('Could not delete project. Please try again.', 'error');
             }
         });
 

--- a/frontend/report.html
+++ b/frontend/report.html
@@ -797,18 +797,13 @@ window.renderPageHeader(pageMain, {
             doc.putTotalPages(totalPagesExp);
         }
 
-        const blob = doc.output('blob');
-
         const now = new Date();
         const pad = n => String(n).padStart(2, '0');
         const timestamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
         const filename = `transactions_report_${timestamp}.pdf`;
 
         doc.save(filename);
-
-        const formData = new FormData();
-        formData.append('report', blob, filename);
-        fetch('../php_backend/public/send_pdf.php', { method: 'POST', body: formData });
+        showMessage('PDF downloaded');
 
     });
 

--- a/php_backend/models/Log.php
+++ b/php_backend/models/Log.php
@@ -37,12 +37,14 @@ class Log {
     /**
      * Remove log entries older than the specified number of days.
      */
-    public static function prune(int $days): void {
+    public static function prune(int $days): bool {
         try {
             $db = Database::getConnection();
             $db->exec('DELETE FROM logs WHERE created_at < (NOW() - INTERVAL ' . (int)$days . ' DAY)');
+            return true;
         } catch (Throwable $e) {
             error_log('Log prune failed: ' . $e->getMessage());
+            return false;
         }
     }
 
@@ -60,6 +62,20 @@ class Log {
 
         set_exception_handler(function (Throwable $e): void {
             self::write($e->getMessage(), 'ERROR');
+            if (PHP_SAPI === 'cli') {
+                fwrite(STDERR, sprintf(
+                    "Uncaught %s: %s in %s on line %d%s",
+                    get_class($e),
+                    $e->getMessage(),
+                    $e->getFile(),
+                    $e->getLine(),
+                    PHP_EOL
+                ));
+                exit(1);
+            }
+            if (!headers_sent()) {
+                http_response_code(500);
+            }
         });
 
 
@@ -74,4 +90,3 @@ class Log {
 }
 
 Log::registerHandlers();
-

--- a/php_backend/models/Project.php
+++ b/php_backend/models/Project.php
@@ -51,7 +51,7 @@ class Project {
                 benefit_risk*weight_risk +
                 benefit_sustainability*weight_sustainability
             ) AS score,
-            COALESCE(SUM(t.amount),0) AS spent
+            COALESCE(SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END),0) AS spent
             FROM projects p
             LEFT JOIN transactions t ON t.group_id = p.group_id
             WHERE p.archived = :archived
@@ -87,6 +87,9 @@ class Project {
         $projStmt = $db->prepare('SELECT group_id, archived FROM projects WHERE id = :id');
         $projStmt->execute(['id' => $id]);
         $proj = $projStmt->fetch(PDO::FETCH_ASSOC);
+        if (!$proj) {
+            return false;
+        }
         $groupId = (int)($proj['group_id'] ?? 0);
         $currentArchived = (int)($proj['archived'] ?? 0);
         $archivedFlag = $data['archived'] ?? $currentArchived;
@@ -125,12 +128,17 @@ class Project {
      */
     public static function setArchived(int $id, bool $archived): bool {
         $db = Database::getConnection();
+        $gidStmt = $db->prepare('SELECT group_id FROM projects WHERE id = :id');
+        $gidStmt->execute(['id' => $id]);
+        $groupIdValue = $gidStmt->fetchColumn();
+        if ($groupIdValue === false) {
+            return false;
+        }
+
         $stmt = $db->prepare('UPDATE projects SET archived = :archived WHERE id = :id');
         $ok = $stmt->execute(['archived' => $archived ? 1 : 0, 'id' => $id]);
         if($ok){
-            $gidStmt = $db->prepare('SELECT group_id FROM projects WHERE id = :id');
-            $gidStmt->execute(['id' => $id]);
-            $groupId = (int)$gidStmt->fetchColumn();
+            $groupId = (int)$groupIdValue;
             if($groupId){
                 TransactionGroup::setActive($groupId, !$archived);
             }
@@ -146,7 +154,11 @@ class Project {
         // find and delete associated group
         $gidStmt = $db->prepare('SELECT group_id FROM projects WHERE id = :id');
         $gidStmt->execute(['id' => $id]);
-        $groupId = (int)$gidStmt->fetchColumn();
+        $groupIdValue = $gidStmt->fetchColumn();
+        if ($groupIdValue === false) {
+            return false;
+        }
+        $groupId = (int)$groupIdValue;
         $stmt = $db->prepare('DELETE FROM projects WHERE id = :id');
         $ok = $stmt->execute(['id' => $id]);
         if($ok && $groupId){
@@ -157,4 +169,3 @@ class Project {
 }
 
 ?>
-

--- a/php_backend/public/logs.php
+++ b/php_backend/public/logs.php
@@ -7,17 +7,41 @@ require_once __DIR__ . '/../models/Setting.php';
 
 header('Content-Type: application/json');
 
-$limit = isset($_GET['limit']) ? (int)$_GET['limit'] : 100;
-$retention = Setting::get('log_retention_days');
-$days = isset($_GET['days']) ? (int)$_GET['days'] : ($retention !== null ? (int)$retention : null);
-if ($retention !== null) {
-    Log::prune((int)$retention);
+$method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+if ($method === 'DELETE') {
+    $data = json_decode(file_get_contents('php://input'), true) ?? [];
+    $prune = isset($data['days']) ? (int)$data['days'] : 0;
+    if ($prune < 1 || $prune > 3650) {
+        http_response_code(400);
+        echo json_encode(['status' => 'error', 'error' => 'Days must be between 1 and 3650']);
+        exit;
+    }
+    if (!Log::prune($prune)) {
+        http_response_code(500);
+        echo json_encode(['status' => 'error', 'error' => 'Logs could not be pruned']);
+        exit;
+    }
+    Log::write('Pruned logs older than ' . $prune . ' days');
+    echo json_encode(['status' => 'ok']);
+    exit;
 }
 
-if (isset($_GET['prune_days'])) {
-    $prune = (int)$_GET['prune_days'];
-    Log::prune($prune);
-    Log::write('Pruned logs older than ' . $prune . ' days');
+if ($method !== 'GET') {
+    http_response_code(405);
+    header('Allow: GET, DELETE');
+    echo json_encode(['status' => 'error', 'error' => 'Method not allowed']);
+    exit;
+}
+
+$limit = isset($_GET['limit']) ? max(1, min(1000, (int)$_GET['limit'])) : 100;
+$retention = Setting::get('log_retention_days');
+$retentionDays = $retention !== null && (int)$retention > 0
+    ? max(1, min(3650, (int)$retention))
+    : null;
+$days = isset($_GET['days']) ? max(1, min(3650, (int)$_GET['days'])) : $retentionDays;
+if ($retentionDays !== null) {
+    Log::prune($retentionDays);
 }
 
 try {
@@ -26,4 +50,3 @@ try {
     http_response_code(500);
     echo json_encode(['error' => $e->getMessage()]);
 }
-

--- a/php_backend/public/projects.php
+++ b/php_backend/public/projects.php
@@ -39,30 +39,53 @@ try {
             break;
         case 'POST':
             $data = json_decode(file_get_contents('php://input'), true) ?? [];
+            if (trim((string)($data['name'] ?? '')) === '') {
+                http_response_code(400);
+                echo json_encode(['status' => 'error', 'error' => 'Project name is required']);
+                break;
+            }
             if (isset($data['archived'])) {
                 $data['archived'] = parseBooleanInput($data['archived']) ? 1 : 0;
             }
             $id = Project::create($data);
+            http_response_code(201);
             echo json_encode(['status' => 'ok', 'id' => $id]);
             break;
         case 'PUT':
             $data = json_decode(file_get_contents('php://input'), true) ?? [];
+            if (!isset($data['id'])) {
+                http_response_code(400);
+                echo json_encode(['status' => 'error', 'error' => 'Missing id']);
+                break;
+            }
+            if (trim((string)($data['name'] ?? '')) === '') {
+                http_response_code(400);
+                echo json_encode(['status' => 'error', 'error' => 'Project name is required']);
+                break;
+            }
             if (isset($data['archived'])) {
                 $data['archived'] = parseBooleanInput($data['archived']) ? 1 : 0;
             }
-            if (isset($data['id'])) {
-                $ok = Project::update((int)$data['id'], $data);
-                echo json_encode(['status' => $ok ? 'ok' : 'error']);
-            } else {
-                echo json_encode(['status' => 'error', 'error' => 'Missing id']);
+            $ok = Project::update((int)$data['id'], $data);
+            if (!$ok) {
+                http_response_code(404);
+                echo json_encode(['status' => 'error', 'error' => 'Project not found']);
+                break;
             }
+            echo json_encode(['status' => 'ok']);
             break;
         case 'PATCH':
             $data = json_decode(file_get_contents('php://input'), true) ?? [];
             if (isset($data['id']) && isset($data['archived'])) {
                 $ok = Project::setArchived((int)$data['id'], parseBooleanInput($data['archived']));
-                echo json_encode(['status' => $ok ? 'ok' : 'error']);
+                if (!$ok) {
+                    http_response_code(404);
+                    echo json_encode(['status' => 'error', 'error' => 'Project not found']);
+                    break;
+                }
+                echo json_encode(['status' => 'ok']);
             } else {
+                http_response_code(400);
                 echo json_encode(['status' => 'error', 'error' => 'Missing id or archived']);
             }
             break;
@@ -70,8 +93,14 @@ try {
             $data = json_decode(file_get_contents('php://input'), true) ?? [];
             if (isset($data['id'])) {
                 $ok = Project::delete((int)$data['id']);
-                echo json_encode(['status' => $ok ? 'ok' : 'error']);
+                if (!$ok) {
+                    http_response_code(404);
+                    echo json_encode(['status' => 'error', 'error' => 'Project not found']);
+                    break;
+                }
+                echo json_encode(['status' => 'ok']);
             } else {
+                http_response_code(400);
                 echo json_encode(['status' => 'error', 'error' => 'Missing id']);
             }
             break;

--- a/tests/ProjectSavingTest.php
+++ b/tests/ProjectSavingTest.php
@@ -36,4 +36,26 @@ class ProjectSavingTest extends TestCase
         $active = $this->db->query('SELECT active FROM transaction_groups WHERE id = (SELECT group_id FROM projects WHERE id = '.$id.')')->fetchColumn();
         $this->assertSame(0, (int)$active);
     }
+
+    public function testSpentIsPositiveAndExcludesIncome(): void
+    {
+        $this->db->exec('CREATE TABLE transactions (id INTEGER PRIMARY KEY AUTOINCREMENT, group_id INT, amount REAL);');
+        $id = Project::create(['name' => 'Kitchen']);
+        $groupId = $this->db->query('SELECT group_id FROM projects WHERE id = ' . $id)->fetchColumn();
+        $insert = $this->db->prepare('INSERT INTO transactions (group_id, amount) VALUES (:group_id, :amount)');
+        $insert->execute(['group_id' => $groupId, 'amount' => -125.50]);
+        $insert->execute(['group_id' => $groupId, 'amount' => -24.50]);
+        $insert->execute(['group_id' => $groupId, 'amount' => 30.00]);
+
+        $projects = Project::all(false);
+
+        $this->assertSame(150.0, (float)$projects[0]['spent']);
+    }
+
+    public function testMissingProjectMutationsReportFailure(): void
+    {
+        $this->assertFalse(Project::update(999, ['name' => 'Missing']));
+        $this->assertFalse(Project::setArchived(999, true));
+        $this->assertFalse(Project::delete(999));
+    }
 }

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -18,7 +18,7 @@ $db = Database::getConnection();
 // Create minimal schema used by the models under test.
 $db->exec('CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT UNIQUE, password TEXT);');
 $db->exec('CREATE TABLE accounts (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT);');
-$db->exec('CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, keyword TEXT, description TEXT);');
+$db->exec('CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, name_normalized TEXT UNIQUE, keyword TEXT, description TEXT);');
 $db->exec('CREATE TABLE tag_aliases (id INTEGER PRIMARY KEY AUTOINCREMENT, tag_id INTEGER, alias TEXT, alias_normalized TEXT, match_type TEXT, active TINYINT DEFAULT 1);');
 $db->exec('CREATE TABLE segments (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, hue_deg REAL, base_l_pct REAL, base_c REAL, locked TINYINT);');
 $db->exec('CREATE TABLE categories (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, description TEXT, segment_id INTEGER, shade_index INTEGER);');


### PR DESCRIPTION
## Summary

- correct project spending totals so outgoing transactions appear as positive spend and incoming transactions are excluded
- add reliable project API validation, failure states, accessible actions, and edit/save feedback
- make log pruning an explicit validated destructive action and render log messages safely
- remove the hidden report upload/email side effect from PDF downloads
- make global notifications accessible and ensure uncaught failures produce real CLI/web failure status
- repair the SQLite test fixture and add project regression coverage

## Root causes and impact

Project expenses were stored as negative amounts but summed directly, producing negative spend and preventing over-budget indicators from working. Several project and log actions ignored failed HTTP responses and reported success regardless. The log table could be recreated on every refresh, log content passed through an HTML-capable formatter, and log pruning mutated data through a GET request. Downloading a PDF also silently uploaded it to an email endpoint despite the UI promising only a download.

These changes make totals accurate, destructive actions explicit, request failures visible, keyboard and screen-reader behavior clearer, and PDF downloads match their label.

## Validation

- `php tests/run_tests.php` — 83 passed, 0 failed
- targeted in-memory SQLite project-spending and missing-project mutation regression check
- PHP syntax checks across all PHP files
- Node syntax checks for every modified inline script and `frontend/js/overlay.js`
- `git diff --check`
