### PR TITLE
Add Instant financial dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,3 +77,4 @@
 - Page headers should be rendered via `frontend/js/page_header.js` using `renderPageHeader(main, { title, breadcrumb, subtitle, actions })`; `title` is required, other fields are optional, and output must keep `page-header`, `page-title`, `page-breadcrumb`, and `page-subtitle` classes.
 - Project `spent` totals count outgoing transactions as positive expenses and exclude incoming transactions.
 - The landing page uses a task-first structure (capture, understand, plan) and keeps live workspace totals in a compact hero snapshot; landing-specific styling belongs in `frontend/landing.css`.
+- The Instant dashboard is the glanceable cross-feature overview. Its snapshot is assembled by `InstantDashboard`, and its page-specific presentation belongs in `frontend/instant.css` and `frontend/js/instant_dashboard.js`.

--- a/frontend/instant.css
+++ b/frontend/instant.css
@@ -1,0 +1,1123 @@
+.instant-page {
+    --instant-ink: #172033;
+    --instant-muted: #64748b;
+    --instant-line: rgba(148, 163, 184, 0.26);
+    --instant-surface: rgba(255, 255, 255, 0.76);
+    --instant-brand: var(--brand-color-600, #4f46e5);
+    --instant-brand-dark: var(--brand-color-700, #4338ca);
+    color: var(--instant-ink);
+}
+
+.instant-main {
+    width: 100%;
+    max-width: 100rem;
+    margin-inline: auto;
+}
+
+.instant-page .page-header {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.2rem 1.4rem;
+    border-radius: 1.25rem;
+}
+
+.instant-page .page-title {
+    font-size: clamp(1.75rem, 3vw, 2.4rem) !important;
+    letter-spacing: -0.035em;
+}
+
+.instant-page .page-subtitle {
+    max-width: 48rem;
+    font-size: 0.86rem;
+}
+
+.instant-page .page-header-actions {
+    align-self: center;
+}
+
+.instant-refresh-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.55rem;
+    min-height: 2.65rem;
+    padding: 0.65rem 1rem;
+    border: 1px solid var(--instant-line);
+    border-radius: 0.8rem;
+    color: var(--instant-brand-dark);
+    background: rgba(255, 255, 255, 0.68);
+    font-size: 0.78rem;
+    font-weight: 800;
+    transition: transform 160ms ease, background-color 160ms ease;
+}
+
+.instant-refresh-button:hover {
+    transform: translateY(-1px);
+    background: #fff;
+}
+
+.instant-refresh-button.is-loading i {
+    animation: instant-spin 800ms linear infinite;
+}
+
+.instant-error {
+    padding: 0.9rem 1rem;
+    border: 1px solid rgba(239, 68, 68, 0.3);
+    border-radius: 0.9rem;
+    color: #991b1b;
+    background: rgba(254, 226, 226, 0.92);
+    font-size: 0.86rem;
+    font-weight: 700;
+}
+
+.instant-hero {
+    position: relative;
+    overflow: hidden;
+    padding: clamp(1.35rem, 3.5vw, 2.75rem);
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    border-radius: 1.75rem;
+    color: #f8fafc;
+    background:
+        radial-gradient(circle at 82% 12%, rgba(45, 212, 191, 0.14), transparent 25%),
+        radial-gradient(circle at 15% 100%, rgba(99, 102, 241, 0.22), transparent 32%),
+        linear-gradient(145deg, #0b1220 0%, #121a2f 58%, #101827 100%);
+    box-shadow: 0 32px 75px -42px rgba(15, 23, 42, 0.9);
+}
+
+.instant-hero::before {
+    position: absolute;
+    inset: 0 0 auto;
+    height: 0.25rem;
+    content: "";
+    background: linear-gradient(90deg, var(--instant-brand), #22d3ee, #34d399);
+}
+
+.instant-hero__glow {
+    position: absolute;
+    top: -12rem;
+    right: -9rem;
+    width: 28rem;
+    height: 28rem;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 999px;
+    pointer-events: none;
+    box-shadow:
+        0 0 0 3rem rgba(255, 255, 255, 0.018),
+        0 0 0 7rem rgba(255, 255, 255, 0.012);
+}
+
+.instant-hero__topline,
+.instant-hero__primary,
+.instant-metrics {
+    position: relative;
+    z-index: 1;
+}
+
+.instant-hero__topline {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.instant-live {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: #a7f3d0;
+    font-size: 0.67rem;
+    font-weight: 850;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.instant-live > span {
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 999px;
+    background: #34d399;
+    box-shadow: 0 0 0 4px rgba(52, 211, 153, 0.12);
+}
+
+.instant-period {
+    color: #94a3b8;
+    font-size: 0.7rem;
+    font-weight: 700;
+}
+
+.instant-hero__primary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: clamp(2rem, 5vw, 5rem);
+    align-items: center;
+    padding: clamp(2rem, 4vw, 3.5rem) 0;
+}
+
+.instant-position {
+    max-width: 52rem;
+}
+
+.instant-kicker {
+    margin: 0 0 0.6rem;
+    color: #94a3b8;
+    font-size: 0.73rem;
+    font-weight: 750;
+    letter-spacing: 0.04em;
+}
+
+.instant-balance {
+    margin: 0;
+    color: #fff;
+    font-size: clamp(3.1rem, 7vw, 6.4rem);
+    font-weight: 780;
+    letter-spacing: -0.065em;
+    line-height: 0.95;
+}
+
+.instant-message {
+    margin: 1rem 0 0;
+    color: #cbd5e1;
+    font-size: clamp(1rem, 1.6vw, 1.24rem);
+    line-height: 1.55;
+}
+
+.instant-pace {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-top: 1.1rem;
+    padding: 0.45rem 0.7rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 999px;
+    color: #cbd5e1;
+    background: rgba(255, 255, 255, 0.055);
+    font-size: 0.69rem;
+    font-weight: 750;
+}
+
+.instant-pace.instant-tone--positive { color: #a7f3d0; }
+.instant-pace.instant-tone--negative { color: #fecaca; }
+
+.instant-score {
+    display: flex;
+    width: 12.5rem;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+}
+
+.instant-score__ring {
+    display: grid;
+    width: 9.5rem;
+    height: 9.5rem;
+    place-items: center;
+    border-radius: 999px;
+    background: conic-gradient(#34d399 var(--score-progress), rgba(255, 255, 255, 0.09) 0deg);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+.instant-score__ring.instant-tone--negative {
+    background: conic-gradient(#fb7185 var(--score-progress), rgba(255, 255, 255, 0.09) 0deg);
+}
+
+.instant-score__ring.instant-tone--neutral {
+    background: conic-gradient(#94a3b8 var(--score-progress), rgba(255, 255, 255, 0.09) 0deg);
+}
+
+.instant-score__centre {
+    display: flex;
+    width: 7.7rem;
+    height: 7.7rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 999px;
+    background: #11192b;
+}
+
+.instant-score__centre > span {
+    color: #fff;
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: -0.04em;
+}
+
+.instant-score__centre small,
+.instant-score > p {
+    color: #94a3b8;
+    font-size: 0.64rem;
+}
+
+.instant-score > p {
+    margin: 0.65rem 0 0;
+}
+
+.instant-metrics {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 1.15rem;
+    background: rgba(255, 255, 255, 0.045);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.instant-metric {
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
+    min-height: 7rem;
+    padding: 1rem;
+}
+
+.instant-metric + .instant-metric {
+    border-left: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.instant-metric__icon {
+    display: inline-flex;
+    flex: 0 0 auto;
+    width: 2.55rem;
+    height: 2.55rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.8rem;
+}
+
+.instant-metric__icon i,
+.instant-attention__icon i,
+.instant-account__icon i {
+    color: inherit !important;
+}
+
+.instant-metric__icon--income { color: #6ee7b7; background: rgba(16, 185, 129, 0.12); }
+.instant-metric__icon--spending { color: #c4b5fd; background: rgba(139, 92, 246, 0.13); }
+.instant-metric__icon--cashflow { color: #7dd3fc; background: rgba(14, 165, 233, 0.13); }
+
+.instant-metric p,
+.instant-metric strong,
+.instant-metric span {
+    display: block;
+}
+
+.instant-metric p {
+    margin: 0 0 0.25rem;
+    color: #94a3b8;
+    font-size: 0.67rem;
+    font-weight: 700;
+}
+
+.instant-metric strong {
+    color: #f8fafc;
+    font-size: clamp(1.05rem, 2vw, 1.42rem);
+    line-height: 1.2;
+}
+
+.instant-metric strong.instant-tone--positive { color: #6ee7b7; }
+.instant-metric strong.instant-tone--negative { color: #fda4af; }
+
+.instant-metric span {
+    margin-top: 0.25rem;
+    color: #94a3b8;
+    font-size: 0.58rem;
+    line-height: 1.4;
+}
+
+.instant-metric span.instant-tone--positive { color: #6ee7b7; }
+.instant-metric span.instant-tone--negative { color: #fda4af; }
+
+.instant-metric--progress {
+    display: block;
+}
+
+.instant-metric__progress-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.instant-metric__progress-heading i {
+    color: #7dd3fc !important;
+}
+
+.instant-progress {
+    position: relative;
+    height: 0.38rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.16);
+}
+
+.instant-progress > span {
+    display: block;
+    width: 0;
+    height: 100%;
+    margin: 0;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--instant-brand), #22d3ee);
+    transition: width 450ms ease;
+}
+
+.instant-metric--progress .instant-progress {
+    margin: 0.8rem 0 0.65rem;
+}
+
+.instant-card {
+    min-width: 0;
+    padding: clamp(1.2rem, 2.5vw, 1.8rem);
+    border: 1px solid rgba(255, 255, 255, 0.62);
+    border-radius: 1.45rem;
+    background: var(--instant-surface);
+    box-shadow: 0 22px 55px -40px rgba(30, 41, 59, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.75);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+}
+
+.instant-card__header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.35rem;
+}
+
+.instant-section-label {
+    margin: 0 0 0.3rem;
+    color: var(--instant-brand-dark);
+    font-size: 0.64rem;
+    font-weight: 850;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.instant-card h2 {
+    margin: 0;
+    color: var(--instant-ink);
+    font-size: 1.2rem;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+}
+
+.instant-text-link,
+.instant-icon-link {
+    color: var(--instant-brand-dark);
+    font-size: 0.7rem;
+    font-weight: 800;
+    text-decoration: none;
+}
+
+.instant-text-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding-top: 0.35rem;
+}
+
+.instant-icon-link {
+    display: inline-flex;
+    width: 2.25rem;
+    height: 2.25rem;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--instant-line);
+    border-radius: 0.7rem;
+    background: rgba(255, 255, 255, 0.56);
+}
+
+.instant-text-link:hover,
+.instant-icon-link:hover {
+    color: var(--instant-brand);
+}
+
+.instant-lead-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1.8fr) minmax(18rem, 0.8fr);
+    gap: 1.25rem;
+}
+
+.instant-detail-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.25rem;
+}
+
+.instant-chart {
+    width: 100%;
+    height: 18rem;
+}
+
+.instant-count {
+    display: inline-flex;
+    min-width: 2rem;
+    height: 2rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 999px;
+    color: var(--instant-brand-dark);
+    background: rgba(224, 231, 255, 0.75);
+    font-size: 0.7rem;
+    font-weight: 850;
+}
+
+.instant-attention-list,
+.instant-budget-list,
+.instant-account-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.instant-attention {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.85rem 0;
+    color: var(--instant-ink);
+    text-decoration: none;
+}
+
+.instant-attention + .instant-attention {
+    border-top: 1px solid var(--instant-line);
+}
+
+.instant-attention__icon {
+    display: inline-flex;
+    width: 2.35rem;
+    height: 2.35rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.75rem;
+    color: var(--instant-brand-dark);
+    background: rgba(224, 231, 255, 0.72);
+}
+
+.instant-attention--urgent .instant-attention__icon { color: #be123c; background: #ffe4e6; }
+.instant-attention--watch .instant-attention__icon { color: #b45309; background: #fef3c7; }
+.instant-attention--good .instant-attention__icon { color: #047857; background: #d1fae5; }
+
+.instant-attention__copy {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.instant-attention__copy strong {
+    font-size: 0.78rem;
+    line-height: 1.35;
+}
+
+.instant-attention__copy > span {
+    color: var(--instant-muted);
+    font-size: 0.68rem;
+    line-height: 1.45;
+}
+
+.instant-attention__arrow {
+    color: #94a3b8 !important;
+    font-size: 0.6rem;
+}
+
+.instant-loading-row {
+    height: 3.8rem;
+    margin: 0.4rem 0;
+    border-radius: 0.8rem;
+    background: linear-gradient(90deg, rgba(226, 232, 240, 0.65), rgba(248, 250, 252, 0.85), rgba(226, 232, 240, 0.65));
+    background-size: 200% 100%;
+    animation: instant-shimmer 1.3s ease infinite;
+}
+
+.instant-ranked-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.instant-ranked-item {
+    display: grid;
+    grid-template-columns: 1.6rem minmax(0, 1fr);
+    gap: 0.75rem;
+    padding: 0.65rem 0;
+    color: var(--instant-ink);
+    text-decoration: none;
+}
+
+.instant-ranked-item + .instant-ranked-item {
+    border-top: 1px solid var(--instant-line);
+}
+
+.instant-ranked-item__rank {
+    padding-top: 0.12rem;
+    color: #94a3b8;
+    font-size: 0.61rem;
+    font-weight: 800;
+}
+
+.instant-ranked-item__body,
+.instant-ranked-item__line {
+    display: flex;
+}
+
+.instant-ranked-item__body {
+    min-width: 0;
+    flex-direction: column;
+}
+
+.instant-ranked-item__line {
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.instant-ranked-item__line strong,
+.instant-ranked-item__line > span {
+    font-size: 0.75rem;
+}
+
+.instant-ranked-item__line strong {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.instant-ranked-item__line > span {
+    flex: 0 0 auto;
+    font-weight: 800;
+}
+
+.instant-ranked-item__bar {
+    display: block;
+    height: 0.32rem;
+    margin-top: 0.45rem;
+    overflow: hidden;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.15);
+}
+
+.instant-ranked-item__bar > span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--instant-brand), #22d3ee);
+}
+
+.instant-ranked-item__body small {
+    margin-top: 0.3rem;
+    color: var(--instant-muted);
+    font-size: 0.59rem;
+}
+
+.instant-budget-summary {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.instant-budget-summary > div {
+    display: flex;
+    align-items: baseline;
+    gap: 0.35rem;
+}
+
+.instant-budget-summary strong {
+    font-size: 1.45rem;
+    letter-spacing: -0.035em;
+}
+
+.instant-budget-summary span {
+    color: var(--instant-muted);
+    font-size: 0.67rem;
+}
+
+.instant-budget-summary > span {
+    color: var(--instant-brand-dark);
+    font-size: 0.75rem;
+    font-weight: 850;
+}
+
+.instant-progress--budget {
+    margin: 0.75rem 0 1rem;
+}
+
+.instant-progress--budget > span.is-watch { background: #f59e0b; }
+.instant-progress--budget > span.is-over { background: #f43f5e; }
+
+.instant-budget-row,
+.instant-account {
+    display: flex;
+    align-items: center;
+    color: var(--instant-ink);
+    text-decoration: none;
+}
+
+.instant-budget-row {
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.72rem 0;
+}
+
+.instant-budget-row + .instant-budget-row,
+.instant-account + .instant-account {
+    border-top: 1px solid var(--instant-line);
+}
+
+.instant-budget-row > span:first-child,
+.instant-account > span:nth-child(2) {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.18rem;
+}
+
+.instant-budget-row strong,
+.instant-account strong {
+    overflow: hidden;
+    font-size: 0.75rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.instant-budget-row small,
+.instant-account small {
+    color: var(--instant-muted);
+    font-size: 0.59rem;
+}
+
+.instant-budget-badge {
+    flex: 0 0 auto;
+    padding: 0.32rem 0.5rem;
+    border-radius: 999px;
+    color: #047857;
+    background: #d1fae5;
+    font-size: 0.62rem;
+    font-weight: 850;
+}
+
+.instant-budget-badge--watch { color: #92400e; background: #fef3c7; }
+.instant-budget-badge--over { color: #be123c; background: #ffe4e6; }
+
+.instant-account {
+    gap: 0.7rem;
+    min-height: 3.65rem;
+    padding: 0.55rem 0;
+}
+
+.instant-account__icon {
+    display: inline-flex;
+    flex: 0 0 auto;
+    width: 2.25rem;
+    height: 2.25rem;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.7rem;
+    color: var(--instant-brand-dark);
+    background: rgba(224, 231, 255, 0.72);
+}
+
+.instant-account__balance {
+    margin-left: auto;
+    font-size: 0.76rem;
+    font-weight: 850;
+}
+
+.instant-account__balance.instant-tone--negative,
+.instant-transaction__amount.instant-tone--negative { color: #be123c; }
+.instant-transaction__amount.instant-tone--positive { color: #047857; }
+
+.instant-list-more {
+    align-self: flex-start;
+    margin-top: 0.7rem;
+    color: var(--instant-brand-dark);
+    font-size: 0.65rem;
+    font-weight: 800;
+}
+
+.instant-recent-list {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    column-gap: 1.5rem;
+}
+
+.instant-transaction {
+    display: grid;
+    grid-template-columns: 3.3rem minmax(0, 1fr) auto auto;
+    gap: 0.75rem;
+    align-items: center;
+    min-height: 4.25rem;
+    padding: 0.65rem 0;
+    color: var(--instant-ink);
+    text-decoration: none;
+}
+
+.instant-transaction:nth-child(n + 3) {
+    border-top: 1px solid var(--instant-line);
+}
+
+.instant-transaction time {
+    color: var(--instant-muted);
+    font-size: 0.65rem;
+    font-weight: 750;
+}
+
+.instant-transaction__description {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.instant-transaction__description strong {
+    overflow: hidden;
+    font-size: 0.75rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.instant-transaction__description small {
+    overflow: hidden;
+    color: var(--instant-muted);
+    font-size: 0.59rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.instant-transaction__amount {
+    font-size: 0.76rem;
+    font-weight: 850;
+}
+
+.instant-transaction > i {
+    color: #94a3b8 !important;
+    font-size: 0.55rem;
+}
+
+.instant-empty {
+    display: flex;
+    min-height: 9rem;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    text-align: center;
+}
+
+.instant-empty i {
+    color: #94a3b8 !important;
+}
+
+.instant-empty p {
+    max-width: 19rem;
+    margin: 0.6rem 0 0;
+    color: var(--instant-muted);
+    font-size: 0.72rem;
+    line-height: 1.5;
+}
+
+.instant-empty a {
+    margin-top: 0.65rem;
+    color: var(--instant-brand-dark);
+    font-size: 0.67rem;
+    font-weight: 800;
+}
+
+.instant-quick-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.65rem;
+    padding: 0.35rem 0.2rem 0.8rem;
+}
+
+.instant-quick-actions > span {
+    margin-right: 0.2rem;
+    color: var(--instant-muted);
+    font-size: 0.66rem;
+    font-weight: 750;
+}
+
+.instant-quick-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.38rem;
+    padding: 0.52rem 0.7rem;
+    border: 1px solid var(--instant-line);
+    border-radius: 0.7rem;
+    color: var(--instant-ink);
+    background: rgba(255, 255, 255, 0.48);
+    font-size: 0.64rem;
+    font-weight: 750;
+    text-decoration: none;
+}
+
+.instant-quick-actions small {
+    margin-left: auto;
+    color: var(--instant-muted);
+    font-size: 0.61rem;
+}
+
+.theme-professional .instant-page .page-header,
+.theme-professional .instant-card {
+    border-color: #e2e8f0;
+    border-radius: 0.65rem;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.07);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+}
+
+.theme-professional .instant-hero {
+    border-radius: 0.65rem;
+}
+
+@media (max-width: 1180px) {
+    .instant-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .instant-metric:nth-child(3),
+    .instant-metric:nth-child(4) {
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .instant-metric:nth-child(3) {
+        border-left: 0;
+    }
+
+    .instant-detail-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .instant-detail-grid > .instant-card:last-child {
+        grid-column: 1 / -1;
+    }
+}
+
+@media (max-width: 920px) {
+    .instant-hero__primary {
+        grid-template-columns: 1fr;
+    }
+
+    .instant-score {
+        width: auto;
+        flex-direction: row;
+        justify-content: flex-start;
+        gap: 1rem;
+        text-align: left;
+    }
+
+    .instant-score__ring {
+        width: 7.5rem;
+        height: 7.5rem;
+    }
+
+    .instant-score__centre {
+        width: 6.1rem;
+        height: 6.1rem;
+    }
+
+    .instant-score > p {
+        max-width: 8rem;
+    }
+
+    .instant-lead-grid,
+    .instant-detail-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .instant-detail-grid > .instant-card:last-child {
+        grid-column: auto;
+    }
+
+    .instant-recent-list {
+        grid-template-columns: 1fr;
+    }
+
+    .instant-transaction:nth-child(n + 2) {
+        border-top: 1px solid var(--instant-line);
+    }
+}
+
+@media (max-width: 640px) {
+    .instant-main.ops-main {
+        padding: 0.85rem;
+    }
+
+    .instant-main.ops-main > * + * {
+        margin-top: 1rem;
+    }
+
+    .instant-page .page-header {
+        grid-template-columns: minmax(0, 1fr) auto;
+        padding: 1rem 1rem 1rem 3.35rem;
+        border-radius: 1rem;
+    }
+
+    .instant-page .page-title {
+        font-size: 1.8rem !important;
+    }
+
+    .instant-page .page-subtitle {
+        font-size: 0.74rem;
+    }
+
+    .instant-refresh-button {
+        width: 2.65rem;
+        padding-inline: 0;
+    }
+
+    .instant-refresh-button span {
+        display: none;
+    }
+
+    .instant-hero,
+    .instant-card {
+        border-radius: 1.2rem;
+    }
+
+    .instant-hero {
+        padding: 1.25rem;
+    }
+
+    .instant-hero__topline {
+        align-items: flex-start;
+    }
+
+    .instant-period {
+        max-width: 9rem;
+        text-align: right;
+        line-height: 1.4;
+    }
+
+    .instant-hero__primary {
+        gap: 1.7rem;
+        padding: 2.2rem 0;
+    }
+
+    .instant-balance {
+        font-size: clamp(3rem, 15vw, 4.2rem);
+    }
+
+    .instant-message {
+        font-size: 0.94rem;
+    }
+
+    .instant-score {
+        flex-direction: row;
+    }
+
+    .instant-score__ring {
+        width: 6.7rem;
+        height: 6.7rem;
+    }
+
+    .instant-score__centre {
+        width: 5.35rem;
+        height: 5.35rem;
+    }
+
+    .instant-score__centre > span {
+        font-size: 1.5rem;
+    }
+
+    .instant-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .instant-metric {
+        min-height: 7.4rem;
+        gap: 0.6rem;
+        padding: 0.75rem;
+    }
+
+    .instant-metric:nth-child(3),
+    .instant-metric:nth-child(4) {
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+    }
+
+    .instant-metric:nth-child(3) {
+        border-left: 0;
+    }
+
+    .instant-metric__icon {
+        width: 2.2rem;
+        height: 2.2rem;
+    }
+
+    .instant-metric strong {
+        font-size: 1.05rem;
+    }
+
+    .instant-metric span {
+        font-size: 0.54rem;
+    }
+
+    .instant-card {
+        padding: 1.15rem;
+    }
+
+    .instant-chart {
+        height: 15.5rem;
+    }
+
+    .instant-text-link {
+        font-size: 0.64rem;
+    }
+
+    .instant-transaction {
+        grid-template-columns: 2.8rem minmax(0, 1fr) auto;
+        gap: 0.55rem;
+    }
+
+    .instant-transaction__amount {
+        grid-column: 3;
+        grid-row: 1;
+    }
+
+    .instant-transaction > i {
+        display: none;
+    }
+
+    .instant-quick-actions {
+        align-items: stretch;
+    }
+
+    .instant-quick-actions > span,
+    .instant-quick-actions a,
+    .instant-quick-actions small {
+        width: 100%;
+    }
+
+    .instant-quick-actions a {
+        justify-content: center;
+    }
+
+    .instant-quick-actions small {
+        margin: 0.25rem 0 0;
+        text-align: center;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .instant-refresh-button,
+    .instant-progress > span {
+        transition: none;
+    }
+
+    .instant-loading-row,
+    .instant-refresh-button.is-loading i {
+        animation: none;
+    }
+}
+
+@keyframes instant-spin {
+    to { transform: rotate(360deg); }
+}
+
+@keyframes instant-shimmer {
+    from { background-position: 100% 0; }
+    to { background-position: -100% 0; }
+}

--- a/frontend/instant.html
+++ b/frontend/instant.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<!-- Instant dashboard: a glanceable overview of balances, cash flow, budgets, and recent activity. -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <title>Instant Dashboard</title>
+    <script>
+        window.tailwind = window.tailwind || {};
+        window.tailwind.config = {};
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="operational_ui.css">
+    <link rel="stylesheet" href="instant.css">
+</head>
+<body class="ops-body dashboard-page instant-page">
+    <div class="flex min-h-screen">
+        <nav id="menu" class="hidden md:flex md:flex-col w-64 flex-shrink-0 bg-transparent p-6 overflow-y-auto"></nav>
+        <main class="ops-main instant-main flex-1 min-w-0 overflow-x-hidden">
+            <div id="instant-error" class="instant-error" role="alert" hidden></div>
+
+            <section class="instant-hero" data-no-card="true" aria-labelledby="instant-balance-label">
+                <div class="instant-hero__glow" aria-hidden="true"></div>
+                <div class="instant-hero__topline">
+                    <span class="instant-live"><span aria-hidden="true"></span>Financial pulse</span>
+                    <span id="instant-period" class="instant-period">Loading latest month…</span>
+                </div>
+
+                <div class="instant-hero__primary">
+                    <div class="instant-position">
+                        <p id="instant-balance-label" class="instant-kicker">Total position across your accounts</p>
+                        <p id="instant-balance" class="instant-balance" aria-live="polite">£—</p>
+                        <p id="instant-message" class="instant-message">Building your financial snapshot…</p>
+                        <span id="instant-pace" class="instant-pace instant-tone--neutral">
+                            <i class="fas fa-wave-square" aria-hidden="true"></i>
+                            <span id="instant-pace-text">Comparing your spending pace</span>
+                        </span>
+                    </div>
+
+                    <div class="instant-score" aria-label="Monthly savings rate">
+                        <div id="instant-score-ring" class="instant-score__ring" style="--score-progress: 0deg">
+                            <div class="instant-score__centre">
+                                <span id="instant-savings-rate">—</span>
+                                <small>Savings rate</small>
+                            </div>
+                        </div>
+                        <p id="instant-score-note">Income kept after spending</p>
+                    </div>
+                </div>
+
+                <div class="instant-metrics" aria-label="Monthly headline metrics">
+                    <article class="instant-metric">
+                        <span class="instant-metric__icon instant-metric__icon--income"><i class="fas fa-arrow-trend-up" aria-hidden="true"></i></span>
+                        <div>
+                            <p>Income</p>
+                            <strong id="instant-income">£—</strong>
+                            <span id="instant-income-change">vs last month</span>
+                        </div>
+                    </article>
+                    <article class="instant-metric">
+                        <span class="instant-metric__icon instant-metric__icon--spending"><i class="fas fa-arrow-trend-down" aria-hidden="true"></i></span>
+                        <div>
+                            <p>Spent</p>
+                            <strong id="instant-spending">£—</strong>
+                            <span id="instant-spending-change">vs last month</span>
+                        </div>
+                    </article>
+                    <article class="instant-metric">
+                        <span class="instant-metric__icon instant-metric__icon--cashflow"><i class="fas fa-scale-balanced" aria-hidden="true"></i></span>
+                        <div>
+                            <p>Net cash flow</p>
+                            <strong id="instant-cashflow">£—</strong>
+                            <span id="instant-cashflow-label">Income minus spending</span>
+                        </div>
+                    </article>
+                    <article class="instant-metric instant-metric--progress">
+                        <div class="instant-metric__progress-heading">
+                            <div><p>Month complete</p><strong id="instant-month-progress">—%</strong></div>
+                            <i class="fas fa-calendar-check" aria-hidden="true"></i>
+                        </div>
+                        <div class="instant-progress" aria-hidden="true"><span id="instant-month-progress-bar"></span></div>
+                        <span id="instant-latest-transaction">Finding latest activity…</span>
+                    </article>
+                </div>
+            </section>
+
+            <div class="instant-lead-grid">
+                <section class="instant-card instant-card--chart" data-no-card="true">
+                    <div class="instant-card__header">
+                        <div>
+                            <p class="instant-section-label">Direction of travel</p>
+                            <h2>Six-month cash flow</h2>
+                        </div>
+                        <a href="yearly_dashboard.html" class="instant-text-link">Full history <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
+                    </div>
+                    <div id="instant-cashflow-chart" class="instant-chart" data-chart-desc="Area chart comparing monthly income and spending over the latest six months."></div>
+                </section>
+
+                <section class="instant-card instant-card--attention" data-no-card="true">
+                    <div class="instant-card__header">
+                        <div>
+                            <p class="instant-section-label">Focus now</p>
+                            <h2>Needs your attention</h2>
+                        </div>
+                        <span id="instant-attention-count" class="instant-count">—</span>
+                    </div>
+                    <div id="instant-attention" class="instant-attention-list" aria-live="polite">
+                        <div class="instant-loading-row"></div>
+                        <div class="instant-loading-row"></div>
+                        <div class="instant-loading-row"></div>
+                    </div>
+                </section>
+            </div>
+
+            <div class="instant-detail-grid">
+                <section class="instant-card" data-no-card="true">
+                    <div class="instant-card__header">
+                        <div>
+                            <p class="instant-section-label">This month</p>
+                            <h2>Where money went</h2>
+                        </div>
+                        <a href="monthly_dashboard.html" class="instant-icon-link" aria-label="Open monthly dashboard"><i class="fas fa-arrow-up-right-from-square" aria-hidden="true"></i></a>
+                    </div>
+                    <div id="instant-categories" class="instant-ranked-list" aria-live="polite"></div>
+                </section>
+
+                <section class="instant-card" data-no-card="true">
+                    <div class="instant-card__header">
+                        <div>
+                            <p class="instant-section-label">Guardrails</p>
+                            <h2>Budget pressure</h2>
+                        </div>
+                        <a href="budgets.html" class="instant-icon-link" aria-label="Open budgets"><i class="fas fa-arrow-up-right-from-square" aria-hidden="true"></i></a>
+                    </div>
+                    <div id="instant-budget-summary" class="instant-budget-summary">
+                        <div><strong id="instant-budget-spent">£—</strong><span>of <span id="instant-budget-total">£—</span></span></div>
+                        <span id="instant-budget-used">—%</span>
+                    </div>
+                    <div class="instant-progress instant-progress--budget" aria-hidden="true"><span id="instant-budget-progress"></span></div>
+                    <div id="instant-budgets" class="instant-budget-list" aria-live="polite"></div>
+                </section>
+
+                <section class="instant-card" data-no-card="true">
+                    <div class="instant-card__header">
+                        <div>
+                            <p class="instant-section-label">Position</p>
+                            <h2>Your accounts</h2>
+                        </div>
+                        <a href="account_dashboard.html" class="instant-icon-link" aria-label="Open account dashboard"><i class="fas fa-arrow-up-right-from-square" aria-hidden="true"></i></a>
+                    </div>
+                    <div id="instant-accounts" class="instant-account-list" aria-live="polite"></div>
+                </section>
+            </div>
+
+            <section class="instant-card instant-recent" data-no-card="true">
+                <div class="instant-card__header">
+                    <div>
+                        <p class="instant-section-label">Latest movement</p>
+                        <h2>Recent activity</h2>
+                    </div>
+                    <a href="search.html" class="instant-text-link">Search everything <i class="fas fa-arrow-right" aria-hidden="true"></i></a>
+                </div>
+                <div id="instant-recent" class="instant-recent-list" aria-live="polite"></div>
+            </section>
+
+            <nav class="instant-quick-actions" aria-label="Instant dashboard quick actions" data-no-card="true">
+                <span>Ready to act?</span>
+                <a href="upload.html"><i class="fas fa-arrow-up-from-bracket" aria-hidden="true"></i>Import transactions</a>
+                <a href="report.html"><i class="fas fa-file-lines" aria-hidden="true"></i>Build a report</a>
+                <a href="budgets.html"><i class="fas fa-bullseye" aria-hidden="true"></i>Adjust budgets</a>
+                <small id="instant-refreshed">Snapshot not loaded</small>
+            </nav>
+        </main>
+    </div>
+
+    <script src="js/page_header.js"></script>
+    <script>
+        const instantHeaderActions = document.createElement('div');
+        const instantRefreshButton = document.createElement('button');
+        instantRefreshButton.id = 'instant-refresh';
+        instantRefreshButton.type = 'button';
+        instantRefreshButton.className = 'instant-refresh-button';
+        instantRefreshButton.setAttribute('aria-label', 'Refresh Instant dashboard');
+        instantRefreshButton.innerHTML = '<i class="fas fa-rotate" aria-hidden="true"></i><span>Refresh</span>';
+        instantHeaderActions.appendChild(instantRefreshButton);
+        window.renderPageHeader(document.querySelector('main.ops-main'), {
+            title: 'Instant',
+            breadcrumb: 'Dashboards / Instant',
+            subtitle: 'Everything worth knowing about your finances, distilled into one clear view.',
+            actions: instantHeaderActions
+        });
+    </script>
+    <script src="js/menu.js"></script>
+    <script src="js/input_help.js"></script>
+    <script src="https://code.highcharts.com/highcharts.js"></script>
+    <script src="js/instant_dashboard.js"></script>
+    <script src="js/overlay.js"></script>
+</body>
+</html>

--- a/frontend/js/instant_dashboard.js
+++ b/frontend/js/instant_dashboard.js
@@ -1,0 +1,425 @@
+// Renders the glanceable financial snapshot on the Instant dashboard.
+(function () {
+    'use strict';
+
+    const money = new Intl.NumberFormat('en-GB', {
+        style: 'currency',
+        currency: 'GBP',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+    });
+    const preciseMoney = new Intl.NumberFormat('en-GB', {
+        style: 'currency',
+        currency: 'GBP',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    });
+
+    const toneClasses = [
+        'instant-tone--positive',
+        'instant-tone--negative',
+        'instant-tone--neutral'
+    ];
+
+    function byId(id) {
+        return document.getElementById(id);
+    }
+
+    function setText(id, value) {
+        const element = byId(id);
+        if (element) {
+            element.textContent = value;
+        }
+    }
+
+    function applyTone(element, tone) {
+        if (!element) return;
+        toneClasses.forEach(className => element.classList.remove(className));
+        element.classList.add('instant-tone--' + (tone || 'neutral'));
+    }
+
+    function formatDate(value, options) {
+        if (!value) return 'No activity yet';
+        const date = new Date(value + (value.length === 10 ? 'T12:00:00' : ''));
+        return date.toLocaleDateString('en-GB', options || {
+            day: 'numeric',
+            month: 'short'
+        });
+    }
+
+    function changeLabel(value, lowerIsBetter) {
+        if (value === null || typeof value === 'undefined') {
+            return { text: 'No previous month comparison', tone: 'neutral' };
+        }
+        if (Math.abs(value) < 0.1) {
+            return { text: 'In line with last month', tone: 'neutral' };
+        }
+        const direction = value > 0 ? 'up' : 'down';
+        let tone = value > 0 ? 'positive' : 'negative';
+        if (lowerIsBetter) tone = value > 0 ? 'negative' : 'positive';
+        return {
+            text: Math.abs(value).toFixed(0) + '% ' + direction + ' on last month',
+            tone
+        };
+    }
+
+    function emptyState(message, href, linkText) {
+        const wrap = document.createElement('div');
+        wrap.className = 'instant-empty';
+        const icon = document.createElement('i');
+        icon.className = 'fas fa-circle-info';
+        icon.setAttribute('aria-hidden', 'true');
+        const text = document.createElement('p');
+        text.textContent = message;
+        wrap.append(icon, text);
+        if (href && linkText) {
+            const link = document.createElement('a');
+            link.href = href;
+            link.textContent = linkText;
+            wrap.appendChild(link);
+        }
+        return wrap;
+    }
+
+    function renderHeadline(data) {
+        setText('instant-period', data.period.label + (data.period.is_current_month ? ' · current month' : ' · latest recorded month'));
+        setText('instant-balance', money.format(data.headline.balance));
+        setText('instant-message', data.headline.message);
+        setText('instant-pace-text', data.headline.spending_pace.label);
+        applyTone(byId('instant-pace'), data.headline.spending_pace.tone);
+
+        const rate = data.metrics.savings_rate;
+        setText('instant-savings-rate', rate === null ? '—' : Math.round(rate) + '%');
+        const score = Math.max(0, Math.min(100, rate === null ? 0 : rate));
+        byId('instant-score-ring').style.setProperty('--score-progress', (score * 3.6) + 'deg');
+        applyTone(byId('instant-score-ring'), rate === null ? 'neutral' : (rate >= 10 ? 'positive' : (rate < 0 ? 'negative' : 'neutral')));
+
+        setText('instant-income', money.format(data.metrics.income));
+        setText('instant-spending', money.format(data.metrics.spending));
+        setText('instant-cashflow', money.format(data.metrics.cashflow));
+        applyTone(byId('instant-cashflow'), data.headline.tone);
+
+        const incomeChange = changeLabel(data.metrics.income_change, false);
+        const spendingChange = changeLabel(data.metrics.spending_change, true);
+        setText('instant-income-change', incomeChange.text);
+        setText('instant-spending-change', spendingChange.text);
+        applyTone(byId('instant-income-change'), incomeChange.tone);
+        applyTone(byId('instant-spending-change'), spendingChange.tone);
+
+        const progress = Math.max(0, Math.min(100, data.period.progress || 0));
+        setText('instant-month-progress', Math.round(progress) + '%');
+        byId('instant-month-progress-bar').style.width = progress + '%';
+        setText(
+            'instant-latest-transaction',
+            data.period.latest_transaction_date
+                ? 'Latest activity ' + formatDate(data.period.latest_transaction_date, { day: 'numeric', month: 'long' })
+                : 'No transactions recorded'
+        );
+    }
+
+    function renderTrend(rows) {
+        const rootStyles = getComputedStyle(document.documentElement);
+        const brand = rootStyles.getPropertyValue('--brand-color-600').trim() || '#4f46e5';
+        const textColor = getComputedStyle(document.body).color || '#172033';
+
+        Highcharts.chart('instant-cashflow-chart', {
+            chart: {
+                type: 'areaspline',
+                backgroundColor: 'transparent',
+                spacing: [12, 4, 2, 0],
+                animation: false
+            },
+            title: { text: null },
+            credits: { enabled: false },
+            accessibility: { enabled: false },
+            xAxis: {
+                categories: rows.map(row => row.label),
+                lineColor: 'rgba(148, 163, 184, 0.24)',
+                tickLength: 0,
+                labels: { style: { color: '#64748b', fontSize: '11px' } }
+            },
+            yAxis: {
+                title: { text: null },
+                gridLineColor: 'rgba(148, 163, 184, 0.16)',
+                labels: {
+                    style: { color: '#64748b', fontSize: '10px' },
+                    formatter: function () {
+                        const abs = Math.abs(this.value);
+                        return '£' + (abs >= 1000 ? Highcharts.numberFormat(this.value / 1000, 1) + 'k' : Highcharts.numberFormat(this.value, 0));
+                    }
+                }
+            },
+            legend: {
+                align: 'left',
+                verticalAlign: 'top',
+                itemStyle: { color: textColor, fontSize: '11px', fontWeight: '600' },
+                symbolRadius: 6
+            },
+            tooltip: {
+                shared: true,
+                valuePrefix: '£',
+                valueDecimals: 0,
+                borderRadius: 10
+            },
+            plotOptions: {
+                areaspline: {
+                    lineWidth: 2.5,
+                    marker: { enabled: false, symbol: 'circle', radius: 3 },
+                    fillOpacity: 0.09,
+                    states: { hover: { lineWidth: 3 } }
+                }
+            },
+            series: [
+                {
+                    name: 'Income',
+                    color: '#10b981',
+                    data: rows.map(row => Number(row.income) || 0)
+                },
+                {
+                    name: 'Spending',
+                    color: brand,
+                    data: rows.map(row => Number(row.spending) || 0)
+                }
+            ]
+        });
+    }
+
+    function attentionIcon(type) {
+        return {
+            budget: 'fa-gauge-high',
+            cashflow: 'fa-arrow-trend-down',
+            tags: 'fa-tags',
+            accounts: 'fa-building-columns',
+            clear: 'fa-circle-check'
+        }[type] || 'fa-circle-info';
+    }
+
+    function renderAttention(items) {
+        const container = byId('instant-attention');
+        container.replaceChildren();
+        setText('instant-attention-count', String(items.length));
+
+        items.forEach(item => {
+            const link = document.createElement('a');
+            link.className = 'instant-attention instant-attention--' + item.severity;
+            link.href = item.href;
+
+            const icon = document.createElement('span');
+            icon.className = 'instant-attention__icon';
+            const iconGlyph = document.createElement('i');
+            iconGlyph.className = 'fas ' + attentionIcon(item.type);
+            iconGlyph.setAttribute('aria-hidden', 'true');
+            icon.appendChild(iconGlyph);
+
+            const copy = document.createElement('span');
+            copy.className = 'instant-attention__copy';
+            const title = document.createElement('strong');
+            title.textContent = item.title;
+            const detail = document.createElement('span');
+            detail.textContent = item.detail;
+            copy.append(title, detail);
+
+            const arrow = document.createElement('i');
+            arrow.className = 'fas fa-chevron-right instant-attention__arrow';
+            arrow.setAttribute('aria-hidden', 'true');
+            link.append(icon, copy, arrow);
+            container.appendChild(link);
+        });
+    }
+
+    function renderCategories(items) {
+        const container = byId('instant-categories');
+        container.replaceChildren();
+        if (!items.length) {
+            container.appendChild(emptyState('No spending has been recorded for this period.', 'upload.html', 'Import a statement'));
+            return;
+        }
+
+        const maximum = Math.max.apply(null, items.map(item => Number(item.amount) || 0));
+        items.forEach((item, index) => {
+            const link = document.createElement('a');
+            link.href = 'search.html?value=' + encodeURIComponent(item.name);
+            link.className = 'instant-ranked-item';
+
+            const rank = document.createElement('span');
+            rank.className = 'instant-ranked-item__rank';
+            rank.textContent = String(index + 1).padStart(2, '0');
+
+            const body = document.createElement('span');
+            body.className = 'instant-ranked-item__body';
+            const line = document.createElement('span');
+            line.className = 'instant-ranked-item__line';
+            const name = document.createElement('strong');
+            name.textContent = item.name;
+            const amount = document.createElement('span');
+            amount.textContent = money.format(item.amount);
+            line.append(name, amount);
+            const bar = document.createElement('span');
+            bar.className = 'instant-ranked-item__bar';
+            const fill = document.createElement('span');
+            fill.style.width = (maximum > 0 ? (item.amount / maximum) * 100 : 0) + '%';
+            bar.appendChild(fill);
+            const share = document.createElement('small');
+            share.textContent = item.share + '% of monthly spending';
+            body.append(line, bar, share);
+            link.append(rank, body);
+            container.appendChild(link);
+        });
+    }
+
+    function renderBudgets(budget) {
+        setText('instant-budget-spent', money.format(budget.spent));
+        setText('instant-budget-total', money.format(budget.total));
+        setText('instant-budget-used', budget.used === null ? 'Not set' : Math.round(budget.used) + '%');
+        const overallUsed = Math.max(0, Math.min(100, budget.used || 0));
+        byId('instant-budget-progress').style.width = overallUsed + '%';
+        byId('instant-budget-progress').className = budget.used > 100 ? 'is-over' : (budget.used >= 85 ? 'is-watch' : '');
+
+        const container = byId('instant-budgets');
+        container.replaceChildren();
+        if (!budget.items.length) {
+            container.appendChild(emptyState('Set category budgets to see pressure before limits are crossed.', 'budgets.html', 'Create budgets'));
+            return;
+        }
+
+        budget.items.forEach(item => {
+            const row = document.createElement('a');
+            row.href = 'budgets.html';
+            row.className = 'instant-budget-row';
+            const label = document.createElement('span');
+            const name = document.createElement('strong');
+            name.textContent = item.category;
+            const detail = document.createElement('small');
+            detail.textContent = money.format(item.spent) + ' of ' + money.format(item.amount);
+            label.append(name, detail);
+            const badge = document.createElement('span');
+            badge.className = 'instant-budget-badge instant-budget-badge--' + item.status;
+            badge.textContent = Math.round(item.used) + '%';
+            row.append(label, badge);
+            container.appendChild(row);
+        });
+    }
+
+    function renderAccounts(accounts) {
+        const container = byId('instant-accounts');
+        container.replaceChildren();
+        if (!accounts.length) {
+            container.appendChild(emptyState('No accounts are connected yet.', 'upload.html', 'Import your first statement'));
+            return;
+        }
+
+        accounts.slice(0, 5).forEach(account => {
+            const link = document.createElement('a');
+            link.href = 'account.html?id=' + encodeURIComponent(account.id);
+            link.className = 'instant-account';
+            const icon = document.createElement('span');
+            icon.className = 'instant-account__icon';
+            const iconGlyph = document.createElement('i');
+            iconGlyph.className = 'fas fa-building-columns';
+            iconGlyph.setAttribute('aria-hidden', 'true');
+            icon.appendChild(iconGlyph);
+            const copy = document.createElement('span');
+            const name = document.createElement('strong');
+            name.textContent = account.name;
+            const date = document.createElement('small');
+            date.textContent = account.ledger_balance_date
+                ? 'Balance dated ' + formatDate(account.ledger_balance_date)
+                : 'Balance date unavailable';
+            copy.append(name, date);
+            const balance = document.createElement('span');
+            balance.className = 'instant-account__balance ' + (account.balance < 0 ? 'instant-tone--negative' : '');
+            balance.textContent = money.format(account.balance);
+            link.append(icon, copy, balance);
+            container.appendChild(link);
+        });
+
+        if (accounts.length > 5) {
+            const more = document.createElement('a');
+            more.href = 'account_dashboard.html';
+            more.className = 'instant-list-more';
+            more.textContent = 'View ' + (accounts.length - 5) + ' more accounts';
+            container.appendChild(more);
+        }
+    }
+
+    function renderRecent(items) {
+        const container = byId('instant-recent');
+        container.replaceChildren();
+        if (!items.length) {
+            container.appendChild(emptyState('No recent transactions are available.', 'upload.html', 'Import transactions'));
+            return;
+        }
+
+        items.forEach(item => {
+            const link = document.createElement('a');
+            link.href = 'transaction.html?id=' + encodeURIComponent(item.id);
+            link.className = 'instant-transaction';
+            const date = document.createElement('time');
+            date.dateTime = item.date;
+            date.textContent = formatDate(item.date, { day: '2-digit', month: 'short' });
+            const description = document.createElement('span');
+            description.className = 'instant-transaction__description';
+            const title = document.createElement('strong');
+            title.textContent = item.description;
+            const meta = document.createElement('small');
+            const pieces = [item.account_name || 'Unknown account'];
+            if (item.is_transfer) pieces.push('Transfer');
+            else if (item.category_name) pieces.push(item.category_name);
+            meta.textContent = pieces.join(' · ');
+            description.append(title, meta);
+            const amount = document.createElement('span');
+            amount.className = 'instant-transaction__amount ' + (item.amount < 0 ? 'instant-tone--negative' : 'instant-tone--positive');
+            amount.textContent = preciseMoney.format(item.amount);
+            const arrow = document.createElement('i');
+            arrow.className = 'fas fa-chevron-right';
+            arrow.setAttribute('aria-hidden', 'true');
+            link.append(date, description, amount, arrow);
+            container.appendChild(link);
+        });
+    }
+
+    function render(data) {
+        renderHeadline(data);
+        renderTrend(data.trend || []);
+        renderAttention(data.attention || []);
+        renderCategories(data.top_categories || []);
+        renderBudgets(data.budget || { total: 0, spent: 0, used: null, items: [] });
+        renderAccounts(data.accounts || []);
+        renderRecent(data.recent || []);
+        setText('instant-refreshed', 'Updated ' + new Date(data.period.generated_at).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' }));
+    }
+
+    async function loadSnapshot() {
+        const refresh = byId('instant-refresh');
+        const error = byId('instant-error');
+        refresh.disabled = true;
+        refresh.setAttribute('aria-busy', 'true');
+        refresh.classList.add('is-loading');
+        error.hidden = true;
+
+        try {
+            const response = await fetch('../php_backend/public/instant_dashboard.php', { cache: 'no-store' });
+            if (!response.ok) {
+                throw new Error('The snapshot request failed with status ' + response.status);
+            }
+            const data = await response.json();
+            if (data.error) {
+                throw new Error(data.error);
+            }
+            render(data);
+        } catch (caught) {
+            console.error('Instant dashboard load failed', caught);
+            error.textContent = 'Instant could not load your financial snapshot. Refresh the page or try again in a moment.';
+            error.hidden = false;
+        } finally {
+            refresh.disabled = false;
+            refresh.removeAttribute('aria-busy');
+            refresh.classList.remove('is-loading');
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        byId('instant-refresh').addEventListener('click', loadSnapshot);
+        loadSnapshot();
+    });
+})();

--- a/frontend/js/page_help.js
+++ b/frontend/js/page_help.js
@@ -8,6 +8,7 @@ const init = () => {
     'settings.php': `Adjust system configuration such as the OpenAI token, batch size for AI tagging and how long to keep log entries. Save changes to update how the application behaves.`,
     'logout.php': `This page confirms you have been signed out. Use the button to return to the login screen when you are ready to sign in again.`,
     'index.html': `The home page is the starting point for exploring your finances. It shows a summary of the system and provides links to every feature. Use the menu on the left to open dashboards, run reports or adjust settings. Spend a moment getting familiar with these links before diving into the details.`,
+    'instant.html': `Instant is your financial command centre. Start with the total account position and this month's cash flow, then scan the trend and attention cards for anything that needs action. The lower panels show spending categories, budget pressure, account balances and recent transactions. Use the links on each card to open the detailed dashboard when you want to investigate further.`,
     'upload.html': `Upload OFX statement files from your bank so the system can read your transactions. Click Choose File, find the statement on your computer and then press Start Upload. When the process finishes you will see the new transactions ready for review. Importing regularly keeps your records up to date.`,
     'account.html': `Drill into a single account to review its balance trend and transaction statement. Sort code and account number or card number are shown at the top. Click any row to edit a transaction and ensure your records match the bank.`,
     'account_dashboard.html': `Check balances and recent activity for each account in one place. Charts show how money moves in and out over time, while tables list individual transactions. Sort codes and account numbers are listed where available. Look for jumps or dips that you do not recognise and click through to investigate further. This helps you spot unusual activity quickly.`,
@@ -78,4 +79,3 @@ if (document.readyState === 'loading') {
 } else {
   init();
 }
-

--- a/frontend/menu.php
+++ b/frontend/menu.php
@@ -37,6 +37,7 @@
   <div class="group">
     <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3 cursor-pointer">Dashboards &amp; Graphs</h3>
     <ul class="space-y-1.5 overflow-hidden max-h-0 transition-all duration-300">
+        <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="instant.html"><i class="fas fa-bolt w-4 text-center text-slate-400"></i> Instant</a></li>
         <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="yearly_dashboard.html"><i class="fas fa-calendar w-4 text-center text-slate-400"></i> Yearly Dashboard</a></li>
         <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="all_years_dashboard.html"><i class="fas fa-calendar-alt w-4 text-center text-slate-400"></i> All Years Dashboard</a></li>
         <li><a class="flex items-center gap-2 border-l-2 border-transparent px-3 py-2 rounded-md text-sm font-normal text-slate-700 hover:text-slate-900 hover:bg-slate-50 transition-colors duration-150" href="monthly_dashboard.html"><i class="fas fa-calendar-day w-4 text-center text-slate-400"></i> Monthly Dashboard</a></li>

--- a/php_backend/models/InstantDashboard.php
+++ b/php_backend/models/InstantDashboard.php
@@ -1,0 +1,498 @@
+<?php
+// Builds the concise, cross-feature snapshot used by the Instant dashboard.
+require_once __DIR__ . '/../Database.php';
+
+class InstantDashboard {
+    /**
+     * Return the latest useful financial snapshot. If the current month has no
+     * transactions, the most recent recorded month becomes the reporting period.
+     */
+    public static function getSnapshot($now = null): array {
+        $db = Database::getConnection();
+        $now = $now ?: new DateTimeImmutable('now');
+        $latestDate = self::latestTransactionDate($db);
+        $currentMonthStart = $now->modify('first day of this month')->setTime(0, 0);
+        $anchor = $now;
+
+        if ($latestDate !== null && $latestDate < $currentMonthStart) {
+            $anchor = $latestDate;
+        }
+
+        $monthStart = $anchor->modify('first day of this month')->setTime(0, 0);
+        $nextMonthStart = $monthStart->modify('+1 month');
+        $previousMonthStart = $monthStart->modify('-1 month');
+        $trendStart = $monthStart->modify('-5 months');
+        $isCurrentMonth = $monthStart->format('Y-m') === $currentMonthStart->format('Y-m');
+        $periodProgress = $isCurrentMonth
+            ? min(1, max(0.01, ((int)$now->format('j')) / (int)$now->format('t')))
+            : 1.0;
+
+        $activity = self::activityBetween($db, $trendStart, $nextMonthStart);
+        $trend = self::buildTrend($activity, $trendStart, $monthStart);
+        $current = self::totalsForPeriod($activity, $monthStart, $nextMonthStart);
+        $previous = self::totalsForPeriod($activity, $previousMonthStart, $monthStart);
+        $accounts = self::accountSummaries($db);
+        $budget = self::budgetSnapshot($db, $activity, $monthStart, $nextMonthStart);
+        $topCategories = self::topCategories($activity, $monthStart, $nextMonthStart);
+        $recent = self::recentActivity($db, 7);
+        $untaggedCount = self::untaggedCount($db);
+        $staleAccounts = self::countStaleAccounts($accounts, $now);
+
+        $totalBalance = 0.0;
+        foreach ($accounts as $account) {
+            $totalBalance += (float)$account['balance'];
+        }
+
+        $savingsRate = $current['income'] > 0
+            ? ($current['cashflow'] / $current['income']) * 100
+            : null;
+        $spendingChange = self::percentageChange($current['spending'], $previous['spending']);
+        $incomeChange = self::percentageChange($current['income'], $previous['income']);
+        $projectedSpending = $periodProgress > 0
+            ? $current['spending'] / $periodProgress
+            : $current['spending'];
+
+        $attention = self::buildAttention(
+            $current,
+            $budget,
+            $untaggedCount,
+            $staleAccounts,
+            $projectedSpending,
+            $previous['spending']
+        );
+
+        return [
+            'period' => [
+                'label' => $monthStart->format('F Y'),
+                'start' => $monthStart->format('Y-m-d'),
+                'is_current_month' => $isCurrentMonth,
+                'progress' => round($periodProgress * 100, 1),
+                'latest_transaction_date' => $latestDate ? $latestDate->format('Y-m-d') : null,
+                'generated_at' => $now->format(DateTime::ATOM),
+            ],
+            'headline' => [
+                'balance' => round($totalBalance, 2),
+                'message' => self::headlineMessage($current, $monthStart),
+                'tone' => self::cashflowTone($current['cashflow']),
+                'spending_pace' => self::spendingPace(
+                    $projectedSpending,
+                    $previous['spending'],
+                    $isCurrentMonth
+                ),
+            ],
+            'metrics' => [
+                'income' => round($current['income'], 2),
+                'spending' => round($current['spending'], 2),
+                'cashflow' => round($current['cashflow'], 2),
+                'savings_rate' => $savingsRate === null ? null : round($savingsRate, 1),
+                'income_change' => $incomeChange,
+                'spending_change' => $spendingChange,
+            ],
+            'trend' => $trend,
+            'top_categories' => $topCategories,
+            'budget' => $budget,
+            'accounts' => $accounts,
+            'recent' => $recent,
+            'attention' => $attention,
+            'data_quality' => [
+                'untagged_transactions' => $untaggedCount,
+                'stale_accounts' => $staleAccounts,
+            ],
+        ];
+    }
+
+    private static function latestTransactionDate(PDO $db) {
+        $value = $db->query('SELECT MAX(`date`) FROM `transactions`')->fetchColumn();
+        if (!$value) {
+            return null;
+        }
+        return new DateTimeImmutable((string)$value);
+    }
+
+    private static function activityBetween(PDO $db, DateTimeImmutable $start, DateTimeImmutable $end): array {
+        $sql = 'SELECT t.`id`, t.`date`, t.`amount`, t.`description`, t.`category_id`, '
+             . 'a.`name` AS account_name, c.`name` AS category_name, tg.`name` AS tag_name '
+             . 'FROM `transactions` t '
+             . 'LEFT JOIN `accounts` a ON a.`id` = t.`account_id` '
+             . 'LEFT JOIN `categories` c ON c.`id` = t.`category_id` '
+             . 'LEFT JOIN `tags` tg ON tg.`id` = t.`tag_id` '
+             . 'WHERE t.`date` >= :start AND t.`date` < :end '
+             . 'AND t.`transfer_id` IS NULL '
+             . 'AND (t.`tag_id` IS NULL OR LOWER(COALESCE(tg.`name`, \'\')) != \'ignore\') '
+             . 'ORDER BY t.`date` ASC, t.`id` ASC';
+        $stmt = $db->prepare($sql);
+        $stmt->execute([
+            'start' => $start->format('Y-m-d'),
+            'end' => $end->format('Y-m-d'),
+        ]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    private static function buildTrend(array $activity, DateTimeImmutable $trendStart, DateTimeImmutable $monthStart): array {
+        $buckets = [];
+        for ($i = 0; $i < 6; $i++) {
+            $date = $trendStart->modify('+' . $i . ' months');
+            $key = $date->format('Y-m');
+            $buckets[$key] = [
+                'key' => $key,
+                'label' => $date->format('M'),
+                'income' => 0.0,
+                'spending' => 0.0,
+                'cashflow' => 0.0,
+            ];
+        }
+
+        foreach ($activity as $row) {
+            $key = substr((string)$row['date'], 0, 7);
+            if (!isset($buckets[$key])) {
+                continue;
+            }
+            $amount = (float)$row['amount'];
+            if ($amount > 0) {
+                $buckets[$key]['income'] += $amount;
+            } elseif ($amount < 0) {
+                $buckets[$key]['spending'] += -$amount;
+            }
+        }
+
+        foreach ($buckets as &$bucket) {
+            $bucket['income'] = round($bucket['income'], 2);
+            $bucket['spending'] = round($bucket['spending'], 2);
+            $bucket['cashflow'] = round($bucket['income'] - $bucket['spending'], 2);
+        }
+        unset($bucket);
+
+        return array_values($buckets);
+    }
+
+    private static function totalsForPeriod(array $activity, DateTimeImmutable $start, DateTimeImmutable $end): array {
+        $income = 0.0;
+        $spending = 0.0;
+        $startValue = $start->format('Y-m-d');
+        $endValue = $end->format('Y-m-d');
+
+        foreach ($activity as $row) {
+            $date = (string)$row['date'];
+            if ($date < $startValue || $date >= $endValue) {
+                continue;
+            }
+            $amount = (float)$row['amount'];
+            if ($amount > 0) {
+                $income += $amount;
+            } elseif ($amount < 0) {
+                $spending += -$amount;
+            }
+        }
+
+        return [
+            'income' => $income,
+            'spending' => $spending,
+            'cashflow' => $income - $spending,
+        ];
+    }
+
+    private static function accountSummaries(PDO $db): array {
+        $sql = 'SELECT a.`id`, a.`name`, COALESCE(a.`ledger_balance`, 0) AS balance, '
+             . 'a.`ledger_balance_date`, MAX(t.`date`) AS last_transaction '
+             . 'FROM `accounts` a '
+             . 'LEFT JOIN `transactions` t ON t.`account_id` = a.`id` '
+             . 'GROUP BY a.`id`, a.`name`, a.`ledger_balance`, a.`ledger_balance_date` '
+             . 'ORDER BY balance DESC, a.`name` ASC';
+        $rows = $db->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($rows as &$row) {
+            $row['id'] = (int)$row['id'];
+            $row['balance'] = round((float)$row['balance'], 2);
+        }
+        unset($row);
+        return $rows;
+    }
+
+    private static function budgetSnapshot(
+        PDO $db,
+        array $activity,
+        DateTimeImmutable $start,
+        DateTimeImmutable $end
+    ): array {
+        $stmt = $db->prepare(
+            'SELECT b.`id`, b.`category_id`, b.`amount`, c.`name` AS category '
+            . 'FROM `budgets` b '
+            . 'JOIN `categories` c ON c.`id` = b.`category_id` '
+            . 'WHERE b.`month` = :month AND b.`year` = :year '
+            . 'ORDER BY c.`name` ASC'
+        );
+        $stmt->execute([
+            'month' => (int)$start->format('n'),
+            'year' => (int)$start->format('Y'),
+        ]);
+        $budgets = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        $spentByCategory = [];
+        $startValue = $start->format('Y-m-d');
+        $endValue = $end->format('Y-m-d');
+
+        foreach ($activity as $row) {
+            if ((string)$row['date'] < $startValue || (string)$row['date'] >= $endValue) {
+                continue;
+            }
+            $categoryId = isset($row['category_id']) ? (int)$row['category_id'] : 0;
+            $amount = (float)$row['amount'];
+            if ($categoryId > 0 && $amount < 0) {
+                $spentByCategory[$categoryId] = ($spentByCategory[$categoryId] ?? 0) + (-$amount);
+            }
+        }
+
+        $totalBudget = 0.0;
+        $totalSpent = 0.0;
+        $items = [];
+        $overCount = 0;
+        $watchCount = 0;
+        foreach ($budgets as $budget) {
+            $amount = (float)$budget['amount'];
+            $spent = $spentByCategory[(int)$budget['category_id']] ?? 0.0;
+            $used = $amount > 0 ? ($spent / $amount) * 100 : 0.0;
+            $totalBudget += $amount;
+            $totalSpent += $spent;
+            $status = $used > 100 ? 'over' : ($used >= 85 ? 'watch' : 'good');
+            if ($status === 'over') {
+                $overCount++;
+            } elseif ($status === 'watch') {
+                $watchCount++;
+            }
+            $items[] = [
+                'id' => (int)$budget['id'],
+                'category_id' => (int)$budget['category_id'],
+                'category' => $budget['category'],
+                'amount' => round($amount, 2),
+                'spent' => round($spent, 2),
+                'remaining' => round($amount - $spent, 2),
+                'used' => round($used, 1),
+                'status' => $status,
+            ];
+        }
+
+        usort($items, function ($a, $b) {
+            return $b['used'] <=> $a['used'];
+        });
+
+        return [
+            'total' => round($totalBudget, 2),
+            'spent' => round($totalSpent, 2),
+            'remaining' => round($totalBudget - $totalSpent, 2),
+            'used' => $totalBudget > 0 ? round(($totalSpent / $totalBudget) * 100, 1) : null,
+            'count' => count($items),
+            'over_count' => $overCount,
+            'watch_count' => $watchCount,
+            'items' => array_slice($items, 0, 4),
+        ];
+    }
+
+    private static function topCategories(
+        array $activity,
+        DateTimeImmutable $start,
+        DateTimeImmutable $end
+    ): array {
+        $totals = [];
+        $startValue = $start->format('Y-m-d');
+        $endValue = $end->format('Y-m-d');
+
+        foreach ($activity as $row) {
+            if ((string)$row['date'] < $startValue || (string)$row['date'] >= $endValue) {
+                continue;
+            }
+            $amount = (float)$row['amount'];
+            if ($amount >= 0) {
+                continue;
+            }
+            $name = trim((string)($row['category_name'] ?? '')) ?: 'Uncategorised';
+            $totals[$name] = ($totals[$name] ?? 0) + (-$amount);
+        }
+
+        arsort($totals);
+        $grandTotal = array_sum($totals);
+        $output = [];
+        foreach (array_slice($totals, 0, 5, true) as $name => $amount) {
+            $output[] = [
+                'name' => $name,
+                'amount' => round($amount, 2),
+                'share' => $grandTotal > 0 ? round(($amount / $grandTotal) * 100, 1) : 0,
+            ];
+        }
+        return $output;
+    }
+
+    private static function recentActivity(PDO $db, int $limit): array {
+        $limit = max(1, min(20, $limit));
+        $sql = 'SELECT t.`id`, t.`date`, t.`amount`, t.`description`, '
+             . 'a.`name` AS account_name, c.`name` AS category_name, '
+             . 'CASE WHEN t.`transfer_id` IS NULL THEN 0 ELSE 1 END AS is_transfer '
+             . 'FROM `transactions` t '
+             . 'LEFT JOIN `accounts` a ON a.`id` = t.`account_id` '
+             . 'LEFT JOIN `categories` c ON c.`id` = t.`category_id` '
+             . 'LEFT JOIN `tags` tg ON tg.`id` = t.`tag_id` '
+             . 'WHERE t.`tag_id` IS NULL OR LOWER(COALESCE(tg.`name`, \'\')) != \'ignore\' '
+             . 'ORDER BY t.`date` DESC, t.`id` DESC LIMIT ' . $limit;
+        $rows = $db->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+        foreach ($rows as &$row) {
+            $row['id'] = (int)$row['id'];
+            $row['amount'] = round((float)$row['amount'], 2);
+            $row['is_transfer'] = (bool)$row['is_transfer'];
+        }
+        unset($row);
+        return $rows;
+    }
+
+    private static function untaggedCount(PDO $db): int {
+        $value = $db->query('SELECT COUNT(*) FROM `transactions` WHERE `tag_id` IS NULL')->fetchColumn();
+        return $value === false ? 0 : (int)$value;
+    }
+
+    private static function countStaleAccounts(array $accounts, DateTimeImmutable $now): int {
+        $cutoff = $now->modify('-14 days')->format('Y-m-d');
+        $count = 0;
+        foreach ($accounts as $account) {
+            $date = $account['ledger_balance_date'] ?? null;
+            if (!$date || $date < $cutoff) {
+                $count++;
+            }
+        }
+        return $count;
+    }
+
+    private static function buildAttention(
+        array $current,
+        array $budget,
+        int $untaggedCount,
+        int $staleAccounts,
+        float $projectedSpending,
+        float $previousSpending
+    ): array {
+        $items = [];
+        $overBudget = (int)($budget['over_count'] ?? 0);
+        $nearBudget = (int)($budget['watch_count'] ?? 0);
+
+        if ($overBudget > 0) {
+            $items[] = [
+                'type' => 'budget',
+                'severity' => 'urgent',
+                'title' => $overBudget === 1 ? 'One budget is over its limit' : $overBudget . ' budgets are over their limits',
+                'detail' => 'Review the highest-pressure categories before more spending lands.',
+                'href' => 'budgets.html',
+            ];
+        } elseif ($nearBudget > 0) {
+            $items[] = [
+                'type' => 'budget',
+                'severity' => 'watch',
+                'title' => $nearBudget === 1 ? 'One budget is close to its limit' : $nearBudget . ' budgets are close to their limits',
+                'detail' => 'These categories have used at least 85% of their allowance.',
+                'href' => 'budgets.html',
+            ];
+        } elseif ($budget['count'] === 0) {
+            $items[] = [
+                'type' => 'budget',
+                'severity' => 'info',
+                'title' => 'No budgets are set for this month',
+                'detail' => 'Add limits to turn spending into an early-warning signal.',
+                'href' => 'budgets.html',
+            ];
+        }
+
+        if ($current['cashflow'] < 0) {
+            $items[] = [
+                'type' => 'cashflow',
+                'severity' => 'urgent',
+                'title' => 'Outgoings are ahead of income',
+                'detail' => 'Current cash flow is negative by £' . number_format(abs($current['cashflow']), 0),
+                'href' => 'monthly_dashboard.html',
+            ];
+        } elseif ($previousSpending > 0 && $projectedSpending > $previousSpending * 1.12) {
+            $items[] = [
+                'type' => 'cashflow',
+                'severity' => 'watch',
+                'title' => 'Spending is running faster than last month',
+                'detail' => 'At this pace, this month could finish above the previous one.',
+                'href' => 'monthly_dashboard.html',
+            ];
+        }
+
+        if ($untaggedCount > 0) {
+            $items[] = [
+                'type' => 'tags',
+                'severity' => $untaggedCount >= 25 ? 'watch' : 'info',
+                'title' => number_format($untaggedCount) . ' transactions need tags',
+                'detail' => 'Completing these improves every category and budget view.',
+                'href' => 'missing_tags.html',
+            ];
+        }
+
+        if ($staleAccounts > 0) {
+            $items[] = [
+                'type' => 'accounts',
+                'severity' => 'info',
+                'title' => $staleAccounts === 1 ? 'One account balance may be stale' : $staleAccounts . ' account balances may be stale',
+                'detail' => 'Import a recent statement to refresh the overall position.',
+                'href' => 'upload.html',
+            ];
+        }
+
+        if (empty($items)) {
+            $items[] = [
+                'type' => 'clear',
+                'severity' => 'good',
+                'title' => 'Nothing urgent needs attention',
+                'detail' => 'Cash flow, budgets, balances and tagging all look healthy.',
+                'href' => 'monthly_dashboard.html',
+            ];
+        }
+
+        return array_slice($items, 0, 4);
+    }
+
+    private static function headlineMessage(array $current, DateTimeImmutable $monthStart): string {
+        if ($current['income'] === 0.0 && $current['spending'] === 0.0) {
+            return 'No activity has been recorded for ' . $monthStart->format('F') . ' yet.';
+        }
+        if ($current['cashflow'] >= 0) {
+            return 'You are £' . number_format($current['cashflow'], 0) . ' ahead for ' . $monthStart->format('F') . '.';
+        }
+        return 'Spending is £' . number_format(abs($current['cashflow']), 0) . ' above income this month.';
+    }
+
+    private static function cashflowTone(float $cashflow): string {
+        if ($cashflow > 0) {
+            return 'positive';
+        }
+        if ($cashflow < 0) {
+            return 'negative';
+        }
+        return 'neutral';
+    }
+
+    private static function spendingPace(float $projected, float $previous, bool $isCurrentMonth): array {
+        if ($previous <= 0) {
+            return ['tone' => 'neutral', 'label' => 'Not enough history to compare spending pace'];
+        }
+        $difference = (($projected - $previous) / $previous) * 100;
+        $prefix = $isCurrentMonth ? 'Projected to finish ' : '';
+        if (abs($difference) < 5) {
+            return ['tone' => 'neutral', 'label' => 'Spending is broadly in line with last month'];
+        }
+        if ($difference > 0) {
+            return [
+                'tone' => 'negative',
+                'label' => $prefix . round(abs($difference)) . '% above last month',
+            ];
+        }
+        return [
+            'tone' => 'positive',
+            'label' => $prefix . round(abs($difference)) . '% below last month',
+        ];
+    }
+
+    private static function percentageChange(float $current, float $previous): ?float {
+        if ($previous == 0.0) {
+            return null;
+        }
+        return round((($current - $previous) / $previous) * 100, 1);
+    }
+}
+
+?>

--- a/php_backend/public/instant_dashboard.php
+++ b/php_backend/public/instant_dashboard.php
@@ -1,0 +1,18 @@
+<?php
+// API endpoint returning the complete glanceable snapshot for the Instant dashboard.
+require_once __DIR__ . '/../auth.php';
+require_api_auth();
+require_once __DIR__ . '/../models/InstantDashboard.php';
+require_once __DIR__ . '/../models/Log.php';
+
+header('Content-Type: application/json');
+
+try {
+    echo json_encode(InstantDashboard::getSnapshot());
+} catch (Throwable $e) {
+    http_response_code(500);
+    Log::write('Instant dashboard error: ' . $e->getMessage(), 'ERROR');
+    echo json_encode(['error' => 'Unable to build the Instant dashboard right now.']);
+}
+
+?>

--- a/tests/run_tests.php
+++ b/tests/run_tests.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../php_backend/models/SavedReport.php';
 require_once __DIR__ . '/../php_backend/OfxParser.php';
 require_once __DIR__ . '/../php_backend/NaturalLanguageReportParser.php';
 require_once __DIR__ . '/../php_backend/models/TagAlias.php';
+require_once __DIR__ . '/../php_backend/models/InstantDashboard.php';
 require_once __DIR__ . '/../php_backend/AiTaggingPipeline.php';
 
 // Use an in-memory SQLite database for tests.
@@ -379,6 +380,37 @@ assertEqual('Example', $reports[0]['description'] ?? null, 'SavedReport descript
 SavedReport::delete($repId);
 $afterDel = SavedReport::all();
 assertEqual(0, count($afterDel), 'SavedReport::delete removes report');
+
+// --- Instant dashboard snapshot ---
+$db->exec('ALTER TABLE accounts ADD COLUMN ledger_balance REAL DEFAULT 0');
+$db->exec('ALTER TABLE accounts ADD COLUMN ledger_balance_date TEXT');
+$db->exec('ALTER TABLE budgets ADD COLUMN month INTEGER');
+$db->exec('ALTER TABLE budgets ADD COLUMN year INTEGER');
+$db->exec('DELETE FROM transactions');
+$db->exec('DELETE FROM budgets');
+$db->exec('DELETE FROM categories');
+$db->exec('DELETE FROM tags');
+$db->exec('DELETE FROM accounts');
+$db->exec("INSERT INTO accounts (id, name, ledger_balance, ledger_balance_date) VALUES (1, 'Current', 2500, '2026-08-10'), (2, 'Savings', 7500, '2026-08-09')");
+$db->exec("INSERT INTO categories (id, name) VALUES (1, 'Income'), (2, 'Home')");
+$db->exec("INSERT INTO tags (id, name, name_normalized) VALUES (1, 'Salary', 'salary'), (2, 'Bills', 'bills')");
+$db->exec("INSERT INTO budgets (category_id, amount, month, year) VALUES (2, 1000, 8, 2026)");
+$db->exec("INSERT INTO transactions (account_id, date, amount, description, category_id, tag_id) VALUES
+    (1, '2026-07-25', 3000, 'July salary', 1, 1),
+    (1, '2026-07-02', -1200, 'July home costs', 2, 2),
+    (1, '2026-08-01', 3200, 'August salary', 1, 1),
+    (1, '2026-08-02', -850, 'August home costs', 2, 2)");
+$db->exec("INSERT INTO transactions (account_id, date, amount, description, transfer_id) VALUES
+    (1, '2026-08-03', -500, 'Transfer out', 99),
+    (2, '2026-08-03', 500, 'Transfer in', 99)");
+$instant = InstantDashboard::getSnapshot(new DateTimeImmutable('2026-08-10T12:00:00+01:00'));
+assertEqual(10000.0, (float)$instant['headline']['balance'], 'Instant dashboard totals account balances');
+assertEqual(3200.0, (float)$instant['metrics']['income'], 'Instant dashboard reports monthly income');
+assertEqual(850.0, (float)$instant['metrics']['spending'], 'Instant dashboard excludes transfers from spending');
+assertEqual(2350.0, (float)$instant['metrics']['cashflow'], 'Instant dashboard calculates monthly cash flow');
+assertEqual(85.0, (float)$instant['budget']['used'], 'Instant dashboard calculates budget pressure');
+assertEqual(true, (bool)$instant['recent'][0]['is_transfer'], 'Instant dashboard keeps transfers in recent activity');
+assertEqual(6, count($instant['trend']), 'Instant dashboard returns a six-month trend');
 
 // Output results and set exit code
 $failed = false;


### PR DESCRIPTION
## What changed

- added the new **Instant** financial command-centre dashboard
- combines account position, monthly income, spending, cash flow, savings rate, and six-month trends
- surfaces budget pressure, top spending categories, stale balances, missing tags, and recent activity
- added transfer-aware snapshot aggregation with fallback to the latest recorded month
- added responsive, professional-theme-compatible presentation, live refresh, drill-through links, quick actions, and contextual help
- added Instant to the primary dashboard navigation
- added seven automated tests for balance totals, cash flow, transfers, budgets, and trend output

## Why

The existing dashboards are excellent for detailed analysis but require users to choose a specific lens first. Instant provides the immediate overview needed to understand the current position and decide where to investigate next.

## Validation

- `php tests/run_tests.php`
- full PHP syntax sweep
- `node --check frontend/js/instant_dashboard.js`
- `git diff --check`
- desktop, 390px mobile, and professional-theme browser validation
- refresh and contextual-help interaction checks
- no browser console errors or horizontal overflow